### PR TITLE
Rebuild test-runtime if `substrate` binary is updated

### DIFF
--- a/test-runtime/Cargo.toml
+++ b/test-runtime/Cargo.toml
@@ -12,3 +12,4 @@ codec = { package = "parity-scale-codec", version = "2", default-features = fals
 subxt = { path = ".." }
 sp-core = { package = "sp-core", git = "https://github.com/paritytech/substrate/", branch = "master" }
 async-std = { version = "1.9.0", features = ["attributes", "tokio1"] }
+which = "4.2.2"

--- a/test-runtime/build.rs
+++ b/test-runtime/build.rs
@@ -113,6 +113,10 @@ async fn run() {
     fs::write(&runtime_path, runtime_api_contents)
         .expect("Couldn't write runtime rust output");
 
+    let substrate_path = which::which(substrate_bin).expect("can resolve path to substrate binary");
+
+    // Re-build if the substrate binary we're pointed to changes (mtime):
+    println!("cargo:rerun-if-changed={}", substrate_path.to_string_lossy());
     // Re-build if we point to a different substrate binary:
     println!("cargo:rerun-if-env-changed={}", SUBSTRATE_BIN_ENV_VAR);
     // Re-build if this file changes:

--- a/test-runtime/build.rs
+++ b/test-runtime/build.rs
@@ -114,7 +114,7 @@ async fn run() {
         .expect("Couldn't write runtime rust output");
 
     let substrate_path =
-        which::which(substrate_bin).expect("can resolve path to substrate binary");
+        which::which(substrate_bin).expect("Cannot resolve path to substrate binary");
 
     // Re-build if the substrate binary we're pointed to changes (mtime):
     println!(

--- a/test-runtime/build.rs
+++ b/test-runtime/build.rs
@@ -113,10 +113,14 @@ async fn run() {
     fs::write(&runtime_path, runtime_api_contents)
         .expect("Couldn't write runtime rust output");
 
-    let substrate_path = which::which(substrate_bin).expect("can resolve path to substrate binary");
+    let substrate_path =
+        which::which(substrate_bin).expect("can resolve path to substrate binary");
 
     // Re-build if the substrate binary we're pointed to changes (mtime):
-    println!("cargo:rerun-if-changed={}", substrate_path.to_string_lossy());
+    println!(
+        "cargo:rerun-if-changed={}",
+        substrate_path.to_string_lossy()
+    );
     // Re-build if we point to a different substrate binary:
     println!("cargo:rerun-if-env-changed={}", SUBSTRATE_BIN_ENV_VAR);
     // Re-build if this file changes:


### PR DESCRIPTION
Prior to this, one could update the substrate binary on their PATH, and the test-runtime would not rebuild in response to this, leading to a potentially out of date runtime being used (the fix was to tweak `test-runtime/build.rs` to force a rebuild).

This resolves the path to the substrate binary and tells cargo to keep an eye on that, too.

Tested by `touch`ing the substrate binary in use, which then caused a rebuild (and otherwise it would not rebuild).

Closes #358 