### PR TITLE
Adds option to pass a mortality parameter to create_signed

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -15,31 +15,18 @@
 // along with subxt.  If not, see <http://www.gnu.org/licenses/>.
 
 use futures::future;
-use sp_runtime::traits::Hash;
 pub use sp_runtime::traits::SignedExtension;
+use sp_runtime::{generic::Era, traits::Hash};
 pub use sp_version::RuntimeVersion;
 
 use crate::{
     error::Error,
     events::EventsDecoder,
-    extrinsic::{
-        self,
-        SignedExtra,
-        Signer,
-        UncheckedExtrinsic,
-    },
-    rpc::{
-        Rpc,
-        RpcClient,
-        SystemProperties,
-    },
+    extrinsic::{self, SignedExtra, Signer, UncheckedExtrinsic},
+    rpc::{Rpc, RpcClient, SystemProperties},
     storage::StorageClient,
     transaction::TransactionProgress,
-    AccountData,
-    Call,
-    Config,
-    ExtrinsicExtraData,
-    Metadata,
+    AccountData, Call, Config, ExtrinsicExtraData, Metadata,
 };
 use std::sync::Arc;
 
@@ -276,6 +263,7 @@ where
             call,
             signer,
             additional_params,
+            Era::Immortal,
         )
         .await?;
         Ok(signed)

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,18 +16,12 @@
 
 use crate::{
     events::EventsDecodingError,
-    metadata::{
-        InvalidMetadataError,
-        MetadataError,
-    },
+    metadata::{InvalidMetadataError, MetadataError},
     Metadata,
 };
 use jsonrpsee::types::Error as RequestError;
 use sp_core::crypto::SecretStringError;
-use sp_runtime::{
-    transaction_validity::TransactionValidityError,
-    DispatchError,
-};
+use sp_runtime::{transaction_validity::TransactionValidityError, DispatchError};
 use thiserror::Error;
 
 /// Error enum.

--- a/src/extrinsic/extra.rs
+++ b/src/extrinsic/extra.rs
@@ -14,21 +14,12 @@
 // You should have received a copy of the GNU General Public License
 // along with subxt.  If not, see <http://www.gnu.org/licenses/>.
 
-use codec::{
-    Decode,
-    Encode,
-};
-use core::{
-    fmt::Debug,
-    marker::PhantomData,
-};
+use codec::{Decode, Encode};
+use core::{fmt::Debug, marker::PhantomData};
 use scale_info::TypeInfo;
 use sp_runtime::{
     generic::Era,
-    traits::{
-        DispatchInfoOf,
-        SignedExtension,
-    },
+    traits::{DispatchInfoOf, SignedExtension},
     transaction_validity::TransactionValidityError,
 };
 
@@ -312,6 +303,7 @@ pub trait SignedExtra<T: Config>: SignedExtension {
         nonce: T::Index,
         genesis_hash: T::Hash,
         additional_params: Self::Parameters,
+        mortality: Era,
     ) -> Self;
 
     /// Returns the transaction extra.
@@ -326,6 +318,7 @@ pub struct DefaultExtra<T: Config> {
     tx_version: u32,
     nonce: T::Index,
     genesis_hash: T::Hash,
+    mortality: Era,
 }
 
 impl<T: Config + Clone + Debug + Eq + Send + Sync> SignedExtra<T> for DefaultExtra<T> {
@@ -346,12 +339,14 @@ impl<T: Config + Clone + Debug + Eq + Send + Sync> SignedExtra<T> for DefaultExt
         nonce: T::Index,
         genesis_hash: T::Hash,
         _params: Self::Parameters,
+        mortality: Era,
     ) -> Self {
         DefaultExtra {
             spec_version,
             tx_version,
             nonce,
             genesis_hash,
+            mortality,
         }
     }
 
@@ -360,7 +355,7 @@ impl<T: Config + Clone + Debug + Eq + Send + Sync> SignedExtra<T> for DefaultExt
             CheckSpecVersion(PhantomData, self.spec_version),
             CheckTxVersion(PhantomData, self.tx_version),
             CheckGenesis(PhantomData, self.genesis_hash),
-            CheckMortality((Era::Immortal, PhantomData), self.genesis_hash),
+            CheckMortality((self.mortality, PhantomData), self.genesis_hash),
             CheckNonce(self.nonce),
             CheckWeight(PhantomData),
             ChargeAssetTxPayment {

--- a/src/extrinsic/mod.rs
+++ b/src/extrinsic/mod.rs
@@ -21,31 +21,16 @@ mod signer;
 
 pub use self::{
     extra::{
-        ChargeAssetTxPayment,
-        CheckGenesis,
-        CheckMortality,
-        CheckNonce,
-        CheckSpecVersion,
-        CheckTxVersion,
-        CheckWeight,
-        DefaultExtra,
-        SignedExtra,
+        ChargeAssetTxPayment, CheckGenesis, CheckMortality, CheckNonce, CheckSpecVersion,
+        CheckTxVersion, CheckWeight, DefaultExtra, SignedExtra,
     },
-    signer::{
-        PairSigner,
-        Signer,
-    },
+    signer::{PairSigner, Signer},
 };
 
-use sp_runtime::traits::SignedExtension;
+use sp_runtime::{generic::Era, traits::SignedExtension};
 use sp_version::RuntimeVersion;
 
-use crate::{
-    Config,
-    Encoded,
-    Error,
-    ExtrinsicExtraData,
-};
+use crate::{Config, Encoded, Error, ExtrinsicExtraData};
 
 /// UncheckedExtrinsic type.
 pub type UncheckedExtrinsic<T> = sp_runtime::generic::UncheckedExtrinsic<
@@ -69,6 +54,7 @@ pub async fn create_signed<T>(
     call: Encoded,
     signer: &(dyn Signer<T> + Send + Sync),
     additional_params: <T::Extra as SignedExtra<T>>::Parameters,
+    mortality: Era,
 ) -> Result<UncheckedExtrinsic<T>, Error>
 where
     T: Config + ExtrinsicExtraData<T>,
@@ -83,6 +69,7 @@ where
         nonce,
         genesis_hash,
         additional_params,
+        mortality,
     );
     let payload = SignedPayload::<T>::new(call, extra.extra())?;
     let signed = signer.sign(payload).await?;


### PR DESCRIPTION
For my use case it'd be useful to add a parameter `mortality` to the `extrinsic::create_signed` function.

So that not every transaction has to be `Era::Immortal`. 

I was wondering if there's a chance to merge this into master? 