### PR TITLE
Simpler dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ sp-version = { package = "sp-version", git = "https://github.com/paritytech/subs
 frame-metadata = "14.0.0"
 
 [dev-dependencies]
-sp-arithmetic = { package = "sp-arithmetic", git = "https://github.com/paritytech/substrate/", branch = "master", default-features = false }
+sp-arithmetic = { git = "https://github.com/paritytech/substrate/", branch = "master", default-features = false }
 assert_matches = "1.5.0"
 async-std = { version = "1.9.0", features = ["attributes", "tokio1"] }
 env_logger = "0.8.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ url = "2.2.1"
 subxt-macro = { version = "0.1.0", path = "macro" }
 
 sp-core = { git = "https://github.com/paritytech/substrate/", branch = "master", default-features = false  }
-sp-runtime = { package = "sp-runtime", git = "https://github.com/paritytech/substrate/", branch = "master", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate/", branch = "master", default-features = false }
 sp-version = { package = "sp-version", git = "https://github.com/paritytech/substrate/", branch = "master" }
 
 frame-metadata = "14.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,14 +34,14 @@ url = "2.2.1"
 
 subxt-macro = { version = "0.1.0", path = "macro" }
 
-sp-arithmetic = { package = "sp-arithmetic", git = "https://github.com/paritytech/substrate/", branch = "master" }
-sp-core = { package = "sp-core", git = "https://github.com/paritytech/substrate/", branch = "master" }
-sp-runtime = { package = "sp-runtime", git = "https://github.com/paritytech/substrate/", branch = "master" }
+sp-core = { package = "sp-core", git = "https://github.com/paritytech/substrate/", branch = "master", default-features = false  }
+sp-runtime = { package = "sp-runtime", git = "https://github.com/paritytech/substrate/", branch = "master", default-features = false }
 sp-version = { package = "sp-version", git = "https://github.com/paritytech/substrate/", branch = "master" }
 
 frame-metadata = "14.0.0"
 
 [dev-dependencies]
+sp-arithmetic = { package = "sp-arithmetic", git = "https://github.com/paritytech/substrate/", branch = "master", default-features = false }
 assert_matches = "1.5.0"
 async-std = { version = "1.9.0", features = ["attributes", "tokio1"] }
 env_logger = "0.8.3"
@@ -51,4 +51,3 @@ which = "4.0.2"
 test-runtime = { path = "test-runtime" }
 
 sp-keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate/", branch = "master" }
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ url = "2.2.1"
 
 subxt-macro = { version = "0.1.0", path = "macro" }
 
-sp-core = { package = "sp-core", git = "https://github.com/paritytech/substrate/", branch = "master", default-features = false  }
+sp-core = { git = "https://github.com/paritytech/substrate/", branch = "master", default-features = false  }
 sp-runtime = { package = "sp-runtime", git = "https://github.com/paritytech/substrate/", branch = "master", default-features = false }
 sp-version = { package = "sp-version", git = "https://github.com/paritytech/substrate/", branch = "master" }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,6 @@ pub use subxt_macro::subxt;
 
 pub use bitvec;
 pub use codec;
-pub use sp_arithmetic;
 pub use sp_core;
 pub use sp_runtime;
 


### PR DESCRIPTION
Micro PR with outcome of some code reading and tinkering.

Moves `sp-arithmetic` to `dev-dependencies` and switches to use `default-features = false`. Was hoping for a reduced number of dependent crates but it stays the same.﻿
