### PR TITLE
Implement `pre_dispatch` for SignedExtensions

### DIFF
--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -34,4 +34,4 @@ pretty_assertions = "0.6.1"
 subxt = { path = ".." }
 trybuild = "1.0.38"
 
-sp-keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate/" }
+sp-keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate/", branch = "master" }

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -34,4 +34,4 @@ pretty_assertions = "0.6.1"
 subxt = { path = ".." }
 trybuild = "1.0.38"
 
-sp-keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate/", branch = "master" }
+sp-keyring = { git = "https://github.com/paritytech/substrate/", branch = "master" }

--- a/src/extrinsic/extra.rs
+++ b/src/extrinsic/extra.rs
@@ -25,7 +25,10 @@ use core::{
 use scale_info::TypeInfo;
 use sp_runtime::{
     generic::Era,
-    traits::SignedExtension,
+    traits::{
+        DispatchInfoOf,
+        SignedExtension,
+    },
     transaction_validity::TransactionValidityError,
 };
 
@@ -68,6 +71,15 @@ where
     ) -> Result<Self::AdditionalSigned, TransactionValidityError> {
         Ok(self.1)
     }
+    fn pre_dispatch(
+        self,
+        _who: &Self::AccountId,
+        _call: &Self::Call,
+        _info: &DispatchInfoOf<Self::Call>,
+        _len: usize,
+    ) -> Result<Self::Pre, TransactionValidityError> {
+        Ok(())
+    }
 }
 
 /// Ensure the transaction version registered in the transaction is the same as at present.
@@ -99,6 +111,15 @@ where
     ) -> Result<Self::AdditionalSigned, TransactionValidityError> {
         Ok(self.1)
     }
+    fn pre_dispatch(
+        self,
+        _who: &Self::AccountId,
+        _call: &Self::Call,
+        _info: &DispatchInfoOf<Self::Call>,
+        _len: usize,
+    ) -> Result<Self::Pre, TransactionValidityError> {
+        Ok(())
+    }
 }
 
 /// Check genesis hash
@@ -129,6 +150,15 @@ where
         &self,
     ) -> Result<Self::AdditionalSigned, TransactionValidityError> {
         Ok(self.1)
+    }
+    fn pre_dispatch(
+        self,
+        _who: &Self::AccountId,
+        _call: &Self::Call,
+        _info: &DispatchInfoOf<Self::Call>,
+        _len: usize,
+    ) -> Result<Self::Pre, TransactionValidityError> {
+        Ok(())
     }
 }
 
@@ -163,6 +193,15 @@ where
     ) -> Result<Self::AdditionalSigned, TransactionValidityError> {
         Ok(self.1)
     }
+    fn pre_dispatch(
+        self,
+        _who: &Self::AccountId,
+        _call: &Self::Call,
+        _info: &DispatchInfoOf<Self::Call>,
+        _len: usize,
+    ) -> Result<Self::Pre, TransactionValidityError> {
+        Ok(())
+    }
 }
 
 /// Nonce check and increment to give replay protection for transactions.
@@ -184,6 +223,15 @@ where
     ) -> Result<Self::AdditionalSigned, TransactionValidityError> {
         Ok(())
     }
+    fn pre_dispatch(
+        self,
+        _who: &Self::AccountId,
+        _call: &Self::Call,
+        _info: &DispatchInfoOf<Self::Call>,
+        _len: usize,
+    ) -> Result<Self::Pre, TransactionValidityError> {
+        Ok(())
+    }
 }
 
 /// Resource limit check.
@@ -203,6 +251,15 @@ where
     fn additional_signed(
         &self,
     ) -> Result<Self::AdditionalSigned, TransactionValidityError> {
+        Ok(())
+    }
+    fn pre_dispatch(
+        self,
+        _who: &Self::AccountId,
+        _call: &Self::Call,
+        _info: &DispatchInfoOf<Self::Call>,
+        _len: usize,
+    ) -> Result<Self::Pre, TransactionValidityError> {
         Ok(())
     }
 }
@@ -228,6 +285,15 @@ impl SignedExtension for ChargeAssetTxPayment {
     fn additional_signed(
         &self,
     ) -> Result<Self::AdditionalSigned, TransactionValidityError> {
+        Ok(())
+    }
+    fn pre_dispatch(
+        self,
+        _who: &Self::AccountId,
+        _call: &Self::Call,
+        _info: &DispatchInfoOf<Self::Call>,
+        _len: usize,
+    ) -> Result<Self::Pre, TransactionValidityError> {
         Ok(())
     }
 }
@@ -317,5 +383,14 @@ impl<T: Config + Clone + Debug + Eq + Send + Sync> SignedExtension for DefaultEx
         &self,
     ) -> Result<Self::AdditionalSigned, TransactionValidityError> {
         self.extra().additional_signed()
+    }
+    fn pre_dispatch(
+        self,
+        _who: &Self::AccountId,
+        _call: &Self::Call,
+        _info: &DispatchInfoOf<Self::Call>,
+        _len: usize,
+    ) -> Result<Self::Pre, TransactionValidityError> {
+        Ok(())
     }
 }


### PR DESCRIPTION
`pre_dispatch` is a new method on the `SignedExtension` trait from substrate. We don't care about this internal implementation detail on the `subxt` side, but we require this trait to be implemented because we are using the `SignedPayload` and `UncheckedExtrinsic` types from `sp_runtime`.

The other option is of course to define our own local types and traits to remove this direct coupling, but that need some careful consideration.

In the meantime this makes things compile and continue working against the `substrate` master branch.

This also fixes an issue with duplicate substrate dependencies.