### PR TITLE
Make EventSubscription and FilterEvents Send-able

### DIFF
--- a/subxt/src/events/event_subscription.rs
+++ b/subxt/src/events/event_subscription.rs
@@ -84,7 +84,7 @@ pub struct EventSubscription<'a, T: Config, Evs: 'static> {
     #[derivative(Debug = "ignore")]
     at: Option<
         std::pin::Pin<
-            Box<dyn Future<Output = Result<Events<'a, T, Evs>, BasicError>> + 'a>,
+            Box<dyn Future<Output = Result<Events<'a, T, Evs>, BasicError>> + Send + 'a>,
         >,
     >,
     _event_type: std::marker::PhantomData<Evs>,
@@ -174,4 +174,18 @@ impl<'a, T: Config, Evs: Decode> Stream for EventSubscription<'a, T, Evs> {
         self.at = None;
         Poll::Ready(Some(events))
     }
+}
+
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    // Ensure `EventSubscription` can be sent; only actually a compile-time check.
+    #[test]
+    fn check_sendability() {
+        fn assert_send<T: Send>() {}
+        assert_send::<EventSubscription<crate::DefaultConfig, ()>>();
+    }
+
 }

--- a/subxt/src/events/event_subscription.rs
+++ b/subxt/src/events/event_subscription.rs
@@ -176,7 +176,6 @@ impl<'a, T: Config, Evs: Decode> Stream for EventSubscription<'a, T, Evs> {
     }
 }
 
-
 #[cfg(test)]
 mod test {
     use super::*;
@@ -187,5 +186,4 @@ mod test {
         fn assert_send<T: Send>() {}
         assert_send::<EventSubscription<crate::DefaultConfig, ()>>();
     }
-
 }

--- a/subxt/src/events/filter_events.rs
+++ b/subxt/src/events/filter_events.rs
@@ -51,7 +51,7 @@ pub struct FilterEvents<'a, Sub: 'a, T: Config, Filter: EventFilter> {
                         FilteredEventDetails<T::Hash, Filter::ReturnType>,
                         BasicError,
                     >,
-                > + 'a,
+                > + Send + 'a,
         >,
     >,
 }
@@ -131,7 +131,7 @@ pub trait EventFilter: private::Sealed {
                     FilteredEventDetails<T::Hash, Self::ReturnType>,
                     BasicError,
                 >,
-            > + 'a,
+            > + Send + 'a,
     >;
 }
 
@@ -150,7 +150,7 @@ impl<Ev: Event> EventFilter for (Ev,) {
     fn filter<'a, T: Config, Evs: Decode + 'static>(
         events: Events<'a, T, Evs>,
     ) -> Box<
-        dyn Iterator<Item = Result<FilteredEventDetails<T::Hash, Ev>, BasicError>> + 'a,
+        dyn Iterator<Item = Result<FilteredEventDetails<T::Hash, Ev>, BasicError>> + Send + 'a,
     > {
         let block_hash = events.block_hash();
         let mut iter = events.into_iter_raw();
@@ -189,7 +189,7 @@ macro_rules! impl_event_filter {
             type ReturnType = ( $(Option<$ty>,)+ );
             fn filter<'a, T: Config, Evs: Decode + 'static>(
                 events: Events<'a, T, Evs>
-            ) -> Box<dyn Iterator<Item=Result<FilteredEventDetails<T::Hash,Self::ReturnType>, BasicError>> + 'a> {
+            ) -> Box<dyn Iterator<Item=Result<FilteredEventDetails<T::Hash,Self::ReturnType>, BasicError>> + Send + 'a> {
                 let block_hash = events.block_hash();
                 let mut iter = events.into_iter_raw();
                 Box::new(std::iter::from_fn(move || {

--- a/subxt/src/events/filter_events.rs
+++ b/subxt/src/events/filter_events.rs
@@ -51,7 +51,8 @@ pub struct FilterEvents<'a, Sub: 'a, T: Config, Filter: EventFilter> {
                         FilteredEventDetails<T::Hash, Filter::ReturnType>,
                         BasicError,
                     >,
-                > + Send + 'a,
+                > + Send
+                + 'a,
         >,
     >,
 }
@@ -131,7 +132,8 @@ pub trait EventFilter: private::Sealed {
                     FilteredEventDetails<T::Hash, Self::ReturnType>,
                     BasicError,
                 >,
-            > + Send + 'a,
+            > + Send
+            + 'a,
     >;
 }
 
@@ -150,7 +152,9 @@ impl<Ev: Event> EventFilter for (Ev,) {
     fn filter<'a, T: Config, Evs: Decode + 'static>(
         events: Events<'a, T, Evs>,
     ) -> Box<
-        dyn Iterator<Item = Result<FilteredEventDetails<T::Hash, Ev>, BasicError>> + Send + 'a,
+        dyn Iterator<Item = Result<FilteredEventDetails<T::Hash, Ev>, BasicError>>
+            + Send
+            + 'a,
     > {
         let block_hash = events.block_hash();
         let mut iter = events.into_iter_raw();

--- a/subxt/src/rpc.rs
+++ b/subxt/src/rpc.rs
@@ -37,9 +37,7 @@ use codec::{
     Decode,
     Encode,
 };
-use core::{
-    convert::TryInto,
-};
+use core::convert::TryInto;
 use frame_metadata::RuntimeMetadataPrefixed;
 pub use jsonrpsee::{
     client_transport::ws::{

--- a/subxt/src/rpc.rs
+++ b/subxt/src/rpc.rs
@@ -31,6 +31,7 @@ use crate::{
     storage::StorageKeyPrefix,
     Config,
     Metadata,
+    PhantomDataSendSync,
 };
 use codec::{
     Decode,
@@ -38,7 +39,6 @@ use codec::{
 };
 use core::{
     convert::TryInto,
-    marker::PhantomData,
 };
 use frame_metadata::RuntimeMetadataPrefixed;
 pub use jsonrpsee::{
@@ -211,14 +211,14 @@ pub struct ReadProof<Hash> {
 pub struct Rpc<T: Config> {
     /// Rpc client for sending requests.
     pub client: Arc<RpcClient>,
-    marker: PhantomData<T>,
+    _marker: PhantomDataSendSync<T>,
 }
 
 impl<T: Config> Clone for Rpc<T> {
     fn clone(&self) -> Self {
         Self {
             client: self.client.clone(),
-            marker: PhantomData,
+            _marker: PhantomDataSendSync::new(),
         }
     }
 }
@@ -228,7 +228,7 @@ impl<T: Config> Rpc<T> {
     pub fn new(client: RpcClient) -> Self {
         Self {
             client: Arc::new(client),
-            marker: PhantomData,
+            _marker: PhantomDataSendSync::new(),
         }
     }
 

--- a/subxt/src/rpc.rs
+++ b/subxt/src/rpc.rs
@@ -37,7 +37,6 @@ use codec::{
     Decode,
     Encode,
 };
-use core::convert::TryInto;
 use frame_metadata::RuntimeMetadataPrefixed;
 pub use jsonrpsee::{
     client_transport::ws::{

--- a/subxt/tests/integration/events.rs
+++ b/subxt/tests/integration/events.rs
@@ -138,7 +138,8 @@ async fn balance_transfer_subscription() -> Result<(), subxt::BasicError> {
 
 // This is just a compile-time check that we can subscribe to events in
 // a context that requires the event subscription/filtering to be Send-able.
-// We test a typical use of EventSubscription and FilterEvents
+// We test a typical use of EventSubscription and FilterEvents. We don't need
+// to run this code; just check that it compiles.
 #[allow(unused)]
 async fn check_events_are_sendable() {
     // check that EventSubscription can be used across await points.
@@ -151,7 +152,6 @@ async fn check_events_are_sendable() {
             // if `event_sub` doesn't implement Send, we can't hold
             // it across an await point inside of a tokio::spawn, which
             // requires Send. This will lead to a compile error.
-            break
         }
 
         Ok::<_, subxt::BasicError>(())
@@ -172,7 +172,6 @@ async fn check_events_are_sendable() {
             // if `event_sub` doesn't implement Send, we can't hold
             // it across an await point inside of a tokio::spawn, which
             // requires Send; This will lead to a compile error.
-            break
         }
 
         Ok::<_, subxt::BasicError>(())

--- a/subxt/tests/integration/events.rs
+++ b/subxt/tests/integration/events.rs
@@ -141,22 +141,17 @@ async fn balance_transfer_subscription() -> Result<(), subxt::BasicError> {
 // We test a typical use of EventSubscription and FilterEvents
 #[allow(unused)]
 async fn check_events_are_sendable() {
-
     // check that EventSubscription can be used across await points.
     async_std::task::spawn(async {
         let ctx = test_context().await;
 
-        let mut event_sub = ctx
-            .api
-            .events()
-            .subscribe()
-            .await?;
+        let mut event_sub = ctx.api.events().subscribe().await?;
 
         while let Some(ev) = event_sub.next().await {
             // if `event_sub` doesn't implement Send, we can't hold
             // it across an await point inside of a tokio::spawn, which
             // requires Send. This will lead to a compile error.
-            break;
+            break
         }
 
         Ok::<_, subxt::BasicError>(())
@@ -177,10 +172,9 @@ async fn check_events_are_sendable() {
             // if `event_sub` doesn't implement Send, we can't hold
             // it across an await point inside of a tokio::spawn, which
             // requires Send; This will lead to a compile error.
-            break;
+            break
         }
 
         Ok::<_, subxt::BasicError>(())
     });
-
 }

--- a/subxt/tests/integration/events.rs
+++ b/subxt/tests/integration/events.rs
@@ -135,3 +135,52 @@ async fn balance_transfer_subscription() -> Result<(), subxt::BasicError> {
 
     Ok(())
 }
+
+// This is just a compile-time check that we can subscribe to events in
+// a context that requires the event subscription/filtering to be Send-able.
+// We test a typical use of EventSubscription and FilterEvents
+#[allow(unused)]
+async fn check_events_are_sendable() {
+
+    // check that EventSubscription can be used across await points.
+    async_std::task::spawn(async {
+        let ctx = test_context().await;
+
+        let mut event_sub = ctx
+            .api
+            .events()
+            .subscribe()
+            .await?;
+
+        while let Some(ev) = event_sub.next().await {
+            // if `event_sub` doesn't implement Send, we can't hold
+            // it across an await point inside of a tokio::spawn, which
+            // requires Send. This will lead to a compile error.
+            break;
+        }
+
+        Ok::<_, subxt::BasicError>(())
+    });
+
+    // Check that FilterEvents can be used across await points.
+    async_std::task::spawn(async {
+        let ctx = test_context().await;
+
+        let mut event_sub = ctx
+            .api
+            .events()
+            .subscribe()
+            .await?
+            .filter_events::<(balances::events::Transfer,)>();
+
+        while let Some(ev) = event_sub.next().await {
+            // if `event_sub` doesn't implement Send, we can't hold
+            // it across an await point inside of a tokio::spawn, which
+            // requires Send; This will lead to a compile error.
+            break;
+        }
+
+        Ok::<_, subxt::BasicError>(())
+    });
+
+}


### PR DESCRIPTION
Without this, they cannot be used in `tokio::spawn`-like contexts, which require things held across await points to impl `Send` (because they might be moved across threads between such points).

Closes #469 