### PR TITLE
Set "std" feature on sp-runtime to avoid a static assertion error

### DIFF
--- a/subxt/Cargo.toml
+++ b/subxt/Cargo.toml
@@ -30,7 +30,7 @@ thiserror = "1.0.24"
 subxt-macro = { version = "0.17.0", path = "../macro" }
 
 sp-core = { version = "5.0.0", default-features = false  }
-sp-runtime = { version = "5.0.0", default-features = false, features = ["std"] }
+sp-runtime = "5.0.0"
 sp-version = "4.0.0"
 
 frame-metadata = "14.0.0"

--- a/subxt/Cargo.toml
+++ b/subxt/Cargo.toml
@@ -30,7 +30,7 @@ thiserror = "1.0.24"
 subxt-macro = { version = "0.17.0", path = "../macro" }
 
 sp-core = { version = "5.0.0", default-features = false  }
-sp-runtime = { version = "5.0.0", default-features = false }
+sp-runtime = { version = "5.0.0", default-features = false, features = ["std"] }
 sp-version = "4.0.0"
 
 frame-metadata = "14.0.0"


### PR DESCRIPTION
A hopefully fairly temporary fix which leads to the "std" feature is enabled on `sp-runtime-interface` (it's the only default feature) in order to avoid an assertion check.

closes #437 