### PR TITLE
Fix compact event field decoding

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -253,10 +253,10 @@ where
                     }
                 }
             }
-            TypeDef::Compact(_compact) => {
+            TypeDef::Compact(compact) => {
                 let inner = self
                     .metadata
-                    .resolve_type(type_id)
+                    .resolve_type(compact.type_param().id())
                     .ok_or(MetadataError::TypeNotFound(type_id))?;
                 let mut decode_compact_primitive = |primitive: &TypeDefPrimitive| {
                     match primitive {
@@ -281,6 +281,7 @@ where
                         }
                     }
                 };
+                println!("{:?}", inner.type_def());
                 match inner.type_def() {
                     TypeDef::Primitive(primitive) => decode_compact_primitive(primitive),
                     TypeDef::Composite(composite) => {

--- a/src/events.rs
+++ b/src/events.rs
@@ -342,21 +342,25 @@ pub enum EventsDecodingError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::convert::TryFrom;
-    use crate::{Config, DefaultConfig, Phase};
+    use crate::{
+        Config,
+        DefaultConfig,
+        Phase,
+    };
     use frame_metadata::{
-        RuntimeMetadataPrefixed,
         v14::{
             ExtrinsicMetadata,
-            RuntimeMetadataLastVersion,
-            PalletMetadata,
             PalletEventMetadata,
-        }
+            PalletMetadata,
+            RuntimeMetadataLastVersion,
+        },
+        RuntimeMetadataPrefixed,
     };
     use scale_info::{
+        meta_type,
         TypeInfo,
-        meta_type
     };
+    use std::convert::TryFrom;
 
     #[derive(Encode)]
     pub struct EventRecord<E: Encode> {
@@ -371,13 +375,13 @@ mod tests {
             phase: Phase::Finalization,
             pallet_index,
             event,
-            topics: vec![]
+            topics: vec![],
         }
     }
 
     fn pallet_metadata<E: TypeInfo + 'static>(pallet_index: u8) -> PalletMetadata {
         let event = PalletEventMetadata {
-            ty: meta_type::<E>()
+            ty: meta_type::<E>(),
         };
         PalletMetadata {
             name: "Test",
@@ -386,7 +390,7 @@ mod tests {
             event: Some(event),
             constants: vec![],
             error: None,
-            index: pallet_index
+            index: pallet_index,
         }
     }
 
@@ -394,7 +398,7 @@ mod tests {
         let extrinsic = ExtrinsicMetadata {
             ty: meta_type::<()>(),
             version: 0,
-            signed_extensions: vec![]
+            signed_extensions: vec![],
         };
         let v14 = RuntimeMetadataLastVersion::new(pallets, extrinsic, meta_type::<()>());
         let runtime_metadata: RuntimeMetadataPrefixed = v14.into();
@@ -415,9 +419,7 @@ mod tests {
 
         let event = Event::A(1);
         let encoded_event = event.encode();
-        let event_records = vec![
-            event_record(pallet_index, event)
-        ];
+        let event_records = vec![event_record(pallet_index, event)];
 
         let mut input = Vec::new();
         event_records.encode_to(&mut input);
@@ -441,9 +443,7 @@ mod tests {
 
         let event = Event::A(u32::MAX);
         let encoded_event = event.encode();
-        let event_records = vec![
-            event_record(pallet_index, event)
-        ];
+        let event_records = vec![event_record(pallet_index, event)];
 
         let mut input = Vec::new();
         event_records.encode_to(&mut input);

--- a/src/events.rs
+++ b/src/events.rs
@@ -281,7 +281,6 @@ where
                         }
                     }
                 };
-                println!("{:?}", inner.type_def());
                 match inner.type_def() {
                     TypeDef::Primitive(primitive) => decode_compact_primitive(primitive),
                     TypeDef::Composite(composite) => {

--- a/src/events.rs
+++ b/src/events.rs
@@ -431,6 +431,48 @@ mod tests {
     }
 
     #[test]
+    fn decode_multiple_events() {
+        #[derive(Clone, Encode, TypeInfo)]
+        enum Event {
+            A(u8),
+            B,
+            C { a: u32 },
+        }
+
+        let pallet_index = 0;
+        let pallet = pallet_metadata::<Event>(pallet_index);
+        let decoder = init_decoder(vec![pallet]);
+
+        let event1 = Event::A(1);
+        let event2 = Event::B;
+        let event3 = Event::C { a: 3 };
+
+        let encoded_event1 = event1.encode();
+        let encoded_event2 = event2.encode();
+        let encoded_event3 = event3.encode();
+
+        let event_records = vec![
+            event_record(pallet_index, event1),
+            event_record(pallet_index, event2),
+            event_record(pallet_index, event3),
+        ];
+
+        let mut input = Vec::new();
+        event_records.encode_to(&mut input);
+
+        let events = decoder.decode_events(&mut &input[..]).unwrap();
+
+        assert_eq!(events[0].1.variant_index, encoded_event1[0]);
+        assert_eq!(events[0].1.data.0, encoded_event1[1..]);
+
+        assert_eq!(events[1].1.variant_index, encoded_event2[0]);
+        assert_eq!(events[1].1.data.0, encoded_event2[1..]);
+
+        assert_eq!(events[2].1.variant_index, encoded_event3[0]);
+        assert_eq!(events[2].1.data.0, encoded_event3[1..]);
+    }
+
+    #[test]
     fn compact_event_field() {
         #[derive(Clone, Encode, TypeInfo)]
         enum Event {
@@ -442,6 +484,33 @@ mod tests {
         let decoder = init_decoder(vec![pallet]);
 
         let event = Event::A(u32::MAX);
+        let encoded_event = event.encode();
+        let event_records = vec![event_record(pallet_index, event)];
+
+        let mut input = Vec::new();
+        event_records.encode_to(&mut input);
+
+        let events = decoder.decode_events(&mut &input[..]).unwrap();
+
+        assert_eq!(events[0].1.variant_index, encoded_event[0]);
+        assert_eq!(events[0].1.data.0, encoded_event[1..]);
+    }
+
+    #[test]
+    fn compact_wrapper_struct_field() {
+        #[derive(Clone, Encode, TypeInfo)]
+        enum Event {
+            A(#[codec(compact)] CompactWrapper),
+        }
+
+        #[derive(Clone, codec::CompactAs, Encode, TypeInfo)]
+        struct CompactWrapper(u64);
+
+        let pallet_index = 0;
+        let pallet = pallet_metadata::<Event>(pallet_index);
+        let decoder = init_decoder(vec![pallet]);
+
+        let event = Event::A(CompactWrapper(0));
         let encoded_event = event.encode();
         let event_records = vec![event_record(pallet_index, event)];
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -431,40 +431,26 @@ mod tests {
     }
 
     #[test]
-    fn compact_fields() {
+    fn compact_event_field() {
         #[derive(Clone, Encode, TypeInfo)]
         enum Event {
             A(#[codec(compact)] u32),
-            B(#[codec(compact)] CompactWrapper),
         }
-
-        #[derive(Clone, codec::CompactAs, Encode, TypeInfo)]
-        struct CompactWrapper(u64);
 
         let pallet_index = 0;
         let pallet = pallet_metadata::<Event>(pallet_index);
         let decoder = init_decoder(vec![pallet]);
 
-        let event1 = Event::A(u32::MAX);
-        let event2 = Event::B(CompactWrapper(0));
-
-        let encoded_event1 = event1.encode();
-        let encoded_event2 = event2.encode();
-
-        let event_records = vec![
-            event_record(pallet_index, event1),
-            event_record(pallet_index, event2),
-        ];
+        let event = Event::A(u32::MAX);
+        let encoded_event = event.encode();
+        let event_records = vec![event_record(pallet_index, event)];
 
         let mut input = Vec::new();
         event_records.encode_to(&mut input);
 
         let events = decoder.decode_events(&mut &input[..]).unwrap();
 
-        assert_eq!(events[0].1.variant_index, encoded_event1[0]);
-        assert_eq!(events[0].1.data.0, encoded_event1[1..]);
-
-        assert_eq!(events[1].1.variant_index, encoded_event2[0]);
-        assert_eq!(events[1].1.data.0, encoded_event2[1..]);
+        assert_eq!(events[0].1.variant_index, encoded_event[0]);
+        assert_eq!(events[0].1.data.0, encoded_event[1..]);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,7 +166,7 @@ impl codec::Encode for Encoded {
 }
 
 /// A phase of a block's execution.
-#[derive(Clone, Debug, Eq, PartialEq, Decode)]
+#[derive(Clone, Debug, Eq, PartialEq, Decode, Encode)]
 pub enum Phase {
     /// Applying an extrinsic.
     ApplyExtrinsic(u32),


### PR DESCRIPTION
Events with compact fields were failing to be decoded. Adds unit tests for event decoding.

Fixes https://github.com/paritytech/subxt/issues/383#issuecomment-1005553251