### PR TITLE
Expose transaction::TransactionProgress as `public`

### DIFF
--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -57,7 +57,6 @@ pub struct TransactionProgress<'client, T: Config> {
 impl<'client, T: Config> Unpin for TransactionProgress<'client, T> {}
 
 impl<'client, T: Config> TransactionProgress<'client, T> {
-
     /// Instantiate a new [`TransactionProgress`] from a custom subscription.
     pub fn new(
         sub: RpcSubscription<SubstrateTransactionStatus<T::Hash, T::Hash>>,

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -57,6 +57,8 @@ pub struct TransactionProgress<'client, T: Config> {
 impl<'client, T: Config> Unpin for TransactionProgress<'client, T> {}
 
 impl<'client, T: Config> TransactionProgress<'client, T> {
+
+    /// Instantiate a new TransactionProgress from a custom subscription
     pub fn new(
         sub: RpcSubscription<SubstrateTransactionStatus<T::Hash, T::Hash>>,
         client: &'client Client<T>,

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -58,7 +58,7 @@ impl<'client, T: Config> Unpin for TransactionProgress<'client, T> {}
 
 impl<'client, T: Config> TransactionProgress<'client, T> {
 
-    /// Instantiate a new TransactionProgress from a custom subscription
+    /// Instantiate a new [`TransactionProgress`] from a custom subscription.
     pub fn new(
         sub: RpcSubscription<SubstrateTransactionStatus<T::Hash, T::Hash>>,
         client: &'client Client<T>,

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -57,7 +57,7 @@ pub struct TransactionProgress<'client, T: Config> {
 impl<'client, T: Config> Unpin for TransactionProgress<'client, T> {}
 
 impl<'client, T: Config> TransactionProgress<'client, T> {
-    pub(crate) fn new(
+    pub fn new(
         sub: RpcSubscription<SubstrateTransactionStatus<T::Hash, T::Hash>>,
         client: &'client Client<T>,
         ext_hash: T::Hash,


### PR DESCRIPTION
Exposing `transaction::TransactionProgress` will allow customs implementation of extrinsic submission without being bound to signing in subxt.

```rust
async fn submit_then_watch<'client>(
    client: &'client Client<DefaultConfig>,
    ext_hash: H256,
    signed_tx: Bytes,
) -> Result<TransactionProgress<'client, DefaultConfig>, parity_scale_codec::Error> {
    let sub = client.rpc().watch_extrinsic(signed_tx).await.unwrap();
    Ok(TransactionProgress::new(sub, client, ext_hash))
}

let events = submit_then_watch(&api, ext_hash, signed_tx)
      .await
      .unwrap()
      .wait_for_finalized_success()
      .await
      .unwrap();
```