### PR TITLE
Distinct handling for N fields + 1 hasher vs N fields + N hashers

### DIFF
--- a/codegen/src/api/storage.rs
+++ b/codegen/src/api/storage.rs
@@ -126,9 +126,9 @@ fn generate_storage_entry_fns(
                         quote!( #entry_struct_ident( #( #field_names ),* ) );
 
                     let key_impl = if hashers.len() == fields.len() {
-                        // If the number of hashers matches the number of fields, we're dealing with a
-                        // StorageNMap, and each field should be hashed separately according to the
-                        // corresponding hasher.
+                        // If the number of hashers matches the number of fields, we're dealing with
+                        // something shaped like a StorageNMap, and each field should be hashed separately
+                        // according to the corresponding hasher.
                         let keys = (0..tuple.fields().len())
                             .into_iter()
                             .zip(hashers)

--- a/codegen/src/api/storage.rs
+++ b/codegen/src/api/storage.rs
@@ -145,7 +145,7 @@ fn generate_storage_entry_fns(
                         // If there is one hasher, then however many fields we have, we want to hash a
                         // tuple of them using the one hasher we're told about. This corresponds to a
                         // StorageMap.
-                        let hasher = hashers.get(0).expect("checked for 1 hashed");
+                        let hasher = hashers.get(0).expect("checked for 1 hasher");
                         let items =
                             (0..tuple.fields().len()).into_iter().map(|field_idx| {
                                 let index = syn::Index::from(field_idx);

--- a/codegen/src/api/storage.rs
+++ b/codegen/src/api/storage.rs
@@ -115,26 +115,58 @@ fn generate_storage_entry_fns(
                             (field_name, field_type)
                         })
                         .collect::<Vec<_>>();
-                    // toddo: [AJ] use unzip here?
-                    let tuple_struct_fields =
-                        fields.iter().map(|(_, field_type)| field_type);
-                    let field_names = fields.iter().map(|(field_name, _)| field_name);
+
+                    let field_names = fields.iter().map(|(n,_)| n);
+                    let field_types = fields.iter().map(|(_,t)| t);
+
                     let entry_struct = quote! {
-                        pub struct #entry_struct_ident( #( pub #tuple_struct_fields ),* );
+                        pub struct #entry_struct_ident( #( pub #field_types ),* );
                     };
                     let constructor =
                         quote!( #entry_struct_ident( #( #field_names ),* ) );
-                    let keys = (0..tuple.fields().len()).into_iter().zip(hashers).map(
-                        |(field, hasher)| {
-                            let index = syn::Index::from(field);
-                            quote!( ::subxt::StorageMapKey::new(&self.#index, #hasher) )
-                        },
-                    );
-                    let key_impl = quote! {
-                        ::subxt::StorageEntryKey::Map(
-                            vec![ #( #keys ),* ]
+
+                    let key_impl = if hashers.len() == fields.len() {
+                        // If the number of hashers matches the number of fields, we're dealing with a
+                        // StorageNMap, and each field should be hashed separately according to the
+                        // corresponding hasher.
+                        let keys = (0..tuple.fields().len())
+                            .into_iter()
+                            .zip(hashers)
+                            .map(|(field_idx, hasher)| {
+                                let index = syn::Index::from(field_idx);
+                                quote!( ::subxt::StorageMapKey::new(&self.#index, #hasher) )
+                            });
+                        quote!{
+                            ::subxt::StorageEntryKey::Map(
+                                vec![ #( #keys ),* ]
+                            )
+                        }
+                    } else if hashers.len() == 1 {
+                        // If there is one hasher, then however many fields we have, we want to hash a
+                        // tuple of them using the one hasher we're told about. This corresponds to a
+                        // StorageMap.
+                        let hasher = hashers.get(0).expect("checked for 1 hashed");
+                        let items = (0..tuple.fields().len()).into_iter().map(
+                            |field_idx| {
+                                let index = syn::Index::from(field_idx);
+                                quote!( &self.#index )
+                            }
+                        );
+                        quote!{
+                            ::subxt::StorageEntryKey::Map(
+                                vec![ ::subxt::StorageMapKey::new(&(#( #items ),*), #hasher) ]
+                            )
+                        }
+                    } else {
+                        // If we hit this condition, we don't know how to handle the number of hashes vs fields
+                        // that we've been handed, so abort.
+                        abort_call_site!(
+                            "Number of hashers ({}) does not equal 1 for StorageMap, or match number of fields ({}) for StorageNMap",
+                            hashers.len(),
+                            fields.len()
                         )
                     };
+
                     (fields, entry_struct, constructor, key_impl)
                 }
                 _ => {

--- a/codegen/src/api/storage.rs
+++ b/codegen/src/api/storage.rs
@@ -129,8 +129,7 @@ fn generate_storage_entry_fns(
                         // If the number of hashers matches the number of fields, we're dealing with
                         // something shaped like a StorageNMap, and each field should be hashed separately
                         // according to the corresponding hasher.
-                        let keys = (0..tuple.fields().len())
-                            .into_iter()
+                        let keys = (0..fields.len())
                             .zip(hashers)
                             .map(|(field_idx, hasher)| {
                                 let index = syn::Index::from(field_idx);
@@ -146,11 +145,10 @@ fn generate_storage_entry_fns(
                         // tuple of them using the one hasher we're told about. This corresponds to a
                         // StorageMap.
                         let hasher = hashers.get(0).expect("checked for 1 hasher");
-                        let items =
-                            (0..tuple.fields().len()).into_iter().map(|field_idx| {
-                                let index = syn::Index::from(field_idx);
-                                quote!( &self.#index )
-                            });
+                        let items = (0..fields.len()).map(|field_idx| {
+                            let index = syn::Index::from(field_idx);
+                            quote!( &self.#index )
+                        });
                         quote! {
                             ::subxt::StorageEntryKey::Map(
                                 vec![ ::subxt::StorageMapKey::new(&(#( #items ),*), #hasher) ]

--- a/codegen/src/api/storage.rs
+++ b/codegen/src/api/storage.rs
@@ -116,8 +116,8 @@ fn generate_storage_entry_fns(
                         })
                         .collect::<Vec<_>>();
 
-                    let field_names = fields.iter().map(|(n,_)| n);
-                    let field_types = fields.iter().map(|(_,t)| t);
+                    let field_names = fields.iter().map(|(n, _)| n);
+                    let field_types = fields.iter().map(|(_, t)| t);
 
                     let entry_struct = quote! {
                         pub struct #entry_struct_ident( #( pub #field_types ),* );
@@ -136,7 +136,7 @@ fn generate_storage_entry_fns(
                                 let index = syn::Index::from(field_idx);
                                 quote!( ::subxt::StorageMapKey::new(&self.#index, #hasher) )
                             });
-                        quote!{
+                        quote! {
                             ::subxt::StorageEntryKey::Map(
                                 vec![ #( #keys ),* ]
                             )
@@ -146,13 +146,12 @@ fn generate_storage_entry_fns(
                         // tuple of them using the one hasher we're told about. This corresponds to a
                         // StorageMap.
                         let hasher = hashers.get(0).expect("checked for 1 hashed");
-                        let items = (0..tuple.fields().len()).into_iter().map(
-                            |field_idx| {
+                        let items =
+                            (0..tuple.fields().len()).into_iter().map(|field_idx| {
                                 let index = syn::Index::from(field_idx);
                                 quote!( &self.#index )
-                            }
-                        );
-                        quote!{
+                            });
+                        quote! {
                             ::subxt::StorageEntryKey::Map(
                                 vec![ ::subxt::StorageMapKey::new(&(#( #items ),*), #hasher) ]
                             )

--- a/codegen/src/api/storage.rs
+++ b/codegen/src/api/storage.rs
@@ -129,8 +129,9 @@ fn generate_storage_entry_fns(
                         // If the number of hashers matches the number of fields, we're dealing with
                         // something shaped like a StorageNMap, and each field should be hashed separately
                         // according to the corresponding hasher.
-                        let keys = (0..fields.len())
-                            .zip(hashers)
+                        let keys = hashers
+                            .into_iter()
+                            .enumerate()
                             .map(|(field_idx, hasher)| {
                                 let index = syn::Index::from(field_idx);
                                 quote!( ::subxt::StorageMapKey::new(&self.#index, #hasher) )

--- a/subxt/tests/integration/main.rs
+++ b/subxt/tests/integration/main.rs
@@ -23,6 +23,8 @@ mod client;
 mod events;
 #[cfg(test)]
 mod frame;
+#[cfg(test)]
+mod storage;
 
 use test_runtime::node_runtime;
 use utils::*;

--- a/subxt/tests/integration/storage.rs
+++ b/subxt/tests/integration/storage.rs
@@ -1,0 +1,100 @@
+// Copyright 2019-2022 Parity Technologies (UK) Ltd.
+// This file is part of subxt.
+//
+// subxt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// subxt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with subxt.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate::{
+    node_runtime::DispatchError,
+    pair_signer,
+    test_context,
+};
+use sp_keyring::AccountKeyring;
+
+#[async_std::test]
+async fn storage_plain_lookup() -> Result<(), subxt::Error<DispatchError>> {
+    let ctx = test_context().await;
+
+    // Look up a plain value
+    let entry = ctx.api.storage().timestamp().now(None).await?;
+    assert!(entry > 0);
+
+    Ok(())
+}
+
+#[async_std::test]
+async fn storage_map_lookup() -> Result<(), subxt::Error<DispatchError>> {
+    let ctx = test_context().await;
+
+    let signer = pair_signer(AccountKeyring::Alice.pair());
+    let alice = AccountKeyring::Alice.to_account_id();
+
+    // Do some transaction to bump the Alice nonce to 1:
+    ctx.api
+        .tx()
+        .system()
+        .remark(vec![1, 2, 3, 4, 5])
+        .sign_and_submit_then_watch(&signer)
+        .await?
+        .wait_for_finalized_success()
+        .await?;
+
+    // Look up the nonce for the user (we expect it to be 1).
+    let entry = ctx
+        .api
+        .storage()
+        .system()
+        .account(alice.into(), None)
+        .await?;
+    assert_eq!(entry.nonce, 1);
+
+    Ok(())
+}
+
+#[async_std::test]
+async fn storage_n_map_storage_lookup() -> Result<(), subxt::Error<DispatchError>> {
+    let ctx = test_context().await;
+
+    // Boilerplate; we create a new asset class with ID 99, and then
+    // we "approveTransfer" of some of this asset class. This Gives us an
+    // entry in the `Approvals` StorageNMap that we can try to look up.
+    let signer = pair_signer(AccountKeyring::Alice.pair());
+    let alice = AccountKeyring::Alice.to_account_id();
+    let bob = AccountKeyring::Bob.to_account_id();
+    ctx.api
+        .tx()
+        .assets()
+        .create(99, alice.clone().into(), 1)
+        .sign_and_submit_then_watch(&signer)
+        .await?
+        .wait_for_finalized_success()
+        .await?;
+    ctx.api
+        .tx()
+        .assets()
+        .approve_transfer(99, bob.clone().into(), 123)
+        .sign_and_submit_then_watch(&signer)
+        .await?
+        .wait_for_finalized_success()
+        .await?;
+
+    // The actual test; look up this approval in storage:
+    let entry = ctx
+        .api
+        .storage()
+        .assets()
+        .approvals(99, alice.into(), bob.into(), None)
+        .await?;
+    assert_eq!(entry.map(|a| a.amount), Some(123));
+    Ok(())
+}

--- a/subxt/tests/integration/storage.rs
+++ b/subxt/tests/integration/storage.rs
@@ -54,7 +54,7 @@ async fn storage_map_lookup() -> Result<(), subxt::Error<DispatchError>> {
         .api
         .storage()
         .system()
-        .account(alice.into(), None)
+        .account(alice, None)
         .await?;
     assert_eq!(entry.nonce, 1);
 
@@ -93,7 +93,7 @@ async fn storage_n_map_storage_lookup() -> Result<(), subxt::Error<DispatchError
         .api
         .storage()
         .assets()
-        .approvals(99, alice.into(), bob.into(), None)
+        .approvals(99, alice, bob, None)
         .await?;
     assert_eq!(entry.map(|a| a.amount), Some(123));
     Ok(())

--- a/subxt/tests/integration/storage.rs
+++ b/subxt/tests/integration/storage.rs
@@ -76,7 +76,7 @@ async fn storage_n_mapish_key_is_properly_created(
         StorageEntry,
     };
 
-    // This is what the generate code hashes a `session().key_owner(..)` key into:
+    // This is what the generated code hashes a `session().key_owner(..)` key into:
     let actual_key_bytes = KeyOwner(KeyTypeId([1, 2, 3, 4]), vec![5u8, 6, 7, 8])
         .key()
         .final_key(StorageKeyPrefix::new::<KeyOwner>())

--- a/subxt/tests/integration/storage.rs
+++ b/subxt/tests/integration/storage.rs
@@ -103,7 +103,7 @@ async fn storage_n_map_storage_lookup() -> Result<(), subxt::Error<DispatchError
     let ctx = test_context().await;
 
     // Boilerplate; we create a new asset class with ID 99, and then
-    // we "approveTransfer" of some of this asset class. This Gives us an
+    // we "approveTransfer" of some of this asset class. This gives us an
     // entry in the `Approvals` StorageNMap that we can try to look up.
     let signer = pair_signer(AccountKeyring::Alice.pair());
     let alice = AccountKeyring::Alice.to_account_id();

--- a/subxt/tests/integration/storage.rs
+++ b/subxt/tests/integration/storage.rs
@@ -50,12 +50,7 @@ async fn storage_map_lookup() -> Result<(), subxt::Error<DispatchError>> {
         .await?;
 
     // Look up the nonce for the user (we expect it to be 1).
-    let entry = ctx
-        .api
-        .storage()
-        .system()
-        .account(alice, None)
-        .await?;
+    let entry = ctx.api.storage().system().account(alice, None).await?;
     assert_eq!(entry.nonce, 1);
 
     Ok(())


### PR DESCRIPTION
~~Tests still needed before this merges (https://github.com/paritytech/substrate/blob/f318350b6410ef47e438aae24c0b4779373d0a7b/frame/assets/src/lib.rs#L274 is example of StorageNMap item).~~

I added a few general storage tests, and a specific one that is fixed by this PR and broken before it.

Closes #446