### PR TITLE
Make system properties an arbitrary JSON object, plus CI fixes

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -120,7 +120,7 @@ fn main() -> color_eyre::Result<()> {
             });
             let (_, bytes) = fetch_metadata(&url)?;
             codegen(&mut &bytes[..])?;
-            return Ok(())
+            Ok(())
         }
     }
 }
@@ -139,7 +139,7 @@ fn fetch_metadata(url: &url::Url) -> color_eyre::Result<(String, Vec<u8>)> {
     let hex_data = json["result"]
         .as_str()
         .map(ToString::to_string)
-        .ok_or(eyre::eyre!("metadata result field should be a string"))?;
+        .ok_or_else(|| eyre::eyre!("metadata result field should be a string"))?;
     let bytes = hex::decode(hex_data.trim_start_matches("0x"))?;
 
     Ok((hex_data, bytes))

--- a/codegen/src/ir.rs
+++ b/codegen/src/ir.rs
@@ -73,6 +73,7 @@ impl ItemMod {
 }
 
 #[derive(Debug, PartialEq, Eq)]
+#[allow(clippy::large_enum_variant)]
 pub enum Item {
     Rust(syn::Item),
     Subxt(SubxtItem),

--- a/codegen/src/types/tests.rs
+++ b/codegen/src/types/tests.rs
@@ -22,7 +22,7 @@ use scale_info::{
     TypeInfo,
 };
 
-const MOD_PATH: &'static [&'static str] = &["subxt_codegen", "types", "tests"];
+const MOD_PATH: &[&str] = &["subxt_codegen", "types", "tests"];
 
 fn get_mod<'a>(module: &'a Module, path_segs: &[&'static str]) -> Option<&'a Module<'a>> {
     let (mod_name, rest) = path_segs.split_first()?;
@@ -790,7 +790,7 @@ fn generics_with_alias_adds_phantom_data_marker() {
 
 #[test]
 fn modules() {
-    mod modules {
+    mod m {
         pub mod a {
             #[allow(unused)]
             #[derive(scale_info::TypeInfo)]
@@ -815,7 +815,7 @@ fn modules() {
     }
 
     let mut registry = Registry::new();
-    registry.register_type(&meta_type::<modules::c::Foo>());
+    registry.register_type(&meta_type::<m::c::Foo>());
     let portable_types: PortableRegistry = registry.into();
 
     let type_gen = TypeGenerator::new(

--- a/codegen/src/types/tests.rs
+++ b/codegen/src/types/tests.rs
@@ -832,7 +832,7 @@ fn modules() {
         quote! {
             pub mod tests {
                 use super::root;
-                pub mod modules {
+                pub mod m {
                     use super::root;
                     pub mod a {
                         use super::root;
@@ -842,7 +842,7 @@ fn modules() {
 
                             #[derive(::subxt::codec::Encode, ::subxt::codec::Decode)]
                             pub struct Bar {
-                                pub a: root::subxt_codegen::types::tests::modules::a::Foo,
+                                pub a: root::subxt_codegen::types::tests::m::a::Foo,
                             }
                         }
 
@@ -855,7 +855,7 @@ fn modules() {
 
                         #[derive(::subxt::codec::Encode, ::subxt::codec::Decode)]
                         pub struct Foo {
-                            pub a: root::subxt_codegen::types::tests::modules::a::b::Bar,
+                            pub a: root::subxt_codegen::types::tests::m::a::b::Bar,
                         }
                     }
                 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -157,7 +157,14 @@ impl<T: Config> Client<T> {
         &self.metadata
     }
 
-    /// Returns the system properties
+    /// Returns the properties defined in the chain spec as a JSON object.
+    ///
+    /// # Note
+    ///
+    /// Some chains use this to define common properties such as `token_decimals` and `token_symbol`
+    /// required for UIs, but this is merely a convention. So it is up to the library user to
+    /// deserialize the JSON into the appropriate type or otherwise extract the properties defined
+    /// in the target chain's spec.
     pub fn properties(&self) -> &SystemProperties {
         &self.properties
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -162,7 +162,7 @@ impl<T: Config> Client<T> {
     /// # Note
     ///
     /// Many chains use this to define common properties such as `token_decimals` and `token_symbol`
-    /// required for UIs, but this is merely a convention. So it is up to the library user to
+    /// required for UIs, but this is merely a convention. It is up to the library user to
     /// deserialize the JSON into the appropriate type or otherwise extract the properties defined
     /// in the target chain's spec.
     pub fn properties(&self) -> &SystemProperties {

--- a/src/client.rs
+++ b/src/client.rs
@@ -161,7 +161,7 @@ impl<T: Config> Client<T> {
     ///
     /// # Note
     ///
-    /// Some chains use this to define common properties such as `token_decimals` and `token_symbol`
+    /// Many chains use this to define common properties such as `token_decimals` and `token_symbol`
     /// required for UIs, but this is merely a convention. So it is up to the library user to
     /// deserialize the JSON into the appropriate type or otherwise extract the properties defined
     /// in the target chain's spec.

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -143,6 +143,11 @@ pub struct PalletMetadata {
 }
 
 impl PalletMetadata {
+    /// Get the name of the pallet.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
     /// Encode a call based on this pallet metadata.
     pub fn encode_call<C>(&self, call: &C) -> Result<Encoded, MetadataError>
     where

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -141,17 +141,8 @@ impl From<u32> for BlockNumber {
     }
 }
 
-/// System properties for a Substrate-based runtime
-#[derive(serde::Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]
-#[serde(rename_all = "camelCase")]
-pub struct SystemProperties {
-    /// The address format
-    pub ss58_format: u8,
-    /// The number of digits after the decimal point in the native token
-    pub token_decimals: u8,
-    /// The symbol of the native token
-    pub token_symbol: String,
-}
+/// Arbitrary properties defined in the chain spec as a JSON object.
+pub type SystemProperties = serde_json::Map<String, serde_json::Value>;
 
 /// Possible transaction status events.
 ///

--- a/tests/integration/frame/timestamp.rs
+++ b/tests/integration/frame/timestamp.rs
@@ -20,12 +20,7 @@ use crate::test_context;
 async fn storage_get_current_timestamp() {
     let cxt = test_context().await;
 
-    let timestamp = cxt
-        .api
-        .storage()
-        .timestamp()
-        .now(None)
-        .await;
+    let timestamp = cxt.api.storage().timestamp().now(None).await;
 
     assert!(timestamp.is_ok())
 }

--- a/tests/integration/frame/timestamp.rs
+++ b/tests/integration/frame/timestamp.rs
@@ -15,34 +15,17 @@
 // along with subxt.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::test_context;
-use std::time::{
-    SystemTime,
-    UNIX_EPOCH,
-};
 
 #[async_std::test]
 async fn storage_get_current_timestamp() {
-    let sys_timestamp = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_millis() as u64;
     let cxt = test_context().await;
-
-    // wait until blocks are produced to get the timestamp
-    let mut sub = cxt.client().rpc().subscribe_blocks().await.unwrap();
-    let block_hash = loop {
-        if let Ok(Some(block)) = sub.next().await {
-            break block.hash()
-        }
-    };
 
     let timestamp = cxt
         .api
         .storage()
         .timestamp()
-        .now(Some(block_hash))
-        .await
-        .unwrap();
+        .now(None)
+        .await;
 
-    assert!(timestamp > sys_timestamp)
+    assert!(timestamp.is_ok())
 }


### PR DESCRIPTION
Closes #316.

System properties are just an arbitrary JSON object defined in the chainspec, so this should be reflected in `subxt`. See https://github.com/paritytech/substrate/blob/b7409a2257c7c231b485ee827daa73d05d303047/client/chain-spec/src/lib.rs#L148

Additionally to satisfy CI:

- Makes timestamp test not flaky
- Fixes clippy errors and warnings