### PR TITLE
Update to jsonrpsee 0.7 and impl Stream on TransactionProgress

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -51,8 +51,9 @@ jobs:
         with:
           # Use this issue template:
           filename: .github/issue_templates/nightly_run_failed.md
-          # Don't create a new issue; skip updating existing:
-          update_existing: false
+          # Update existing issue if found; hopefully will make it clearer
+          # that it is still an issue:
+          update_existing: true
           # Look for new *open* issues in this search (we want to
           # create a new one if we only find closed versions):
           search_existing: open

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ chameleon = "0.1.0"
 scale-info = { version = "1.0.0", features = ["bit-vec"] }
 futures = "0.3.13"
 hex = "0.4.3"
-jsonrpsee = { version = "0.5.1", features = ["macros", "ws-client", "http-client"] }
+jsonrpsee = { version = "0.7.0", features = ["macros", "ws-client", "http-client"] }
 log = "0.4.14"
 num-traits = { version = "0.2.14", default-features = false }
 serde = { version = "1.0.124", features = ["derive"] }

--- a/examples/submit_and_watch.rs
+++ b/examples/submit_and_watch.rs
@@ -22,6 +22,7 @@
 //! polkadot --dev --tmp
 //! ```
 
+use futures::StreamExt;
 use sp_keyring::AccountKeyring;
 use subxt::{
     ClientBuilder,
@@ -144,7 +145,8 @@ async fn handle_transfer_events() -> Result<(), Box<dyn std::error::Error>> {
         .sign_and_submit_then_watch(&signer)
         .await?;
 
-    while let Some(ev) = balance_transfer_progress.next().await? {
+    while let Some(ev) = balance_transfer_progress.next().await {
+        let ev = ev?;
         use subxt::TransactionStatus::*;
 
         // Made it into a block, but not finalized.

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,7 +22,7 @@ use crate::{
     },
     Metadata,
 };
-use jsonrpsee::types::Error as RequestError;
+use jsonrpsee::core::error::Error as RequestError;
 use sp_core::crypto::SecretStringError;
 use sp_runtime::{
     transaction_validity::TransactionValidityError,

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -33,25 +33,23 @@ use core::{
 };
 use frame_metadata::RuntimeMetadataPrefixed;
 use jsonrpsee::{
+    core::{
+        client::{
+            Client,
+            ClientT,
+            Subscription,
+            SubscriptionClientT,
+        },
+        to_json_value,
+        DeserializeOwned,
+        Error as RpcError,
+        JsonValue,
+    },
     http_client::{
         HttpClient,
         HttpClientBuilder,
     },
-    types::{
-        to_json_value,
-        traits::{
-            Client,
-            SubscriptionClient,
-        },
-        DeserializeOwned,
-        Error as RpcError,
-        JsonValue,
-        Subscription,
-    },
-    ws_client::{
-        WsClient,
-        WsClientBuilder,
-    },
+    ws_client::WsClientBuilder,
 };
 use serde::{
     Deserialize,
@@ -172,7 +170,7 @@ pub enum SubstrateTransactionStatus<Hash, BlockHash> {
 #[derive(Clone)]
 pub enum RpcClient {
     /// JSONRPC client WebSocket transport.
-    WebSocket(Arc<WsClient>),
+    WebSocket(Arc<Client>),
     /// JSONRPC client HTTP transport.
     // NOTE: Arc because `HttpClient` is not clone.
     Http(Arc<HttpClient>),
@@ -239,14 +237,14 @@ impl RpcClient {
     }
 }
 
-impl From<WsClient> for RpcClient {
-    fn from(client: WsClient) -> Self {
+impl From<Client> for RpcClient {
+    fn from(client: Client) -> Self {
         RpcClient::WebSocket(Arc::new(client))
     }
 }
 
-impl From<Arc<WsClient>> for RpcClient {
-    fn from(client: Arc<WsClient>) -> Self {
+impl From<Arc<Client>> for RpcClient {
+    fn from(client: Arc<Client>) -> Self {
         RpcClient::WebSocket(client)
     }
 }

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -14,9 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with subxt.  If not, see <http://www.gnu.org/licenses/>.
 
-use jsonrpsee::types::{
+use jsonrpsee::core::{
+    client::Subscription,
     DeserializeOwned,
-    Subscription,
 };
 use sp_core::{
     storage::{
@@ -247,12 +247,12 @@ where
     T: DeserializeOwned,
 {
     match sub.next().await {
-        Ok(Some(next)) => Some(next),
-        Ok(None) => None,
-        Err(e) => {
+        Some(Ok(next)) => Some(next),
+        Some(Err(e)) => {
             log::error!("Subscription {} failed: {:?} dropping", sub_name, e);
             None
         }
+        None => None,
     }
 }
 

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -50,6 +50,9 @@ pub struct TransactionProgress<'client, T: Config> {
     client: &'client Client<T>,
 }
 
+// The above type is not `Unpin` by default unless the generic param `T` is,
+// so we manually make it clear that Unpin is actually fine regardless of `T`
+// (we don't care if this moves around in memory while it's "pinned").
 impl<'client, T: Config> Unpin for TransactionProgress<'client, T> {}
 
 impl<'client, T: Config> TransactionProgress<'client, T> {

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -79,12 +79,12 @@ impl<'client, T: Config> TransactionProgress<'client, T> {
     /// waiting for this to happen.
     ///
     /// **Note:** consumes `self`. If you'd like to perform multiple actions as the state of the
-    /// transaction progresses, use [`TransactionProgress::next()`] instead.
+    /// transaction progresses, use [`TransactionProgress::next_item()`] instead.
     ///
     /// **Note:** transaction statuses like `Invalid` and `Usurped` are ignored, because while they
     /// may well indicate with some probability that the transaction will not make it into a block,
     /// there is no guarantee that this is true. Thus, we prefer to "play it safe" here. Use the lower
-    /// level [`TransactionProgress::next()`] API if you'd like to handle these statuses yourself.
+    /// level [`TransactionProgress::next_item()`] API if you'd like to handle these statuses yourself.
     pub async fn wait_for_in_block(
         mut self,
     ) -> Result<TransactionInBlock<'client, T>, Error> {
@@ -109,12 +109,12 @@ impl<'client, T: Config> TransactionProgress<'client, T> {
     /// instance when it is, or an error if there was a problem waiting for finalization.
     ///
     /// **Note:** consumes `self`. If you'd like to perform multiple actions as the state of the
-    /// transaction progresses, use [`TransactionProgress::next()`] instead.
+    /// transaction progresses, use [`TransactionProgress::next_item()`] instead.
     ///
     /// **Note:** transaction statuses like `Invalid` and `Usurped` are ignored, because while they
     /// may well indicate with some probability that the transaction will not make it into a block,
     /// there is no guarantee that this is true. Thus, we prefer to "play it safe" here. Use the lower
-    /// level [`TransactionProgress::next()`] API if you'd like to handle these statuses yourself.
+    /// level [`TransactionProgress::next_item()`] API if you'd like to handle these statuses yourself.
     pub async fn wait_for_finalized(
         mut self,
     ) -> Result<TransactionInBlock<'client, T>, Error> {
@@ -138,12 +138,12 @@ impl<'client, T: Config> TransactionProgress<'client, T> {
     /// as well as a couple of other details (block hash and extrinsic hash).
     ///
     /// **Note:** consumes self. If you'd like to perform multiple actions as progress is made,
-    /// use [`TransactionProgress::next()`] instead.
+    /// use [`TransactionProgress::next_item()`] instead.
     ///
     /// **Note:** transaction statuses like `Invalid` and `Usurped` are ignored, because while they
     /// may well indicate with some probability that the transaction will not make it into a block,
     /// there is no guarantee that this is true. Thus, we prefer to "play it safe" here. Use the lower
-    /// level [`TransactionProgress::next()`] API if you'd like to handle these statuses yourself.
+    /// level [`TransactionProgress::next_item()`] API if you'd like to handle these statuses yourself.
     pub async fn wait_for_finalized_success(self) -> Result<TransactionEvents<T>, Error> {
         let evs = self.wait_for_finalized().await?.wait_for_success().await?;
         Ok(evs)
@@ -217,7 +217,7 @@ impl<'client, T: Config> Stream for TransactionProgress<'client, T> {
 //* Note that the number of finality watchers is, at the time of writing, found in the constant
 //* `MAX_FINALITY_WATCHERS` in the `sc_transaction_pool` crate.
 //*
-/// Possible transaction statuses returned from our [`TransactionProgress::next()`] call.
+/// Possible transaction statuses returned from our [`TransactionProgress::next_item()`] call.
 ///
 /// These status events can be grouped based on their kinds as:
 ///

--- a/tests/integration/client.rs
+++ b/tests/integration/client.rs
@@ -84,7 +84,7 @@ async fn chain_subscribe_blocks() {
     let node_process = test_node_process().await;
     let client = node_process.client();
     let mut blocks = client.rpc().subscribe_blocks().await.unwrap();
-    blocks.next().await.unwrap();
+    blocks.next().await.unwrap().unwrap();
 }
 
 #[async_std::test]
@@ -92,7 +92,7 @@ async fn chain_subscribe_finalized_blocks() {
     let node_process = test_node_process().await;
     let client = node_process.client();
     let mut blocks = client.rpc().subscribe_finalized_blocks().await.unwrap();
-    blocks.next().await.unwrap();
+    blocks.next().await.unwrap().unwrap();
 }
 
 #[async_std::test]


### PR DESCRIPTION
Update to using jsonrpsee 0.7

With the 0.7 update to `jsonrpsee` we now also implement `futures::Stream` on `TransactionProgress` to open up access to the various `StreamExt` combinator methods and such.