### PR TITLE
Remove unused sp_version dependency

### DIFF
--- a/subxt/Cargo.toml
+++ b/subxt/Cargo.toml
@@ -31,7 +31,6 @@ subxt-macro = { version = "0.18.0", path = "../macro" }
 
 sp-core = { version = "6.0.0", default-features = false  }
 sp-runtime = "6.0.0"
-sp-version = "5.0.0"
 
 frame-metadata = "15.0.0"
 derivative = "2.2.0"

--- a/subxt/src/storage.rs
+++ b/subxt/src/storage.rs
@@ -26,7 +26,6 @@ use sp_core::storage::{
     StorageKey,
 };
 pub use sp_runtime::traits::SignedExtension;
-pub use sp_version::RuntimeVersion;
 use std::marker::PhantomData;
 
 use crate::{

--- a/subxt/src/transaction.rs
+++ b/subxt/src/transaction.rs
@@ -20,7 +20,6 @@ use crate::PhantomDataSendSync;
 use codec::Decode;
 use sp_runtime::traits::Hash;
 pub use sp_runtime::traits::SignedExtension;
-pub use sp_version::RuntimeVersion;
 
 use crate::{
     client::Client,


### PR DESCRIPTION
We had already copied in the one struct we need from this anyway, since it changed between versions and we only needed to decode a subset of it, but because the `use sp_version` declarations were `pub`, they weren't spotted as unneeded. 