### PR TITLE
Codegen: enum variant indices

### DIFF
--- a/codegen/src/types/tests.rs
+++ b/codegen/src/types/tests.rs
@@ -312,8 +312,11 @@ fn generate_enum() {
                 use super::root;
                 #[derive(::subxt::codec::Encode, ::subxt::codec::Decode)]
                 pub enum E {
+                    # [codec (index = 0)]
                     A,
+                    # [codec (index = 1)]
                     B (::core::primitive::bool,),
+                    # [codec (index = 2)]
                     C { a: ::core::primitive::u32, },
                 }
             }
@@ -467,7 +470,9 @@ fn box_fields_enum() {
                 use super::root;
                 #[derive(::subxt::codec::Encode, ::subxt::codec::Decode)]
                 pub enum E {
+                    # [codec (index = 0)]
                     A(::std::boxed::Box<::core::primitive::bool>,),
+                    # [codec (index = 1)]
                     B { a: ::std::boxed::Box<::core::primitive::u32>, },
                 }
             }

--- a/codegen/src/types/type_def.rs
+++ b/codegen/src/types/type_def.rs
@@ -139,7 +139,11 @@ impl<'a> quote::ToTokens for TypeDefGen<'a> {
                     } else {
                         self.composite_fields(v.fields(), &type_params, false)
                     };
-                    variants.push(quote! { #variant_name #fields });
+                    let index = proc_macro2::Literal::u8_unsuffixed(v.index());
+                    variants.push(quote! {
+                        #[codec(index = #index)]
+                        #variant_name #fields
+                    });
                     let unused_params_set = unused_type_params.iter().cloned().collect();
                     let used_params = type_params_set.difference(&unused_params_set);
 


### PR DESCRIPTION
This fix is required for calls that embed other calls, such as `sudo` and `batch`. Without it, these calls fail if the explicit index provided in the metadata does not match the implicit index of the enum variant 