### PR TITLE
Get event context on EventSubscription

### DIFF
--- a/subxt/src/subscription.rs
+++ b/subxt/src/subscription.rs
@@ -39,7 +39,8 @@ use sp_core::{
 use sp_runtime::traits::Header;
 use std::collections::VecDeque;
 
-
+/// Raw bytes for an Event, including the block hash where it occurred and its
+/// corresponding event index.
 #[derive(Debug)]
 #[cfg_attr(test, derive(PartialEq, Clone))]
 pub struct EventContext<T> {
@@ -92,8 +93,8 @@ impl<'a, T: Config> BlockReader<'a, T> {
                         x.into_iter()
                             .flatten()
                             .enumerate()
-                            .map(|(idx, (phase, raw))| {
-                                (phase, idx, raw)
+                            .map(|(event_idx, (phase, raw))| {
+                                (phase, event_idx, raw)
                             })
                             .collect()
                     });
@@ -152,7 +153,7 @@ impl<'a, T: Config> EventSubscription<'a, T> {
     /// event index.
     pub async fn next_context(
         &mut self,
-    ) -> Option<Result<(<T as Config>::Hash, usize, RawEvent), BasicError>> {
+    ) -> Option<Result<EventContext<T::Hash>, BasicError>> {
         loop {
             if let Some(raw_event) = self.events.pop_front() {
                 return Some(Ok(raw_event))

--- a/subxt/src/subscription.rs
+++ b/subxt/src/subscription.rs
@@ -312,17 +312,17 @@ mod tests {
                             phase.clone(),
                             // The event index
                             idx,
-                            {
-                                // set variant index so we can uniquely identify
-                                // the event, independently from the event index
-                                let mut event = event.clone();
-                                event.variant_index = (idx * 2) as u8;
-                                event
-                            }
+                            event.clone(),
                         ))
                     });
             }
         }
+
+        // set variant index so we can uniquely identify the event
+        events.iter_mut().enumerate().for_each(|(idx, event)| {
+            event.3.variant_index = idx as u8;
+        });
+
 
         let half_len = events.len() / 2;
 
@@ -407,17 +407,16 @@ mod tests {
                             phase.clone(),
                             // The event index
                             idx,
-                            {
-                                // set variant index so we can uniquely identify
-                                // the event, independently from the event index
-                                let mut event = event.clone();
-                                event.variant_index = (idx * 2) as u8;
-                                event
-                            }
+                            event.clone(),
                         ))
                     });
             }
         }
+
+        // set variant index so we can uniquely identify the event
+        events.iter_mut().enumerate().for_each(|(idx, event)| {
+            event.3.variant_index = idx as u8;
+        });
 
         let half_len = events.len() / 2;
 

--- a/subxt/src/subscription.rs
+++ b/subxt/src/subscription.rs
@@ -43,8 +43,8 @@ use std::collections::VecDeque;
 /// corresponding event index.
 #[derive(Debug)]
 #[cfg_attr(test, derive(PartialEq, Clone))]
-pub struct EventContext<T> {
-    pub block: T,
+pub struct EventContext<Hash> {
+    pub block_hash: Hash,
     pub event_idx: usize,
     pub event: RawEvent,
 }
@@ -188,7 +188,7 @@ impl<'a, T: Config> EventSubscription<'a, T> {
                         }
                         self.events.push_back(
                             EventContext {
-                                block: received_hash,
+                                block_hash: received_hash,
                                 event_idx: event_idx,
                                 event: raw
                             }
@@ -424,7 +424,7 @@ mod tests {
                             (
                                 phase.clone(),
                                 EventContext {
-                                    block: block_hash,
+                                    block_hash: block_hash,
                                     event_idx: idx,
                                     event: event.clone(),
                                 }
@@ -446,7 +446,7 @@ mod tests {
                 block_reader: BlockReader::Mock(Box::new(
                     vec![
                         (
-                            events[0].1.block,
+                            events[0].1.block_hash,
                             Ok(events
                                 .iter()
                                 .take(half_len)
@@ -456,7 +456,7 @@ mod tests {
                                 .collect()),
                         ),
                         (
-                            events[half_len].1.block,
+                            events[half_len].1.block_hash,
                             Ok(events
                                 .iter()
                                 .skip(half_len)

--- a/test-runtime/build.rs
+++ b/test-runtime/build.rs
@@ -45,8 +45,7 @@ async fn run() {
         env::var(SUBSTRATE_BIN_ENV_VAR).unwrap_or_else(|_| "substrate".to_owned());
 
     // Run binary.
-    let port = next_open_port()
-        .expect("Cannot spawn substrate: no available ports in the given port range");
+    let port = 8833;
     let cmd = Command::new(&substrate_bin)
         .arg("--dev")
         .arg("--tmp")

--- a/test-runtime/build.rs
+++ b/test-runtime/build.rs
@@ -45,7 +45,8 @@ async fn run() {
         env::var(SUBSTRATE_BIN_ENV_VAR).unwrap_or_else(|_| "substrate".to_owned());
 
     // Run binary.
-    let port = 8833;
+    let port = next_open_port()
+        .expect("Cannot spawn substrate: no available ports in the given port range");
     let cmd = Command::new(&substrate_bin)
         .arg("--dev")
         .arg("--tmp")


### PR DESCRIPTION
Currently, the `next` method on the `EventSubscription` type only returns the event itself, not clarifying where it occurred. This PR introduces a new method, `next_context`, that additionally returns the corresponding block hash and the index of the event.

Btw, I think it would be great to have a block number, too, but I think that'd require upstream substrate changes (or additional queries on `subxt`'s side).

Feedback/criticism appreciated.

EDIT: Will wait for your feedback before I'll resolve the conflicts.