### PR TITLE
add CODEOWNERS and update Cargo.toml authors

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Code Owners for everything
+* @subxt-dev

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,10 @@ members = [".", "client", "proc-macro"]
 [package]
 name = "substrate-subxt"
 version = "0.15.0"
-authors = ["Parity Technologies <admin@parity.io>"]
+authors = [
+    "Parity Technologies <admin@parity.io>",
+    "Interlay Ltd <contact@interlay.io>"
+]
 edition = "2018"
 
 license = "GPL-3.0"


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

Further to our discussions on Element, since @ascjones is only able to commit to subxt part-time, @interlay would like to become official maintainers of this project. We would also extend an open invite to other interested parachain teams who actively use subxt for client software.

See also: https://github.com/paritytech/polkadot/pull/4128