### PR TITLE
Additional parameters for SignedExtra

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -213,7 +213,7 @@ where
     where
         <<<T as ExtrinsicExtraData<T>>::Extra as SignedExtra<T>>::Extra as SignedExtension>::AdditionalSigned: Send + Sync + 'static
     {
-        let extrinsic = self.create_signed(signer).await?;
+        let extrinsic = self.create_signed(signer, Default::default()).await?;
         self.client
             .rpc()
             .submit_and_watch_extrinsic(extrinsic, self.client.events_decoder())
@@ -235,7 +235,7 @@ where
     where
         <<<T as ExtrinsicExtraData<T>>::Extra as SignedExtra<T>>::Extra as SignedExtension>::AdditionalSigned: Send + Sync + 'static
     {
-        let extrinsic = self.create_signed(signer).await?;
+        let extrinsic = self.create_signed(signer, Default::default()).await?;
         self.client.rpc().submit_extrinsic(extrinsic).await
     }
 
@@ -243,6 +243,7 @@ where
     pub async fn create_signed(
         &self,
         signer: &(dyn Signer<T> + Send + Sync),
+        additional_params: <T::Extra as SignedExtra<T>>::Parameters,
     ) -> Result<UncheckedExtrinsic<T>, Error>
     where
         <<<T as ExtrinsicExtraData<T>>::Extra as SignedExtra<T>>::Extra as SignedExtension>::AdditionalSigned: Send + Sync + 'static
@@ -273,6 +274,7 @@ where
             account_nonce,
             call,
             signer,
+            additional_params,
         )
         .await?;
         Ok(signed)

--- a/src/extrinsic/extra.rs
+++ b/src/extrinsic/extra.rs
@@ -230,6 +230,8 @@ impl SignedExtension for ChargeTransactionPayment {
 pub trait SignedExtra<T: Config>: SignedExtension {
     /// The type the extras.
     type Extra: SignedExtension + Send + Sync;
+    /// The additional config parameters.
+    type Parameters: Default + Send + Sync;
 
     /// Creates a new `SignedExtra`.
     fn new(
@@ -237,6 +239,7 @@ pub trait SignedExtra<T: Config>: SignedExtension {
         tx_version: u32,
         nonce: T::Index,
         genesis_hash: T::Hash,
+        additional_params: Self::Parameters,
     ) -> Self;
 
     /// Returns the transaction extra.
@@ -263,12 +266,14 @@ impl<T: Config + Clone + Debug + Eq + Send + Sync> SignedExtra<T> for DefaultExt
         CheckWeight<T>,
         ChargeTransactionPayment,
     );
+    type Parameters = ();
 
     fn new(
         spec_version: u32,
         tx_version: u32,
         nonce: T::Index,
         genesis_hash: T::Hash,
+        _params: Self::Parameters,
     ) -> Self {
         DefaultExtra {
             spec_version,

--- a/src/extrinsic/mod.rs
+++ b/src/extrinsic/mod.rs
@@ -68,6 +68,7 @@ pub async fn create_signed<T>(
     nonce: T::Index,
     call: Encoded,
     signer: &(dyn Signer<T> + Send + Sync),
+    additional_params: <T::Extra as SignedExtra<T>>::Parameters,
 ) -> Result<UncheckedExtrinsic<T>, Error>
 where
     T: Config + ExtrinsicExtraData<T>,
@@ -81,6 +82,7 @@ where
         tx_version,
         nonce,
         genesis_hash,
+        additional_params,
     );
     let payload = SignedPayload::<T>::new(call, extra.extra())?;
     let signed = signer.sign(payload).await?;


### PR DESCRIPTION
We need to control the transaction longevity in our application. subxt does's have an API to do so.
We can use a custom SignedExtra implementation to fill the CheckMortality parameters. However, a custom SignedExtra has no way to be passed in extra infomation to construct the CheckMortality. This PR add an associated type to allow SignedExtra to carry some custom data to construct the signed extra.  Check [here](https://github.com/Phala-Network/phala-blockchain/blob/db56f7a6e6f490aa68d6ba2af6a498e597e8ea04/crates/phaxt/src/extra.rs#L66-L87) for more detail.