### PR TITLE
Remove bounds on Config trait that aren't strictly necessary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ sp-runtime = { git = "https://github.com/paritytech/substrate/", branch = "maste
 sp-version = { package = "sp-version", git = "https://github.com/paritytech/substrate/", branch = "master" }
 
 frame-metadata = "14.0.0"
+derivative = "2.2.0"
 
 [dev-dependencies]
 sp-arithmetic = { git = "https://github.com/paritytech/substrate/", branch = "master", default-features = false }

--- a/src/client.rs
+++ b/src/client.rs
@@ -40,6 +40,7 @@ use crate::{
     Config,
     Metadata,
 };
+use derivative::Derivative;
 use std::sync::Arc;
 
 /// ClientBuilder for constructing a Client.
@@ -111,7 +112,8 @@ impl ClientBuilder {
 }
 
 /// Client to interface with a substrate node.
-#[derive(Clone)]
+#[derive(Derivative)]
+#[derivative(Clone(bound = ""))]
 pub struct Client<T: Config> {
     rpc: Rpc<T>,
     genesis_hash: T::Hash,

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,7 +32,10 @@ use sp_runtime::traits::{
 };
 
 /// Runtime types.
-pub trait Config: Clone + Default + Sized + Send + Sync + 'static {
+// Note: the 'static bound isn't strictly required, but currently deriving TypeInfo
+// automatically applies a 'static bound to all generic types (including this one),
+// and so until that is resolved, we'll keep the (easy to satisfy) constraint here.
+pub trait Config: 'static {
     /// Account index (aka nonce) type. This stores the number of previous
     /// transactions associated with a sender account.
     type Index: Parameter + Member + Default + AtLeast32Bit + Copy + scale_info::TypeInfo;
@@ -83,8 +86,10 @@ pub trait Parameter: Codec + EncodeLike + Clone + Eq + Debug {}
 impl<T> Parameter for T where T: Codec + EncodeLike + Clone + Eq + Debug {}
 
 /// Default set of commonly used types by Substrate runtimes.
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
-pub struct DefaultConfig;
+// Note: We only use this at the type level, so instances of it should not be constructed,
+// hence the private () type contained within.
+#[derive(Debug)]
+pub struct DefaultConfig(());
 
 impl Config for DefaultConfig {
     type Index = u32;

--- a/src/config.rs
+++ b/src/config.rs
@@ -86,10 +86,9 @@ pub trait Parameter: Codec + EncodeLike + Clone + Eq + Debug {}
 impl<T> Parameter for T where T: Codec + EncodeLike + Clone + Eq + Debug {}
 
 /// Default set of commonly used types by Substrate runtimes.
-// Note: We only use this at the type level, so instances of it should not be constructed,
-// hence the private () type contained within.
-#[derive(Debug)]
-pub struct DefaultConfig(());
+// Note: We only use this at the type level, so it should be impossible to
+// create an instance of it.
+pub enum DefaultConfig {}
 
 impl Config for DefaultConfig {
     type Index = u32;

--- a/src/events.rs
+++ b/src/events.rs
@@ -23,6 +23,7 @@ use crate::{
     Error,
     Event,
     Metadata,
+    PhantomDataSendSync,
     Phase,
 };
 use codec::{
@@ -39,7 +40,6 @@ use scale_info::{
     TypeDefPrimitive,
 };
 use sp_core::Bytes;
-use std::marker::PhantomData;
 
 /// Raw bytes for an Event
 #[derive(Debug)]
@@ -71,15 +71,12 @@ impl RawEvent {
 /// Events decoder.
 #[derive(Derivative)]
 #[derivative(Clone(bound = ""), Debug(bound = ""))]
-pub struct EventsDecoder<T> {
+pub struct EventsDecoder<T: Config> {
     metadata: Metadata,
-    marker: PhantomData<T>,
+    marker: PhantomDataSendSync<T>,
 }
 
-impl<T> EventsDecoder<T>
-where
-    T: Config,
-{
+impl<T: Config> EventsDecoder<T> {
     /// Creates a new `EventsDecoder`.
     pub fn new(metadata: Metadata) -> Self {
         Self {

--- a/src/events.rs
+++ b/src/events.rs
@@ -14,16 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with subxt.  If not, see <http://www.gnu.org/licenses/>.
 
-use codec::{
-    Codec,
-    Compact,
-    Decode,
-    Encode,
-    Error as CodecError,
-    Input,
-};
-use std::marker::PhantomData;
-
 use crate::{
     metadata::{
         EventMetadata,
@@ -35,11 +25,21 @@ use crate::{
     Metadata,
     Phase,
 };
+use codec::{
+    Codec,
+    Compact,
+    Decode,
+    Encode,
+    Error as CodecError,
+    Input,
+};
+use derivative::Derivative;
 use scale_info::{
     TypeDef,
     TypeDefPrimitive,
 };
 use sp_core::Bytes;
+use std::marker::PhantomData;
 
 /// Raw bytes for an Event
 #[derive(Debug)]
@@ -69,7 +69,8 @@ impl RawEvent {
 }
 
 /// Events decoder.
-#[derive(Debug, Clone)]
+#[derive(Derivative)]
+#[derivative(Clone(bound = ""), Debug(bound = ""))]
 pub struct EventsDecoder<T> {
     metadata: Metadata,
     marker: PhantomData<T>,

--- a/src/extrinsic/extra.rs
+++ b/src/extrinsic/extra.rs
@@ -18,10 +18,7 @@ use codec::{
     Decode,
     Encode,
 };
-use core::{
-    fmt::Debug,
-    marker::PhantomData,
-};
+use derivative::Derivative;
 use scale_info::TypeInfo;
 use sp_runtime::{
     generic::Era,
@@ -47,20 +44,45 @@ use crate::Config;
 /// This is modified from the substrate version to allow passing in of the version, which is
 /// returned via `additional_signed()`.
 
+/// A version of [`std::marker::PhantomData`] that is also Send and Sync (which is fine
+/// because regardless of the generic param, it is always possible to Send + Sync this).
+#[derive(Derivative, Encode, Decode, TypeInfo)]
+#[derivative(
+    Clone(bound = ""),
+    PartialEq(bound = ""),
+    Debug(bound = ""),
+    Eq(bound = ""),
+    Default(bound = "")
+)]
+#[scale_info(skip_type_params(T))]
+pub struct PhantomDataSendSync<T>(core::marker::PhantomData<T>);
+
+unsafe impl<T> Send for PhantomDataSendSync<T> {}
+unsafe impl<T> Sync for PhantomDataSendSync<T> {}
+
+impl<T> PhantomDataSendSync<T> {
+    pub(crate) fn new() -> Self {
+        Self(core::marker::PhantomData)
+    }
+}
+
 /// Ensure the runtime version registered in the transaction is the same as at present.
-#[derive(Encode, Decode, Clone, Eq, PartialEq, Debug, TypeInfo)]
+#[derive(Derivative, Encode, Decode, TypeInfo)]
+#[derivative(
+    Clone(bound = ""),
+    PartialEq(bound = ""),
+    Debug(bound = ""),
+    Eq(bound = "")
+)]
 #[scale_info(skip_type_params(T))]
 pub struct CheckSpecVersion<T: Config>(
-    pub PhantomData<T>,
+    pub PhantomDataSendSync<T>,
     /// Local version to be used for `AdditionalSigned`
     #[codec(skip)]
     pub u32,
 );
 
-impl<T> SignedExtension for CheckSpecVersion<T>
-where
-    T: Config + Clone + Debug + Eq + Send + Sync,
-{
+impl<T: Config> SignedExtension for CheckSpecVersion<T> {
     const IDENTIFIER: &'static str = "CheckSpecVersion";
     type AccountId = T::AccountId;
     type Call = ();
@@ -88,19 +110,22 @@ where
 ///
 /// This is modified from the substrate version to allow passing in of the version, which is
 /// returned via `additional_signed()`.
-#[derive(Encode, Decode, Clone, Eq, PartialEq, Debug, TypeInfo)]
+#[derive(Derivative, Encode, Decode, TypeInfo)]
+#[derivative(
+    Clone(bound = ""),
+    PartialEq(bound = ""),
+    Debug(bound = ""),
+    Eq(bound = "")
+)]
 #[scale_info(skip_type_params(T))]
 pub struct CheckTxVersion<T: Config>(
-    pub PhantomData<T>,
+    pub PhantomDataSendSync<T>,
     /// Local version to be used for `AdditionalSigned`
     #[codec(skip)]
     pub u32,
 );
 
-impl<T> SignedExtension for CheckTxVersion<T>
-where
-    T: Config + Clone + Debug + Eq + Send + Sync,
-{
+impl<T: Config> SignedExtension for CheckTxVersion<T> {
     const IDENTIFIER: &'static str = "CheckTxVersion";
     type AccountId = T::AccountId;
     type Call = ();
@@ -128,19 +153,22 @@ where
 ///
 /// This is modified from the substrate version to allow passing in of the genesis hash, which is
 /// returned via `additional_signed()`.
-#[derive(Encode, Decode, Clone, Eq, PartialEq, Debug, TypeInfo)]
+#[derive(Derivative, Encode, Decode, TypeInfo)]
+#[derivative(
+    Clone(bound = ""),
+    PartialEq(bound = ""),
+    Debug(bound = ""),
+    Eq(bound = "")
+)]
 #[scale_info(skip_type_params(T))]
 pub struct CheckGenesis<T: Config>(
-    pub PhantomData<T>,
+    pub PhantomDataSendSync<T>,
     /// Local genesis hash to be used for `AdditionalSigned`
     #[codec(skip)]
     pub T::Hash,
 );
 
-impl<T> SignedExtension for CheckGenesis<T>
-where
-    T: Config + Clone + Debug + Eq + Send + Sync,
-{
+impl<T: Config> SignedExtension for CheckGenesis<T> {
     const IDENTIFIER: &'static str = "CheckGenesis";
     type AccountId = T::AccountId;
     type Call = ();
@@ -169,20 +197,23 @@ where
 /// This is modified from the substrate version to allow passing in of the genesis hash, which is
 /// returned via `additional_signed()`. It assumes therefore `Era::Immortal` (The transaction is
 /// valid forever)
-#[derive(Encode, Decode, Clone, Eq, PartialEq, Debug, TypeInfo)]
+#[derive(Derivative, Encode, Decode, TypeInfo)]
+#[derivative(
+    Clone(bound = ""),
+    PartialEq(bound = ""),
+    Debug(bound = ""),
+    Eq(bound = "")
+)]
 #[scale_info(skip_type_params(T))]
 pub struct CheckMortality<T: Config>(
     /// The default structure for the Extra encoding
-    pub (Era, PhantomData<T>),
+    pub (Era, PhantomDataSendSync<T>),
     /// Local genesis hash to be used for `AdditionalSigned`
     #[codec(skip)]
     pub T::Hash,
 );
 
-impl<T> SignedExtension for CheckMortality<T>
-where
-    T: Config + Clone + Debug + Eq + Send + Sync,
-{
+impl<T: Config> SignedExtension for CheckMortality<T> {
     const IDENTIFIER: &'static str = "CheckMortality";
     type AccountId = T::AccountId;
     type Call = ();
@@ -205,14 +236,17 @@ where
 }
 
 /// Nonce check and increment to give replay protection for transactions.
-#[derive(Encode, Decode, Clone, Eq, PartialEq, Debug, TypeInfo)]
+#[derive(Derivative, Encode, Decode, TypeInfo)]
+#[derivative(
+    Clone(bound = ""),
+    PartialEq(bound = ""),
+    Debug(bound = ""),
+    Eq(bound = "")
+)]
 #[scale_info(skip_type_params(T))]
 pub struct CheckNonce<T: Config>(#[codec(compact)] pub T::Index);
 
-impl<T> SignedExtension for CheckNonce<T>
-where
-    T: Config + Clone + Debug + Eq + Send + Sync,
-{
+impl<T: Config> SignedExtension for CheckNonce<T> {
     const IDENTIFIER: &'static str = "CheckNonce";
     type AccountId = T::AccountId;
     type Call = ();
@@ -235,14 +269,17 @@ where
 }
 
 /// Resource limit check.
-#[derive(Encode, Decode, Clone, Eq, PartialEq, Debug, TypeInfo)]
+#[derive(Derivative, Encode, Decode, TypeInfo)]
+#[derivative(
+    Clone(bound = ""),
+    PartialEq(bound = ""),
+    Debug(bound = ""),
+    Eq(bound = "")
+)]
 #[scale_info(skip_type_params(T))]
-pub struct CheckWeight<T: Config>(pub PhantomData<T>);
+pub struct CheckWeight<T: Config>(pub PhantomDataSendSync<T>);
 
-impl<T> SignedExtension for CheckWeight<T>
-where
-    T: Config + Clone + Debug + Eq + Send + Sync,
-{
+impl<T: Config> SignedExtension for CheckWeight<T> {
     const IDENTIFIER: &'static str = "CheckWeight";
     type AccountId = T::AccountId;
     type Call = ();
@@ -266,17 +303,21 @@ where
 
 /// Require the transactor pay for themselves and maybe include a tip to gain additional priority
 /// in the queue.
-#[derive(Encode, Decode, Clone, Debug, Default, Eq, PartialEq, TypeInfo)]
+#[derive(Derivative, Encode, Decode, TypeInfo)]
+#[derivative(
+    Clone(bound = ""),
+    PartialEq(bound = ""),
+    Debug(bound = ""),
+    Eq(bound = ""),
+    Default(bound = "")
+)]
 #[scale_info(skip_type_params(T))]
 pub struct ChargeTransactionPayment<T: Config>(
     #[codec(compact)] u128,
-    pub PhantomData<T>,
+    pub PhantomDataSendSync<T>,
 );
 
-impl<T> SignedExtension for ChargeTransactionPayment<T>
-where
-    T: Config + Clone + Debug + Eq + Send + Sync,
-{
+impl<T: Config> SignedExtension for ChargeTransactionPayment<T> {
     const IDENTIFIER: &'static str = "ChargeTransactionPayment";
     type AccountId = T::AccountId;
     type Call = ();
@@ -300,7 +341,14 @@ where
 
 /// Require the transactor pay for themselves and maybe include a tip to gain additional priority
 /// in the queue.
-#[derive(Encode, Decode, Clone, Default, Eq, PartialEq, Debug, TypeInfo)]
+#[derive(Derivative, Encode, Decode, TypeInfo)]
+#[derivative(
+    Clone(bound = ""),
+    PartialEq(bound = ""),
+    Debug(bound = ""),
+    Eq(bound = ""),
+    Default(bound = "")
+)]
 #[scale_info(skip_type_params(T))]
 pub struct ChargeAssetTxPayment<T: Config> {
     /// The tip for the block author.
@@ -309,13 +357,10 @@ pub struct ChargeAssetTxPayment<T: Config> {
     /// The asset with which to pay the tip.
     pub asset_id: Option<u32>,
     /// Marker for unused type parameter.
-    pub marker: PhantomData<T>,
+    pub marker: PhantomDataSendSync<T>,
 }
 
-impl<T> SignedExtension for ChargeAssetTxPayment<T>
-where
-    T: Config + Clone + Debug + Eq + Send + Sync,
-{
+impl<T: Config> SignedExtension for ChargeAssetTxPayment<T> {
     const IDENTIFIER: &'static str = "ChargeAssetTxPayment";
     type AccountId = T::AccountId;
     type Call = ();
@@ -358,19 +403,25 @@ pub trait SignedExtra<T: Config>: SignedExtension {
 }
 
 /// Default `SignedExtra` for substrate runtimes.
-#[derive(Encode, Decode, Clone, Eq, PartialEq, Debug, TypeInfo)]
+#[derive(Derivative, Encode, Decode, TypeInfo)]
+#[derivative(
+    Clone(bound = ""),
+    PartialEq(bound = ""),
+    Debug(bound = ""),
+    Eq(bound = "")
+)]
 #[scale_info(skip_type_params(T))]
 pub struct DefaultExtraWithTxPayment<T: Config, X> {
     spec_version: u32,
     tx_version: u32,
     nonce: T::Index,
     genesis_hash: T::Hash,
-    marker: PhantomData<X>,
+    marker: PhantomDataSendSync<X>,
 }
 
 impl<T, X> SignedExtra<T> for DefaultExtraWithTxPayment<T, X>
 where
-    T: Config + Clone + Debug + Eq + Send + Sync,
+    T: Config,
     X: SignedExtension<AccountId = T::AccountId, Call = ()> + Default,
 {
     type Extra = (
@@ -396,18 +447,21 @@ where
             tx_version,
             nonce,
             genesis_hash,
-            marker: PhantomData,
+            marker: PhantomDataSendSync::new(),
         }
     }
 
     fn extra(&self) -> Self::Extra {
         (
-            CheckSpecVersion(PhantomData, self.spec_version),
-            CheckTxVersion(PhantomData, self.tx_version),
-            CheckGenesis(PhantomData, self.genesis_hash),
-            CheckMortality((Era::Immortal, PhantomData), self.genesis_hash),
+            CheckSpecVersion(PhantomDataSendSync::new(), self.spec_version),
+            CheckTxVersion(PhantomDataSendSync::new(), self.tx_version),
+            CheckGenesis(PhantomDataSendSync::new(), self.genesis_hash),
+            CheckMortality(
+                (Era::Immortal, PhantomDataSendSync::new()),
+                self.genesis_hash,
+            ),
             CheckNonce(self.nonce),
-            CheckWeight(PhantomData),
+            CheckWeight(PhantomDataSendSync::new()),
             X::default(),
         )
     }
@@ -416,7 +470,7 @@ where
 impl<T, X: SignedExtension<AccountId = T::AccountId, Call = ()> + Default> SignedExtension
     for DefaultExtraWithTxPayment<T, X>
 where
-    T: Config + Clone + Debug + Eq + Send + Sync,
+    T: Config,
     X: SignedExtension,
 {
     const IDENTIFIER: &'static str = "DefaultExtra";

--- a/src/extrinsic/extra.rs
+++ b/src/extrinsic/extra.rs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with subxt.  If not, see <http://www.gnu.org/licenses/>.
 
+use crate::PhantomDataSendSync;
 use codec::{
     Decode,
     Encode,
@@ -43,28 +44,6 @@ use crate::Config;
 ///
 /// This is modified from the substrate version to allow passing in of the version, which is
 /// returned via `additional_signed()`.
-
-/// A version of [`std::marker::PhantomData`] that is also Send and Sync (which is fine
-/// because regardless of the generic param, it is always possible to Send + Sync this).
-#[derive(Derivative, Encode, Decode, TypeInfo)]
-#[derivative(
-    Clone(bound = ""),
-    PartialEq(bound = ""),
-    Debug(bound = ""),
-    Eq(bound = ""),
-    Default(bound = "")
-)]
-#[scale_info(skip_type_params(T))]
-pub struct PhantomDataSendSync<T>(core::marker::PhantomData<T>);
-
-unsafe impl<T> Send for PhantomDataSendSync<T> {}
-unsafe impl<T> Sync for PhantomDataSendSync<T> {}
-
-impl<T> PhantomDataSendSync<T> {
-    pub(crate) fn new() -> Self {
-        Self(core::marker::PhantomData)
-    }
-}
 
 /// Ensure the runtime version registered in the transaction is the same as at present.
 #[derive(Derivative, Encode, Decode, TypeInfo)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,7 @@ use core::{
     fmt::Debug,
     marker::PhantomData,
 };
+use derivative::Derivative;
 
 mod client;
 mod config;
@@ -180,7 +181,14 @@ pub enum Phase {
 ///
 /// [`WrapperKeepOpaque`] stores the type only in its opaque format, aka as a `Vec<u8>`. To
 /// access the real type `T` [`Self::try_decode`] needs to be used.
-#[derive(Debug, Eq, PartialEq, Default, Clone, Decode, Encode)]
+#[derive(Derivative, Encode, Decode)]
+#[derivative(
+    Debug(bound = ""),
+    Clone(bound = ""),
+    PartialEq(bound = ""),
+    Eq(bound = ""),
+    Default(bound = "")
+)]
 pub struct WrapperKeepOpaque<T> {
     data: Vec<u8>,
     _phantom: PhantomData<T>,

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -132,11 +132,20 @@ impl StorageMapKey {
 }
 
 /// Client for querying runtime storage.
-#[derive(Clone)]
 pub struct StorageClient<'a, T: Config> {
     rpc: &'a Rpc<T>,
     metadata: &'a Metadata,
     iter_page_size: u32,
+}
+
+impl<'a, T: Config> Clone for StorageClient<'a, T> {
+    fn clone(&self) -> Self {
+        Self {
+            rpc: self.rpc,
+            metadata: self.metadata,
+            iter_page_size: self.iter_page_size,
+        }
+    }
 }
 
 impl<'a, T: Config> StorageClient<'a, T> {

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -16,11 +16,6 @@
 
 use std::task::Poll;
 
-use sp_core::storage::StorageKey;
-use sp_runtime::traits::Hash;
-pub use sp_runtime::traits::SignedExtension;
-pub use sp_version::RuntimeVersion;
-
 use crate::{
     client::Client,
     error::{
@@ -32,6 +27,7 @@ use crate::{
     Config,
     Phase,
 };
+use derivative::Derivative;
 use futures::{
     Stream,
     StreamExt,
@@ -40,10 +36,15 @@ use jsonrpsee::core::{
     client::Subscription as RpcSubscription,
     Error as RpcError,
 };
+use sp_core::storage::StorageKey;
+use sp_runtime::traits::Hash;
+pub use sp_runtime::traits::SignedExtension;
+pub use sp_version::RuntimeVersion;
 
 /// This struct represents a subscription to the progress of some transaction, and is
 /// returned from [`crate::SubmittableExtrinsic::sign_and_submit_then_watch()`].
-#[derive(Debug)]
+#[derive(Derivative)]
+#[derivative(Debug(bound = ""))]
 pub struct TransactionProgress<'client, T: Config> {
     sub: Option<RpcSubscription<SubstrateTransactionStatus<T::Hash, T::Hash>>>,
     ext_hash: T::Hash,
@@ -261,7 +262,8 @@ impl<'client, T: Config> Stream for TransactionProgress<'client, T> {
 /// finalized. The `FinalityTimeout` event will be emitted when the block did not reach finality
 /// within 512 blocks. This either indicates that finality is not available for your chain,
 /// or that finality gadget is lagging behind.
-#[derive(Debug)]
+#[derive(Derivative)]
+#[derivative(Debug(bound = ""))]
 pub enum TransactionStatus<'client, T: Config> {
     /// The transaction is part of the "future" queue.
     Future,
@@ -310,7 +312,8 @@ impl<'client, T: Config> TransactionStatus<'client, T> {
 }
 
 /// This struct represents a transaction that has made it into a block.
-#[derive(Debug)]
+#[derive(Derivative)]
+#[derivative(Debug(bound = ""))]
 pub struct TransactionInBlock<'client, T: Config> {
     block_hash: T::Hash,
     ext_hash: T::Hash,
@@ -416,7 +419,8 @@ impl<'client, T: Config> TransactionInBlock<'client, T> {
 
 /// This represents the events related to our transaction.
 /// We can iterate over the events, or look for a specific one.
-#[derive(Debug)]
+#[derive(Derivative)]
+#[derivative(Debug(bound = ""))]
 pub struct TransactionEvents<T: Config> {
     block_hash: T::Hash,
     ext_hash: T::Hash,


### PR DESCRIPTION
We use types implementing the `Config` trait in Subxt, but only at compile-time; we never instantiate an instance of them. And yet, the Config trait has various bounds on it (`Debug`, `Clone`, `Copy`, `Send`, `Sync` etc).

This PR removes those bounds (well, mostly; `'static` is still there for now and should be able to go away eventually, but that should never complicate anything in real use).

The reason I think that these bounds existed in the first place is that Rust's inbuilt "derive" mechanism is quite primitive (eg deriving `Clone` will derive something like `impl <T: Clone> Clone for MyType<T>`; the `T` also needs to be `Clone`). As a result, we ended up with a bunch of additional bounds on the `Config` type so that it could be passed around as a generic type `T` and would still satisfy these derives.

Removing the bounds on Config has pros and cons:

Pros:
- More technically correct; `Config` is never instantiated, and so it shouldn't need any of these bounds.
- Makes it a little easier for users to implement `Config` on their own types; they don't need to pointlessly derive anything.

Cons:
- Introduces `derivative` crate to allow ignoring the `T` when deriving various traits on things that use `Config`. (we could manually derive the traits everywhere, but that would be needlessly verbose). This additional complexity will apply to anything else that takes a `T: Config` type.
- Adds a `PhantomDataSendSync<T>` type (which is just `PhantomData + Send + Sync`) to ensure that the lack of `Send` + `Sync` on `Config` doesn't translate to a lack of `Send` + `Sync` on types using the config.

I think I lean towards being more "correct" at the cost of the additional complexity (and from a user facing POV, they won't see any of the added complexity, but will benefit a little from `Config` being easier to implement.

That said, I'm curious to hear people's opinions on the matter!