### PR TITLE
Log debug message for JSON-RPC response

### DIFF
--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -235,6 +235,7 @@ impl RpcClient {
             RpcClient::WebSocket(inner) => inner.request(method, params).await,
             RpcClient::Http(inner) => inner.request(method, params).await,
         };
+        log::debug!("response: {:?}", data);
         data
     }
 


### PR DESCRIPTION
While troubleshooting #399, I wanted to look at the raw bytes returned from the storage query before attempting to decode. Previously this was logged by `jsonrpsee`, but no longer.

This is useful since we can just ask users to enable `RUST_LOG=debug` for their client/test and we can then easily check the decoding of the raw bytes.. 