### PR TITLE
Fix conversion of `Call` struct names to UpperCamelCase

### DIFF
--- a/codegen/src/api/mod.rs
+++ b/codegen/src/api/mod.rs
@@ -462,7 +462,7 @@ where
                     type_gen,
                 );
                 CompositeDef::struct_def(
-                    var.name(),
+                    struct_name.as_ref(),
                     Default::default(),
                     fields,
                     Some(parse_quote!(pub)),


### PR DESCRIPTION
Should not use the variant name e.g. `transfer_keep_alive` but the converted name `TransferKeepAlive`