### PR TITLE
Release initial versions of `subxt-codegen` and `subxt-cli`

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subxt-cli"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 
@@ -16,7 +16,7 @@ path = "src/main.rs"
 
 [dependencies]
 # perform subxt codegen
-subxt-codegen = { version = "0.1.0", path = "../codegen" }
+subxt-codegen = { version = "0.2.0", path = "../codegen" }
 # parse command line args
 structopt = "0.3.25"
 # make the request to a substrate node to get the metadata

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,58 @@
+# subxt-cli
+
+Utilities for working with substrate metadata for `subxt`
+
+```
+USAGE:
+subxt <SUBCOMMAND>
+
+FLAGS:
+-h, --help       
+Prints help information
+
+    -V, --version    
+            Prints version information
+
+
+SUBCOMMANDS:
+codegen     Generate runtime API client code from metadata
+help        Prints this message or the help of the given subcommand(s)
+metadata    Download metadata from a substrate node, for use with `subxt` codegen
+```
+
+## Metadata
+
+Use to download metadata for inspection, or use in the `subxt` macro. e.g.
+
+`subxt metadata -f bytes > metadata.scale`
+
+```
+USAGE:
+    subxt metadata [OPTIONS]
+
+OPTIONS:
+    -f, --format <format>    the format of the metadata to display: `json`, `hex` or `bytes` [default: json]
+        --url <url>          the url of the substrate node to query for metadata [default: http://localhost:9933]
+```
+
+## Codegen
+
+Use to invoke the `subxt-codegen` crate which is used by `subxt-macro` to generate the the runtime API and types. Useful
+for troubleshooting codegen as an alternative to `cargo expand`, and also provides the possibility of customizing the 
+generated code if the macro does not produce the desired API. e.g. 
+
+`subxt codegen | rustfmt --edition=2018 --emit=stdout`
+
+```
+USAGE:
+    subxt codegen [OPTIONS]
+
+OPTIONS:
+    -f, --file <file>    
+            the path to the encoded metadata file
+
+        --url <url>      
+            the url of the substrate node to query for metadata for codegen
+
+```
+

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subxt-codegen"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -27,7 +27,7 @@ quote = "1.0.8"
 syn = "1.0.58"
 scale-info = "1.0.0"
 
-subxt-codegen = { version = "0.1.0", path = "../codegen" }
+subxt-codegen = { version = "0.2.0", path = "../codegen" }
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"


### PR DESCRIPTION
In order to be able to use `subxt-cli` for downloading metadata. See https://github.com/paritytech/subxt/pull/319#discussion_r748193904