### PR TITLE
Use released substrate dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,12 +36,12 @@ subxt-macro = { version = "0.1.0", path = "macro" }
 
 sp-core = { version = "4.0.0", default-features = false  }
 sp-runtime = { version = "4.0.0", default-features = false }
-sp-version = { package = "sp-version", git = "https://github.com/paritytech/substrate/", branch = "master" }
+sp-version = "4.0.0"
 
 frame-metadata = "14.0.0"
 
 [dev-dependencies]
-sp-arithmetic = { git = "https://github.com/paritytech/substrate/", branch = "master", default-features = false }
+sp-arithmetic = { version = "4.0.0", default-features = false }
 assert_matches = "1.5.0"
 async-std = { version = "1.9.0", features = ["attributes", "tokio1"] }
 env_logger = "0.8.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,8 @@ url = "2.2.1"
 
 subxt-macro = { version = "0.1.0", path = "macro" }
 
-sp-core = { git = "https://github.com/paritytech/substrate/", branch = "master", default-features = false  }
-sp-runtime = { git = "https://github.com/paritytech/substrate/", branch = "master", default-features = false }
+sp-core = { version = "4.0.0", default-features = false  }
+sp-runtime = { version = "4.0.0", default-features = false }
 sp-version = { package = "sp-version", git = "https://github.com/paritytech/substrate/", branch = "master" }
 
 frame-metadata = "14.0.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -107,9 +107,6 @@ pub enum RuntimeError {
     /// There are no providers so the account cannot be created.
     #[error("There are no providers so the account cannot be created.")]
     NoProviders,
-    /// There are too many consumers so the account cannot be created.
-    #[error("There are too many consumers so the account cannot be created.")]
-    TooManyConsumers,
     /// Bad origin.
     #[error("Bad origin: throw by ensure_signed, ensure_root or ensure_none.")]
     BadOrigin,
@@ -144,7 +141,6 @@ impl RuntimeError {
             DispatchError::CannotLookup => Ok(Self::CannotLookup),
             DispatchError::ConsumerRemaining => Ok(Self::ConsumerRemaining),
             DispatchError::NoProviders => Ok(Self::NoProviders),
-            DispatchError::TooManyConsumers => Ok(Self::TooManyConsumers),
             DispatchError::Arithmetic(_math_error) => {
                 Ok(Self::Other("math_error".into()))
             }

--- a/test-runtime/Cargo.toml
+++ b/test-runtime/Cargo.toml
@@ -5,11 +5,11 @@ edition = "2021"
 
 [dependencies]
 subxt = { path = ".." }
-sp-runtime = { package = "sp-runtime", git = "https://github.com/paritytech/substrate/", branch = "master" }
+sp-runtime = "4.0.0"
 codec = { package = "parity-scale-codec", version = "2", default-features = false, features = ["derive", "full", "bit-vec"] }
 
 [build-dependencies]
 subxt = { path = ".." }
-sp-core = { package = "sp-core", git = "https://github.com/paritytech/substrate/", branch = "master" }
+sp-core = "4.0.0"
 async-std = { version = "1.9.0", features = ["attributes", "tokio1"] }
 which = "4.2.2"


### PR DESCRIPTION
Use substrate crates from `crates.io`, which will allow us to do a release of this crate.

# todo

- [ ] Release `sp-keyring` which is still at an old version on `crates.io`. It's a dev dependency but it depends on `sp-core` and `sp-runtime`, so brings in conflicting versions which causes the tests to not compile.