### PR TITLE
Add more tests for `events.rs/decode_and_consume_type`

### DIFF
--- a/subxt/src/events.rs
+++ b/subxt/src/events.rs
@@ -709,4 +709,12 @@ mod tests {
         // The last byte (0x0 u8) should not be consumed
         assert_eq!(dummy_cursor.len(), 1);
     }
+
+    #[test]
+    fn decode_array() {
+        decode_and_consume_type_consumes_all_bytes([0]);
+        decode_and_consume_type_consumes_all_bytes([1, 2, 3, 4, 5]);
+        decode_and_consume_type_consumes_all_bytes([0; 500]);
+        decode_and_consume_type_consumes_all_bytes(["str", "abc", "cde"]);
+    }
 }

--- a/subxt/src/events.rs
+++ b/subxt/src/events.rs
@@ -753,4 +753,54 @@ mod tests {
         let res = decode_and_consume_type(INVALID_TYPE_ID, &reg, dummy_cursor);
         assert_matches!(res, Err(crate::error::GenericError::Metadata(_)));
     }
+
+    #[test]
+    fn decode_composite() {
+        #[derive(Clone, Encode, TypeInfo)]
+        struct Composite {}
+        decode_and_consume_type_consumes_all_bytes(Composite {});
+
+        #[derive(Clone, Encode, TypeInfo)]
+        struct CompositeV2 {
+            id: u32,
+            name: String,
+        }
+        decode_and_consume_type_consumes_all_bytes(CompositeV2 {
+            id: 10,
+            name: "str".to_string(),
+        });
+
+        #[derive(Clone, Encode, TypeInfo)]
+        struct CompositeV3<T> {
+            id: u32,
+            extra: T,
+        }
+        decode_and_consume_type_consumes_all_bytes(CompositeV3 {
+            id: 10,
+            extra: vec![0, 1, 2],
+        });
+        decode_and_consume_type_consumes_all_bytes(CompositeV3 {
+            id: 10,
+            extra: bitvec::bitvec![Lsb0, u8; 0, 1, 1, 0, 1],
+        });
+        decode_and_consume_type_consumes_all_bytes(CompositeV3 {
+            id: 10,
+            extra: ("str", 1),
+        });
+        decode_and_consume_type_consumes_all_bytes(CompositeV3 {
+            id: 10,
+            extra: CompositeV2 {
+                id: 2,
+                name: "str".to_string(),
+            },
+        });
+
+        #[derive(Clone, Encode, TypeInfo)]
+        struct CompositeV4(u32, bool);
+        decode_and_consume_type_consumes_all_bytes(CompositeV4(1, true));
+
+        #[derive(Clone, Encode, TypeInfo)]
+        struct CompositeV5(u32);
+        decode_and_consume_type_consumes_all_bytes(CompositeV5(1));
+    }
 }

--- a/subxt/src/events.rs
+++ b/subxt/src/events.rs
@@ -803,4 +803,32 @@ mod tests {
         struct CompositeV5(u32);
         decode_and_consume_type_consumes_all_bytes(CompositeV5(1));
     }
+
+    #[test]
+    fn decode_compact() {
+        #[derive(Clone, Encode, TypeInfo)]
+        enum Compact {
+            A(#[codec(compact)] u32),
+        }
+        decode_and_consume_type_consumes_all_bytes(Compact::A(1));
+
+        #[derive(Clone, Encode, TypeInfo)]
+        struct CompactV2(#[codec(compact)] u32);
+        decode_and_consume_type_consumes_all_bytes(CompactV2(1));
+
+        #[derive(Clone, Encode, TypeInfo)]
+        struct CompactV3 {
+            #[codec(compact)]
+            val: u32,
+        }
+        decode_and_consume_type_consumes_all_bytes(CompactV3 { val: 1 });
+
+        #[derive(Clone, Encode, TypeInfo)]
+        struct CompactV4<T> {
+            #[codec(compact)]
+            val: T,
+        }
+        decode_and_consume_type_consumes_all_bytes(CompactV4 { val: 0u8 });
+        decode_and_consume_type_consumes_all_bytes(CompactV4 { val: 1u16 });
+    }
 }

--- a/subxt/src/events.rs
+++ b/subxt/src/events.rs
@@ -711,10 +711,14 @@ mod tests {
     }
 
     #[test]
-    fn decode_array() {
+    fn decode_array_and_seq() {
         decode_and_consume_type_consumes_all_bytes([0]);
         decode_and_consume_type_consumes_all_bytes([1, 2, 3, 4, 5]);
         decode_and_consume_type_consumes_all_bytes([0; 500]);
         decode_and_consume_type_consumes_all_bytes(["str", "abc", "cde"]);
+
+        decode_and_consume_type_consumes_all_bytes(vec![0]);
+        decode_and_consume_type_consumes_all_bytes(vec![1, 2, 3, 4, 5]);
+        decode_and_consume_type_consumes_all_bytes(vec!["str", "abc", "cde"]);
     }
 }

--- a/test-runtime/README.md
+++ b/test-runtime/README.md
@@ -3,7 +3,7 @@
 The logic for this crate exists mainly in the `build.rs` file.
 
 At compile time, this crate will:
-- Spin up a local `substrate` binary (set the `SUBSTRATE_NODE_PATH` env var to point to a custom binary, otehrwise it'll look for `substrate` on your PATH).
+- Spin up a local `substrate` binary (set the `SUBSTRATE_NODE_PATH` env var to point to a custom binary, otherwise it'll look for `substrate` on your PATH).
 - Obtain metadata from this node.
 - Export the metadata and a `node_runtime` module which has been annotated using the `subxt` proc macro and is based off the above metadata.
 

--- a/test-runtime/build.rs
+++ b/test-runtime/build.rs
@@ -161,7 +161,7 @@ fn next_open_port() -> Option<u16> {
     }
 }
 
-/// If the substrate process isn't explicilty killed on drop,
+/// If the substrate process isn't explicitly killed on drop,
 /// it seems that panics that occur while the command is running
 /// will leave it running and block the build step from ever finishing.
 /// Wrapping it in this prevents this from happening.

--- a/test-runtime/build.rs
+++ b/test-runtime/build.rs
@@ -54,6 +54,10 @@ async fn run() {
         .spawn();
     let mut cmd = match cmd {
         Ok(cmd) => KillOnDrop(cmd),
+        Err(ref e) if e.kind() == std::io::ErrorKind::NotFound => {
+            panic!("A substrate binary should be installed on your path for testing purposes. \
+            See https://github.com/paritytech/subxt/tree/master#integration-testing")
+        }
         Err(e) => {
             panic!("Cannot spawn substrate command '{}': {}", substrate_bin, e)
         }


### PR DESCRIPTION
Test code branches of `decode_and_consume_type` in isolation (issue #414).

While at it, fix some typos and add explicit error handling for missing substrate binary.