### PR TITLE
fetch system chain, name and version

### DIFF
--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -391,6 +391,21 @@ impl<T: Config> Rpc<T> {
         Ok(self.client.request("system_properties", &[]).await?)
     }
 
+    /// Fetch system chain
+    pub async fn system_chain(&self) -> Result<String, Error> {
+        Ok(self.client.request("system_chain", &[]).await?)
+    }
+
+    /// Fetch system name
+    pub async fn system_name(&self) -> Result<String, Error> {
+        Ok(self.client.request("system_name", &[]).await?)
+    }
+
+    /// Fetch system version
+    pub async fn system_version(&self) -> Result<String, Error> {
+        Ok(self.client.request("system_version", &[]).await?)
+    }
+
     /// Get a header
     pub async fn header(
         &self,

--- a/tests/integration/client.rs
+++ b/tests/integration/client.rs
@@ -124,19 +124,10 @@ async fn test_iter() {
 }
 
 #[async_std::test]
-async fn fetch_system_chain() {
+async fn fetch_system_info() {
     let node_process = test_node_process().await;
-    node_process.client().rpc().system_chain().await.unwrap();
-}
-
-#[async_std::test]
-async fn fetch_system_name() {
-    let node_process = test_node_process().await;
-    node_process.client().rpc().system_name().await.unwrap();
-}
-
-#[async_std::test]
-async fn fetch_system_version() {
-    let node_process = test_node_process().await;
-    node_process.client().rpc().system_version().await.unwrap();
+    let client = node_process.client();
+    assert_eq!(client.rpc().system_chain().await.unwrap(), "Development");
+    assert_eq!(client.rpc().system_name().await.unwrap(), "Substrate Node");
+    assert_eq!(client.rpc().system_version().await.unwrap().is_empty(), false);
 }

--- a/tests/integration/client.rs
+++ b/tests/integration/client.rs
@@ -129,8 +129,5 @@ async fn fetch_system_info() {
     let client = node_process.client();
     assert_eq!(client.rpc().system_chain().await.unwrap(), "Development");
     assert_eq!(client.rpc().system_name().await.unwrap(), "Substrate Node");
-    assert_eq!(
-        client.rpc().system_version().await.unwrap().is_empty(),
-        false
-    );
+    assert!(!client.rpc().system_version().await.unwrap().is_empty());
 }

--- a/tests/integration/client.rs
+++ b/tests/integration/client.rs
@@ -122,3 +122,21 @@ async fn test_iter() {
     }
     assert_eq!(i, 13);
 }
+
+#[async_std::test]
+async fn fetch_system_chain() {
+    let node_process = test_node_process().await;
+    node_process.client().rpc().system_chain().await.unwrap();
+}
+
+#[async_std::test]
+async fn fetch_system_name() {
+    let node_process = test_node_process().await;
+    node_process.client().rpc().system_name().await.unwrap();
+}
+
+#[async_std::test]
+async fn fetch_system_version() {
+    let node_process = test_node_process().await;
+    node_process.client().rpc().system_version().await.unwrap();
+}

--- a/tests/integration/client.rs
+++ b/tests/integration/client.rs
@@ -129,5 +129,8 @@ async fn fetch_system_info() {
     let client = node_process.client();
     assert_eq!(client.rpc().system_chain().await.unwrap(), "Development");
     assert_eq!(client.rpc().system_name().await.unwrap(), "Substrate Node");
-    assert_eq!(client.rpc().system_version().await.unwrap().is_empty(), false);
+    assert_eq!(
+        client.rpc().system_version().await.unwrap().is_empty(),
+        false
+    );
 }


### PR DESCRIPTION
I find this additional information useful to be available from a client tool perspective. And goes in line with the methods available in `polkadot.js`.