### PR TITLE
fix remote example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ chameleon = "0.1.0"
 scale-info = { version = "1.0.0", features = ["bit-vec"] }
 futures = "0.3.13"
 hex = "0.4.3"
-jsonrpsee = { version = "0.7.0", features = ["macros", "ws-client", "http-client"] }
+jsonrpsee = { version = "0.7.0", features = ["macros", "ws-client", "http-client", "client-ws-transport"] }
 log = "0.4.14"
 num-traits = { version = "0.2.14", default-features = false }
 serde = { version = "1.0.124", features = ["derive"] }

--- a/examples/fetch_remote.rs
+++ b/examples/fetch_remote.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
 
     let api = ClientBuilder::new()
-        .set_url("wss://rpc.polkadot.io")
+        .set_url("wss://rpc.polkadot.io:443")
         .build()
         .await?
         .to_runtime_api::<polkadot::RuntimeApi<polkadot::DefaultConfig>>();


### PR DESCRIPTION
The port number is required in the `url` for the remote node. 

Also `client-ws-transport` feature needs to be specified for `wss` to be handled properly.