### PR TITLE
Substitute BTreeMap/BTreeSet generated types for Vec

### DIFF
--- a/codegen/src/api/mod.rs
+++ b/codegen/src/api/mod.rs
@@ -147,11 +147,13 @@ impl RuntimeGenerator {
                 "frame_support::traits::misc::WrapperKeepOpaque",
                 parse_quote!(::subxt::WrapperKeepOpaque),
             ),
-            // We override this because it's used as a key in a BTreeMap, and so we
-            // need to implement some extra derives for it for that to compile.
             (
-                "sp_npos_elections::ElectionScore",
-                parse_quote!(::subxt::ElectionScore),
+                "BTreeMap",
+                parse_quote!(::subxt::KeyedVec)
+            ),
+            (
+                "BTreeSet",
+                parse_quote!(::std::vec::Vec)
             ),
         ]
         .iter()

--- a/codegen/src/api/mod.rs
+++ b/codegen/src/api/mod.rs
@@ -147,14 +147,8 @@ impl RuntimeGenerator {
                 "frame_support::traits::misc::WrapperKeepOpaque",
                 parse_quote!(::subxt::WrapperKeepOpaque),
             ),
-            (
-                "BTreeMap",
-                parse_quote!(::subxt::KeyedVec)
-            ),
-            (
-                "BTreeSet",
-                parse_quote!(::std::vec::Vec)
-            ),
+            ("BTreeMap", parse_quote!(::subxt::KeyedVec)),
+            ("BTreeSet", parse_quote!(::std::vec::Vec)),
         ]
         .iter()
         .map(|(path, substitute): &(&str, syn::TypePath)| {

--- a/codegen/src/api/mod.rs
+++ b/codegen/src/api/mod.rs
@@ -147,6 +147,10 @@ impl RuntimeGenerator {
                 "frame_support::traits::misc::WrapperKeepOpaque",
                 parse_quote!(::subxt::WrapperKeepOpaque),
             ),
+            // BTreeMap and BTreeSet impose an `Ord` constraint on their key types. This
+            // can cause an issue with generated code that doesn't impl `Ord` by default.
+            // Decoding them to Vec by default (KeyedVec is just an alias for Vec with
+            // suitable type params) avoids these issues.
             ("BTreeMap", parse_quote!(::subxt::KeyedVec)),
             ("BTreeSet", parse_quote!(::std::vec::Vec)),
         ]

--- a/subxt/src/lib.rs
+++ b/subxt/src/lib.rs
@@ -242,40 +242,6 @@ impl<T> PhantomDataSendSync<T> {
 unsafe impl<T> Send for PhantomDataSendSync<T> {}
 unsafe impl<T> Sync for PhantomDataSendSync<T> {}
 
-/// [`ElectionScore`] overrides any generated instance of `sp_npos_elections::ElectionScore` found
-/// in the metadata, so that we can add some extra derives required for it to be used as the key
-/// in a [`std::collections::BTreeMap`].
-#[derive(Encode, Decode, Debug, PartialEq, Eq)]
-pub struct ElectionScore {
-    /// The minimal winner, in terms of total backing stake.
-    ///
-    /// This parameter should be maximized.
-    pub minimal_stake: u128,
-    /// The sum of the total backing of all winners.
-    ///
-    /// This parameter should maximized
-    pub sum_stake: u128,
-    /// The sum squared of the total backing of all winners, aka. the variance.
-    ///
-    /// Ths parameter should be minimized.
-    pub sum_stake_squared: u128,
-}
-
-// These are copied from the original impl; they don't affect encoding/decoding but help
-// to keep the ordering the same if we then work with the decoded results.
-impl Ord for ElectionScore {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        // we delegate this to the lexicographic cmp of slices`, and to incorporate that we want the
-        // third element to be minimized, we swap them.
-        [self.minimal_stake, self.sum_stake, other.sum_stake_squared].cmp(&[
-            other.minimal_stake,
-            other.sum_stake,
-            self.sum_stake_squared,
-        ])
-    }
-}
-impl PartialOrd for ElectionScore {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
+/// This represents a key-value collection and is SCALE compatible
+/// with collections like BTreeMap and BTreeSet
+pub type KeyedVec<K, V> = Vec<(K, V)>;

--- a/subxt/src/lib.rs
+++ b/subxt/src/lib.rs
@@ -243,5 +243,6 @@ unsafe impl<T> Send for PhantomDataSendSync<T> {}
 unsafe impl<T> Sync for PhantomDataSendSync<T> {}
 
 /// This represents a key-value collection and is SCALE compatible
-/// with collections like BTreeMap and BTreeSet
+/// with collections like BTreeMap. This has the same type params
+/// as `BTreeMap` which allows us to easily swap the two during codegen.
 pub type KeyedVec<K, V> = Vec<(K, V)>;

--- a/subxt/tests/integration/codegen/polkadot.rs
+++ b/subxt/tests/integration/codegen/polkadot.rs
@@ -1,3 +1,4 @@
+// Note [jsdw]: generated from polkadot 0.9.13-82616422d0-aarch64-macos
 #[allow(dead_code, unused_imports, non_camel_case_types)]
 pub mod api {
     use super::api as root_mod;
@@ -20073,9 +20074,7 @@ pub mod api {
                     #[derive(
                         :: subxt :: codec :: Encode, :: subxt :: codec :: Decode, Debug,
                     )]
-                    pub struct BoundedBTreeMap<_0, _1>(
-                        pub ::std::collections::BTreeMap<_0, _1>,
-                    );
+                    pub struct BoundedBTreeMap<_0, _1>(pub ::subxt::KeyedVec<_0, _1>);
                 }
                 pub mod bounded_vec {
                     use super::runtime_types;
@@ -23047,7 +23046,7 @@ pub mod api {
             #[derive(:: subxt :: codec :: Encode, :: subxt :: codec :: Decode, Debug)]
             pub struct EraRewardPoints<_0> {
                 pub total: ::core::primitive::u32,
-                pub individual: ::std::collections::BTreeMap<_0, ::core::primitive::u32>,
+                pub individual: ::subxt::KeyedVec<_0, ::core::primitive::u32>,
             }
             #[derive(:: subxt :: codec :: Encode, :: subxt :: codec :: Decode, Debug)]
             pub struct Exposure<_0, _1> {

--- a/subxt/tests/integration/frame/balances.rs
+++ b/subxt/tests/integration/frame/balances.rs
@@ -136,7 +136,7 @@ async fn storage_balance_lock() -> Result<(), subxt::Error<DispatchError>> {
         .await?;
 
     assert_eq!(
-        locks,
+        locks.0,
         vec![runtime_types::pallet_balances::BalanceLock {
             id: *b"staking ",
             amount: 100_000_000_000_000,

--- a/subxt/tests/integration/frame/balances.rs
+++ b/subxt/tests/integration/frame/balances.rs
@@ -136,7 +136,7 @@ async fn storage_balance_lock() -> Result<(), subxt::Error<DispatchError>> {
         .await?;
 
     assert_eq!(
-        locks.0,
+        locks,
         vec![runtime_types::pallet_balances::BalanceLock {
             id: *b"staking ",
             amount: 100_000_000_000_000,


### PR DESCRIPTION
Recently, we hit an issue (#454) where a key type given to a BTreeMap did not impl Ord, leading to compile errors attempting to use the generated code.

This PR impls @ascjones's suggestion in #456 and makes types that would have been decoded into BTreeMap/BTreeSet instead decode to `Vec<(K,V)>` or `Vec<K>`. Since Vecs don't require their contents to impl any particular traits, this avoids such issues, while still preserving the decode order.

Closes #456 and #315