### PR TITLE
Reexport support crates

### DIFF
--- a/proc-macro/src/lib.rs
+++ b/proc-macro/src/lib.rs
@@ -116,7 +116,7 @@ decl_derive!(
     /// #[module]
     /// pub trait MyTrait: System + Balances {}
     ///
-    /// #[derive(Call)]
+    /// #[derive(Call, Encode)]
     /// pub struct FunStuffCall<T: MyTrait> {
     ///     /// Runtime marker.
     ///     pub _runtime: PhantomData<T>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@ extern crate substrate_subxt_proc_macro;
 pub use sp_core;
 pub use sp_runtime;
 
+pub use codec;
 use codec::{
     Codec,
     Decode,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@ use codec::{
     Codec,
     Decode,
 };
+pub use frame_support;
 use futures::future;
 use jsonrpsee_http_client::{
     HttpClient,


### PR DESCRIPTION
This reexports the internally used `frame_support` and `codec` crates which gives easy access to `codec::Encode`, which is required for deriving your own `Call`s and `frame_support::{Parameter}` that is helpful for module type bounds.