### PR TITLE
Generate release changelog based on commits

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -31,8 +31,12 @@ We also assume that ongoing work done is being merged directly to the `master` b
 5.  Update `CHANGELOG.md` to reflect the difference between this release and the last. If you're unsure of
     what to add, check with the Tools team. See the `CHANGELOG.md` file for details of the format it follows.
 
-    Any [closed PRs](https://github.com/paritytech/subxt/pulls?q=is%3Apr+sort%3Aupdated-desc+is%3Aclosed) between the last release and
-    this release branch should be noted.
+    Utilize the following script to generate the merged PRs between releases.
+    ```
+    ./scripts/generate_changelog.sh
+    ```
+    Ensure that the script picked the latest published release tag (e.g. if releasing `v0.17.0`, the script should
+    provide `[+] Latest release tag: v0.16.0` ). Then group the PRs into "Added" and "Changed" sections.
 
 6.  Commit any of the above changes to the release branch and open a PR in GitHub with a base of `master`.
 

--- a/scripts/generate_changelog.sh
+++ b/scripts/generate_changelog.sh
@@ -4,6 +4,16 @@
 
 set -eu
 
+function usage() {
+    cat <<HELP_USAGE
+This script obtains the changelog between the latest release tag and origin/master.
+
+Usage: $0 [-h]
+
+    -h  Print help message.
+HELP_USAGE
+}
+
 function log_error() {
     echo "Error:" "$@" >&2
     exit 1
@@ -12,6 +22,15 @@ function log_error() {
 function log_info() {
     echo -e "[+]" "$@"
 }
+
+while getopts "h?" opt; do
+    case "$opt" in
+        h|\?)
+            usage
+            exit 0
+            ;;
+    esac
+done
 
 GIT_BIN=$(which git) || log_error 'git is not installed. Please follow https://github.com/git-guides/install-git for instructions'
 

--- a/scripts/generate_changelog.sh
+++ b/scripts/generate_changelog.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# This script obtains the changelog to be introduced in the new release.
+
+set -eu
+
+function log_error() {
+    echo "Error:" "$@" >&2
+    exit 1
+}
+
+function log_info() {
+    echo -e "[+]" "$@"
+}
+
+GIT_BIN=$(which git) || log_error 'git is not installed. Please follow https://github.com/git-guides/install-git for instructions'
+
+# Generate the changelog between the provided tag and origin/master.
+function generate_changelog() {
+    local tag="$1"
+    # From the remote origin url, get a link to pull requests.
+    remote_link=$($GIT_BIN config --get remote.origin.url | sed 's/\.git/\/pull\//g') || log_error 'Failed to get remote origin url'
+
+    prs=$($GIT_BIN --no-pager log --pretty=format:"%s" "$tag"..origin/master) || log_error 'Failed to obtain commit list'
+
+    log_info "Changelog\n"
+    while IFS= read -r line; do
+        # Obtain the pr number from each line. The regex should match, as provided by the previous grep.
+        if [[ $line =~ "(#"([0-9]+)")"$ ]]; then
+            pr_number="${BASH_REMATCH[1]}"
+        else
+            continue
+        fi
+
+        # Generate a valid PR link.
+        pr_link="$remote_link$pr_number"
+        # Generate the link as markdown.
+        pr_md_link=" ([#$pr_number]($pr_link))"
+        # Print the changelog line as `- commit-title pr-link`.
+        echo "$line" | awk -v var="$pr_md_link" '{NF--; printf "- "; printf; print var}'
+    done <<< "$prs"
+}
+
+# Get latest release tag.
+tag=$($GIT_BIN describe --match "v[0-9]*" --abbrev=0 origin/master) || log_error 'Failed to obtain the latest release tag'
+log_info "Latest release tag: $tag"
+# TODO: verify that the tag is part of an actual release
+$GIT_BIN verify-tag "$tag" > /dev/null 2>&1 || log_error 'Failed to verify tag'
+
+generate_changelog "$tag"

--- a/scripts/generate_changelog.sh
+++ b/scripts/generate_changelog.sh
@@ -44,7 +44,5 @@ function generate_changelog() {
 # Get latest release tag.
 tag=$($GIT_BIN describe --match "v[0-9]*" --abbrev=0 origin/master) || log_error 'Failed to obtain the latest release tag'
 log_info "Latest release tag: $tag"
-# TODO: verify that the tag is part of an actual release
-$GIT_BIN verify-tag "$tag" > /dev/null 2>&1 || log_error 'Failed to verify tag'
 
 generate_changelog "$tag"


### PR DESCRIPTION
This script is intended to automate part of the release process.
As stated in the [release](https://github.com/paritytech/subxt/blob/master/RELEASING.md), the changelog should be created from closed PRs.
In this approach, the script inspects the merged PRs into the main branch `origin/master`, that is similar to what the substrate repository does.



### Testing Done
*  ``` shellcheck ./scripts/generate_changelog.sh ```
* Output without commits
```
./scripts/generate_changelog.sh
[+] Latest release tag: v0.18.0
[+] Changelog

```
* Output with commits

```
./scripts/generate_changelog.sh
[+] Latest release tag: v0.17.0
[+] Changelog

- Release preparation for v0.18.0 ([#464](https://github.com/paritytech/subxt/pull/464))
- Reference key storage api ([#447](https://github.com/paritytech/subxt/pull/447))
- Update scale-info and parity-scale-codec requirements ([#462](https://github.com/paritytech/subxt/pull/462))
- Filter one or multiple events by type from an EventSubscription ([#461](https://github.com/paritytech/subxt/pull/461))
- Distinct handling for N fields + 1 hasher vs N fields + N hashers ([#458](https://github.com/paritytech/subxt/pull/458))
- Substitute BTreeMap/BTreeSet generated types for Vec ([#459](https://github.com/paritytech/subxt/pull/459))
- Obtain DispatchError::Module info dynamically ([#453](https://github.com/paritytech/subxt/pull/453))
- Add hardcoded override to ElectionScore ([#455](https://github.com/paritytech/subxt/pull/455))
- Expose method to fetch nonce via `Client` ([#451](https://github.com/paritytech/subxt/pull/451))
- DispatchError::Module is now a tuple variant in latest Substrate ([#439](https://github.com/paritytech/subxt/pull/439))
- Fix flaky event subscription test ([#450](https://github.com/paritytech/subxt/pull/450))
- Improve documentation ([#449](https://github.com/paritytech/subxt/pull/449))
- New Event Subscription API ([#442](https://github.com/paritytech/subxt/pull/442))
- Export `codegen::TypeGenerator` ([#444](https://github.com/paritytech/subxt/pull/444))
- Fix conversion of `Call` struct names to UpperCamelCase ([#441](https://github.com/paritytech/subxt/pull/441))
- Update release documentation with dry-run ([#435](https://github.com/paritytech/subxt/pull/435))
```