### PR TITLE
Make own version of RuntimeVersion to avoid mismatches

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -17,7 +17,6 @@
 use futures::future;
 use sp_runtime::traits::Hash;
 pub use sp_runtime::traits::SignedExtension;
-pub use sp_version::RuntimeVersion;
 
 use crate::{
     error::Error,
@@ -31,6 +30,7 @@ use crate::{
     rpc::{
         Rpc,
         RpcClient,
+        RuntimeVersion,
         SystemProperties,
     },
     storage::StorageClient,
@@ -132,7 +132,7 @@ impl<T: Config> std::fmt::Debug for Client<T> {
             .field("metadata", &"<Metadata>")
             .field("events_decoder", &"<EventsDecoder>")
             .field("properties", &self.properties)
-            .field("runtime_version", &self.runtime_version.to_string())
+            .field("runtime_version", &self.runtime_version)
             .field("iter_page_size", &self.iter_page_size)
             .finish()
     }

--- a/src/extrinsic/mod.rs
+++ b/src/extrinsic/mod.rs
@@ -39,12 +39,12 @@ pub use self::{
 };
 
 use sp_runtime::traits::SignedExtension;
-use sp_version::RuntimeVersion;
 
 use crate::{
     Config,
     Encoded,
     Error,
+    rpc::RuntimeVersion,
 };
 
 /// UncheckedExtrinsic type.

--- a/src/extrinsic/mod.rs
+++ b/src/extrinsic/mod.rs
@@ -41,10 +41,10 @@ pub use self::{
 use sp_runtime::traits::SignedExtension;
 
 use crate::{
+    rpc::RuntimeVersion,
     Config,
     Encoded,
     Error,
-    rpc::RuntimeVersion,
 };
 
 /// UncheckedExtrinsic type.

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -169,7 +169,7 @@ pub enum SubstrateTransactionStatus<Hash, BlockHash> {
 
 /// This contains the runtime version information necessary to make transactions, as obtained from
 /// the RPC call `state_getRuntimeVersion`,
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RuntimeVersion {
     /// Version of the runtime specification. A full-node will not attempt to use its native

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -21,8 +21,10 @@
 // Related: https://github.com/paritytech/subxt/issues/66
 #![allow(irrefutable_let_patterns)]
 
-use std::sync::Arc;
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    sync::Arc,
+};
 
 use codec::{
     Decode,
@@ -170,21 +172,21 @@ pub enum SubstrateTransactionStatus<Hash, BlockHash> {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RuntimeVersion {
-	/// Version of the runtime specification. A full-node will not attempt to use its native
-	/// runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
-	/// `spec_version` and `authoring_version` are the same between Wasm and native.
-	pub spec_version: u32,
+    /// Version of the runtime specification. A full-node will not attempt to use its native
+    /// runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
+    /// `spec_version` and `authoring_version` are the same between Wasm and native.
+    pub spec_version: u32,
 
-	/// All existing dispatches are fully compatible when this number doesn't change. If this
-	/// number changes, then `spec_version` must change, also.
-	///
-	/// This number must change when an existing dispatchable (module ID, dispatch ID) is changed,
-	/// either through an alteration in its user-level semantics, a parameter
-	/// added/removed/changed, a dispatchable being removed, a module being removed, or a
-	/// dispatchable/module changing its index.
-	///
-	/// It need *not* change when a new module is added or when a dispatchable is added.
-	pub transaction_version: u32,
+    /// All existing dispatches are fully compatible when this number doesn't change. If this
+    /// number changes, then `spec_version` must change, also.
+    ///
+    /// This number must change when an existing dispatchable (module ID, dispatch ID) is changed,
+    /// either through an alteration in its user-level semantics, a parameter
+    /// added/removed/changed, a dispatchable being removed, a module being removed, or a
+    /// dispatchable/module changing its index.
+    ///
+    /// It need *not* change when a new module is added or when a dispatchable is added.
+    pub transaction_version: u32,
 
     /// The other fields present may vary and aren't necessary for `subxt`; they are preserved in
     /// this map.
@@ -631,22 +633,27 @@ mod test {
 
     #[test]
     fn test_deser_runtime_version() {
-        let val: RuntimeVersion = serde_json::from_str(r#"{
+        let val: RuntimeVersion = serde_json::from_str(
+            r#"{
             "specVersion": 123,
             "transactionVersion": 456,
             "foo": true,
             "wibble": [1,2,3]
-        }"#).expect("deserializing failed");
+        }"#,
+        )
+        .expect("deserializing failed");
 
         let mut m = std::collections::HashMap::new();
         m.insert("foo".to_owned(), serde_json::json!(true));
-        m.insert("wibble".to_owned(), serde_json::json!([1,2,3]));
+        m.insert("wibble".to_owned(), serde_json::json!([1, 2, 3]));
 
-        assert_eq!(val, RuntimeVersion {
-            spec_version: 123,
-            transaction_version: 456,
-            other: m
-        });
+        assert_eq!(
+            val,
+            RuntimeVersion {
+                spec_version: 123,
+                transaction_version: 456,
+                other: m
+            }
+        );
     }
-
 }

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -22,6 +22,7 @@
 #![allow(irrefutable_let_patterns)]
 
 use std::sync::Arc;
+use std::collections::HashMap;
 
 use codec::{
     Decode,
@@ -68,7 +69,6 @@ use sp_runtime::generic::{
     Block,
     SignedBlock,
 };
-use sp_version::RuntimeVersion;
 
 use crate::{
     error::Error,
@@ -163,6 +163,33 @@ pub enum SubstrateTransactionStatus<Hash, BlockHash> {
     Dropped,
     /// Transaction is no longer valid in the current state.
     Invalid,
+}
+
+/// This contains the runtime version information necessary to make transactions, as obtained from
+/// the RPC call `state_getRuntimeVersion`,
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RuntimeVersion {
+	/// Version of the runtime specification. A full-node will not attempt to use its native
+	/// runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
+	/// `spec_version` and `authoring_version` are the same between Wasm and native.
+	pub spec_version: u32,
+
+	/// All existing dispatches are fully compatible when this number doesn't change. If this
+	/// number changes, then `spec_version` must change, also.
+	///
+	/// This number must change when an existing dispatchable (module ID, dispatch ID) is changed,
+	/// either through an alteration in its user-level semantics, a parameter
+	/// added/removed/changed, a dispatchable being removed, a module being removed, or a
+	/// dispatchable/module changing its index.
+	///
+	/// It need *not* change when a new module is added or when a dispatchable is added.
+	pub transaction_version: u32,
+
+    /// The other fields present may vary and aren't necessary for `subxt`; they are preserved in
+    /// this map.
+    #[serde(flatten)]
+    pub other: HashMap<String, serde_json::Value>,
 }
 
 /// Rpc client wrapper.
@@ -596,4 +623,30 @@ impl<T: Config> Rpc<T> {
         let params = &[to_json_value(public_key)?, to_json_value(key_type)?];
         Ok(self.client.request("author_hasKey", params).await?)
     }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_deser_runtime_version() {
+        let val: RuntimeVersion = serde_json::from_str(r#"{
+            "specVersion": 123,
+            "transactionVersion": 456,
+            "foo": true,
+            "wibble": [1,2,3]
+        }"#).expect("deserializing failed");
+
+        let mut m = std::collections::HashMap::new();
+        m.insert("foo".to_owned(), serde_json::json!(true));
+        m.insert("wibble".to_owned(), serde_json::json!([1,2,3]));
+
+        assert_eq!(val, RuntimeVersion {
+            spec_version: 123,
+            transaction_version: 456,
+            other: m
+        });
+    }
+
 }


### PR DESCRIPTION
This came about because `stateVersion` went away in a recentish version of substrate/polkadot, which started breaking `subxt` which was quite strict in what it expected to be decoded.

Here we make the decoding more lenient, only expecting the props we need and keeping props that exist but aren't needed in a `HashMap` incase they are useful to others.