### PR TITLE
Update substrate dependencies

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -14,7 +14,7 @@ description = "Subxt example usage"
 [dev-dependencies]
 subxt = { path = "../subxt" }
 async-std = { version = "1.9.0", features = ["attributes", "tokio1"] }
-sp-keyring = "4.0.0"
+sp-keyring = "5.0.0"
 env_logger = "0.9.0"
 futures = "0.3.13"
 codec = { package = "parity-scale-codec", version = "2", default-features = false, features = ["derive", "full", "bit-vec"] }

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -33,4 +33,4 @@ subxt-codegen = { path = "../codegen", version = "0.16.0" }
 pretty_assertions = "1.0.0"
 subxt = { path = "../subxt", version = "0.16.0" }
 trybuild = "1.0.38"
-sp-keyring = "4.0.0"
+sp-keyring = "5.0.0"

--- a/subxt/Cargo.toml
+++ b/subxt/Cargo.toml
@@ -30,8 +30,8 @@ url = "2.2.1"
 
 subxt-macro = { version = "0.16.0", path = "../macro" }
 
-sp-core = { version = "4.0.0", default-features = false  }
-sp-runtime = { version = "4.0.0", default-features = false }
+sp-core = { version = "5.0.0", default-features = false  }
+sp-runtime = { version = "5.0.0", default-features = false }
 sp-version = "4.0.0"
 
 frame-metadata = "14.0.0"
@@ -46,4 +46,4 @@ tempdir = "0.3.7"
 wabt = "0.10.0"
 which = "4.0.2"
 test-runtime = { path = "../test-runtime" }
-sp-keyring = "4.0.0"
+sp-keyring = "5.0.0"

--- a/test-runtime/Cargo.toml
+++ b/test-runtime/Cargo.toml
@@ -5,11 +5,11 @@ edition = "2021"
 
 [dependencies]
 subxt = { path = "../subxt" }
-sp-runtime = "4.0.0"
+sp-runtime = "5.0.0"
 codec = { package = "parity-scale-codec", version = "2", default-features = false, features = ["derive", "full", "bit-vec"] }
 
 [build-dependencies]
 subxt = { path = "../subxt", version = "0.16.0" }
-sp-core = "4.0.0"
+sp-core = "5.0.0"
 async-std = { version = "1.9.0", features = ["attributes", "tokio1"] }
 which = "4.2.2"


### PR DESCRIPTION
In order to use the recently released `pallet-contracts-primitives` from https://github.com/paritytech/cargo-contract/pull/79, I need to update the common Substrate dependencies here to `5.0.0`.