### PR TITLE
Workaround for pallet missing declare error type

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -58,7 +58,7 @@ pub enum MetadataError {
     /// Event is not in metadata.
     #[error("Event {0} not found")]
     EventNotFound(u8),
-    /// Event is not in metadata.
+    /// Error is not in metadata.
     #[error("Error {0} not found")]
     ErrorNotFound(u8),
     /// Storage is not in metadata.


### PR DESCRIPTION
Ref Substrate issue https://github.com/paritytech/substrate/issues/8501

I'd like fix that issue, but I think subxt still need to do a workaround because it would crash inside subxt.

In short,
when pallet missing declare Error type, the errors field in metadata will be empty,
then, if Subxt parsing block meets error which not list in metadata, it will trigger https://github.com/paritytech/substrate-subxt/blob/master/src/metadata.rs#L256
then, it will crash inside Subxt