### PR TITLE
Export `codegen::TypeGenerator`

### DIFF
--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -25,5 +25,8 @@ pub use self::{
         generate_runtime_api,
         RuntimeGenerator,
     },
-    types::GeneratedTypeDerives,
+    types::{
+        GeneratedTypeDerives,
+        TypeGenerator,
+    },
 };

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -28,5 +28,6 @@ pub use self::{
     types::{
         GeneratedTypeDerives,
         TypeGenerator,
+        Module,
     },
 };

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -27,7 +27,7 @@ pub use self::{
     },
     types::{
         GeneratedTypeDerives,
-        TypeGenerator,
         Module,
+        TypeGenerator,
     },
 };

--- a/codegen/src/types/mod.rs
+++ b/codegen/src/types/mod.rs
@@ -221,6 +221,7 @@ impl<'a> TypeGenerator<'a> {
     }
 }
 
+/// Represents a Rust `mod`, containing generated types and child `mod`s.
 #[derive(Debug)]
 pub struct Module<'a> {
     name: Ident,
@@ -248,7 +249,8 @@ impl<'a> ToTokens for Module<'a> {
 }
 
 impl<'a> Module<'a> {
-    pub fn new(name: Ident, root_mod: Ident) -> Self {
+    /// Create a new [`Module`], with a reference to the root `mod` for resolving type paths.
+    pub(crate) fn new(name: Ident, root_mod: Ident) -> Self {
         Self {
             name,
             root_mod,


### PR DESCRIPTION
I require it for a macro to generate Rust API for `ink!` contracts for benchmarking. This prototype could one day be promoted to it's own crate, or even integrated here :grin: 