### PR TITLE
[Do Not Merge] Deprecate 0.15 crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "client", "proc-macro"]
 
 [package]
 name = "substrate-subxt"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ readme = "README.md"
 repository = "https://github.com/paritytech/substrate-subxt"
 documentation = "https://docs.rs/substrate-subxt"
 homepage = "https://www.parity.io/"
-description = "Submit extrinsics (transactions) to a substrate node via RPC"
-keywords = ["parity", "substrate", "blockchain"]
+description = "Deprecated: crate renamed to subxt."
+keywords = ["parity", "substrate", "blockchain", "deprecated"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,8 +49,8 @@ pallet-staking = "3.0.0"
 
 sp-rpc = { version = "3.0.0", package = "sp-rpc" }
 sp-core = { version = "3.0.0", package = "sp-core" }
-substrate-subxt-client = { version = "0.7.0", path = "client", optional = true }
-substrate-subxt-proc-macro = { version = "0.15.0", path = "proc-macro" }
+substrate-subxt-client = { version = "0.7.1", path = "client", optional = true }
+substrate-subxt-proc-macro = { version = "0.15.1", path = "proc-macro" }
 
 [dev-dependencies]
 async-std = { version = "1.9.0", features = ["attributes"] }

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# DEPRECATED
+
+This crate has been renamed to `subxt` on Crates.io. Visit https://crates.io/crates/subxt for the new version, or go to See https://github.com/paritytech/subxt for the latest updates and progress.
+
+
+
 # subxt &middot; ![build](https://github.com/paritytech/substrate-subxt/workflows/Rust/badge.svg) [![Latest Version](https://img.shields.io/crates/v/substrate-subxt.svg)](https://crates.io/crates/substrate-subxt) [![Documentation](https://docs.rs/substrate-subxt/badge.svg)](https://docs.rs/substrate-subxt)
 
 A library to **sub**mit e**xt**rinsics to a [substrate](https://github.com/paritytech/substrate) node via RPC.

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0"
 repository = "https://github.com/paritytech/substrate-subxt"
 documentation = "https://docs.rs/substrate-subxt-client"
 homepage = "https://www.parity.io/"
-description = "Embed a substrate node into your subxt application."
+description = "Deprecated. See https://github.com/paritytech/subxt. Embed a substrate node into your subxt application."
 keywords = ["parity", "substrate", "blockchain"]
 
 [dependencies]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0"
 repository = "https://github.com/paritytech/substrate-subxt"
 documentation = "https://docs.rs/substrate-subxt-client"
 homepage = "https://www.parity.io/"
-description = "Deprecated. See https://github.com/paritytech/subxt. Embed a substrate node into your subxt application."
+description = "Deprecated. See https://github.com/paritytech/subxt."
 keywords = ["parity", "substrate", "blockchain"]
 
 [dependencies]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/paritytech/substrate-subxt"
 documentation = "https://docs.rs/substrate-subxt-client"
 homepage = "https://www.parity.io/"
 description = "Deprecated. See https://github.com/paritytech/subxt."
-keywords = ["parity", "substrate", "blockchain"]
+keywords = ["deprecated", "parity", "substrate", "blockchain"]
 
 [dependencies]
 async-std = "1.8.0"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-subxt-client"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["David Craven <david@craven.ch>", "Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/proc-macro/Cargo.toml
+++ b/proc-macro/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/paritytech/substrate-subxt"
 documentation = "https://docs.rs/substrate-subxt"
 homepage = "https://www.parity.io/"
 description = "Deprecated: crate renamed to subxt-macro."
+keywords = ["deprecated"]
 
 [lib]
 proc-macro = true

--- a/proc-macro/Cargo.toml
+++ b/proc-macro/Cargo.toml
@@ -9,7 +9,7 @@ license = "GPL-3.0"
 repository = "https://github.com/paritytech/substrate-subxt"
 documentation = "https://docs.rs/substrate-subxt"
 homepage = "https://www.parity.io/"
-description = "Deprecated: crate renamed to subxt-macro. Derive calls, events, storage and tests for interacting Substrate modules with substrate-subxt"
+description = "Deprecated: crate renamed to subxt-macro."
 
 [lib]
 proc-macro = true

--- a/proc-macro/Cargo.toml
+++ b/proc-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-subxt-proc-macro"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["David Craven <david@craven.ch>", "Parity Technologies <admin@parity.io>"]
 edition = "2018"
 autotests = false
@@ -9,7 +9,7 @@ license = "GPL-3.0"
 repository = "https://github.com/paritytech/substrate-subxt"
 documentation = "https://docs.rs/substrate-subxt"
 homepage = "https://www.parity.io/"
-description = "Derive calls, events, storage and tests for interacting Substrate modules with substrate-subxt"
+description = "Deprecated: crate renamed to subxt-macro. Derive calls, events, storage and tests for interacting Substrate modules with substrate-subxt"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
Some small changes to the last tagged 0.15 release so that we can publish a new 0.15.1 release of the old `substrate-` prefixed crates with a deprecation notice pointing to the new ones. 

This should never be merged (but can be tagged 0.15.1 to keep tabs on this code change).