### PR TITLE
fix: derive Ord & PartialOrd

### DIFF
--- a/codegen/src/types.rs
+++ b/codegen/src/types.rs
@@ -270,7 +270,7 @@ impl<'a> quote::ToTokens for ModuleType<'a> {
                 let (fields, _) =
                     self.composite_fields(composite.fields(), &type_params, true);
                 let ty_toks = quote! {
-                    #[derive(Debug, Eq, PartialEq, ::codec::Encode, ::codec::Decode)]
+                    #[derive(Debug, Eq, PartialEq, Ord, PartialOrd, ::codec::Encode, ::codec::Decode)]
                     pub struct #type_name #fields
                 };
                 tokens.extend(ty_toks);
@@ -310,7 +310,7 @@ impl<'a> quote::ToTokens for ModuleType<'a> {
                 }
 
                 let ty_toks = quote! {
-                    #[derive(Debug, Eq, PartialEq, ::codec::Encode, ::codec::Decode)]
+                    #[derive(Debug, Eq, PartialEq, Ord, PartialOrd, ::codec::Encode, ::codec::Decode)]
                     pub enum #type_name {
                         #( #variants, )*
                     }


### PR DESCRIPTION
This addresses [this](https://github.com/paritytech/subxt/pull/294#issuecomment-945715216) compilation error. I am not sure if it is always ok to unconditionally derive Ord and PartialOrd, but at least in my case it now compiles without errors.