### PR TITLE
Return events from blocks skipped over during Finalization, too

### DIFF
--- a/codegen/src/api/mod.rs
+++ b/codegen/src/api/mod.rs
@@ -347,7 +347,7 @@ impl RuntimeGenerator {
                         ::subxt::events::subscribe::<T, Event>(self.client).await
                     }
 
-                    pub async fn subscribe_finalized(&self) -> Result<::subxt::events::EventSubscription<'a, ::subxt::events::FinalizedEventSub<T::Header>, T, Event>, ::subxt::BasicError> {
+                    pub async fn subscribe_finalized(&self) -> Result<::subxt::events::EventSubscription<'a, ::subxt::events::FinalizedEventSub<'a, T::Header>, T, Event>, ::subxt::BasicError> {
                         ::subxt::events::subscribe_finalized::<T, Event>(self.client).await
                     }
                 }

--- a/codegen/src/api/mod.rs
+++ b/codegen/src/api/mod.rs
@@ -343,11 +343,11 @@ impl RuntimeGenerator {
                         ::subxt::events::at::<T, Event>(self.client, block_hash).await
                     }
 
-                    pub async fn subscribe(&self) -> Result<::subxt::events::EventSubscription<'a, T, Event>, ::subxt::BasicError> {
+                    pub async fn subscribe(&self) -> Result<::subxt::events::EventSubscription<'a, ::subxt::events::JsonRpcSub<T::Header>, T, Event>, ::subxt::BasicError> {
                         ::subxt::events::subscribe::<T, Event>(self.client).await
                     }
 
-                    pub async fn subscribe_finalized(&self) -> Result<::subxt::events::EventSubscription<'a, T, Event>, ::subxt::BasicError> {
+                    pub async fn subscribe_finalized(&self) -> Result<::subxt::events::EventSubscription<'a, ::subxt::events::BoxedJsonRpcSub<T::Header>, T, Event>, ::subxt::BasicError> {
                         ::subxt::events::subscribe_finalized::<T, Event>(self.client).await
                     }
                 }

--- a/codegen/src/api/mod.rs
+++ b/codegen/src/api/mod.rs
@@ -343,11 +343,11 @@ impl RuntimeGenerator {
                         ::subxt::events::at::<T, Event>(self.client, block_hash).await
                     }
 
-                    pub async fn subscribe(&self) -> Result<::subxt::events::EventSubscription<'a, ::subxt::events::JsonRpcSub<T::Header>, T, Event>, ::subxt::BasicError> {
+                    pub async fn subscribe(&self) -> Result<::subxt::events::EventSubscription<'a, ::subxt::events::EventSub<T::Header>, T, Event>, ::subxt::BasicError> {
                         ::subxt::events::subscribe::<T, Event>(self.client).await
                     }
 
-                    pub async fn subscribe_finalized(&self) -> Result<::subxt::events::EventSubscription<'a, ::subxt::events::BoxedJsonRpcSub<T::Header>, T, Event>, ::subxt::BasicError> {
+                    pub async fn subscribe_finalized(&self) -> Result<::subxt::events::EventSubscription<'a, ::subxt::events::FinalizedEventSub<T::Header>, T, Event>, ::subxt::BasicError> {
                         ::subxt::events::subscribe_finalized::<T, Event>(self.client).await
                     }
                 }

--- a/examples/examples/rpc_call.rs
+++ b/examples/examples/rpc_call.rs
@@ -41,7 +41,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await?
         .to_runtime_api::<polkadot::RuntimeApi<DefaultConfig, DefaultExtra<DefaultConfig>>>();
 
-    let block_number = 1;
+    let block_number = 1u32;
 
     let block_hash = api
         .client

--- a/subxt/Cargo.toml
+++ b/subxt/Cargo.toml
@@ -22,7 +22,6 @@ futures = "0.3.13"
 hex = "0.4.3"
 jsonrpsee = { version = "0.8.0", features = ["async-client", "client-ws-transport"] }
 log = "0.4.14"
-num-traits = { version = "0.2.14", default-features = false }
 serde = { version = "1.0.124", features = ["derive"] }
 serde_json = "1.0.64"
 thiserror = "1.0.24"

--- a/subxt/src/config.rs
+++ b/subxt/src/config.rs
@@ -47,7 +47,7 @@ pub trait Config: 'static {
         + Copy
         + core::hash::Hash
         + core::str::FromStr
-        + Into<u128>;
+        + Into<u64>;
 
     /// The output of the `Hashing` function.
     type Hash: Parameter

--- a/subxt/src/config.rs
+++ b/subxt/src/config.rs
@@ -47,9 +47,7 @@ pub trait Config: 'static {
         + Copy
         + core::hash::Hash
         + core::str::FromStr
-        + num_traits::One
-        + core::ops::Add<Output = Self::BlockNumber>
-        + MaybeSerializeDeserialize;
+        + Into<u128>;
 
     /// The output of the `Hashing` function.
     type Hash: Parameter

--- a/subxt/src/config.rs
+++ b/subxt/src/config.rs
@@ -46,7 +46,10 @@ pub trait Config: 'static {
         + Default
         + Copy
         + core::hash::Hash
-        + core::str::FromStr;
+        + core::str::FromStr
+        + num_traits::One
+        + core::ops::Add<Output = Self::BlockNumber>
+        + MaybeSerializeDeserialize;
 
     /// The output of the `Hashing` function.
     type Hash: Parameter

--- a/subxt/src/events/event_subscription.rs
+++ b/subxt/src/events/event_subscription.rs
@@ -87,6 +87,9 @@ pub async fn subscribe_finalized<'a, T: Config, Evs: Decode + 'static>(
         .await?
         .map(|h| *h.number());
 
+    // The complexity here is because the finalized block subscription may skip over
+    // some blocks, so here we attempt to ensure that we pay attention to every block
+    // that was skipped over as well as the latest block we were told about.
     let block_subscription =
         client
             .rpc()
@@ -141,12 +144,12 @@ pub async fn subscribe_finalized<'a, T: Config, Evs: Decode + 'static>(
 }
 
 /// A `jsonrpsee` Subscription. This forms a part of the `EventSubscription` type handed back
-/// in codegen from `subscribe_finalized`, and so is exposed here to be used there.
+/// in codegen from `subscribe_finalized`, and is exposed to be used in codegen.
 #[doc(hidden)]
 pub type FinalizedEventSub<'a, Header> = BoxStream<'a, Result<Header, BasicError>>;
 
 /// A `jsonrpsee` Subscription. This forms a part of the `EventSubscription` type handed back
-/// in codegen from `subscribe`, and so is exposed here to be used there.
+/// in codegen from `subscribe`, and is exposed to be used in codegen.
 #[doc(hidden)]
 pub type EventSub<Item> = Subscription<Item>;
 

--- a/subxt/src/events/event_subscription.rs
+++ b/subxt/src/events/event_subscription.rs
@@ -126,11 +126,11 @@ pub async fn subscribe_finalized<'a, T: Config, Evs: Decode + 'static>(
 }
 
 /// Return a Stream of all block headers starting from `current_block_num` and ending just before `end_num`.
-fn get_block_headers<'a, T: Config>(
-    client: &'a Client<T>,
+fn get_block_headers<T: Config>(
+    client: &'_ Client<T>,
     mut current_block_num: u128,
     end_num: u128,
-) -> impl Stream<Item = Result<T::Header, BasicError>> + Unpin + Send + 'a {
+) -> impl Stream<Item = Result<T::Header, BasicError>> + Unpin + Send + '_ {
     // Iterate over all of the previous blocks we need headers for. We go from (start_num..end_num).
     // If start_num == end_num, return nothing.
     let block_numbers = std::iter::from_fn(move || {
@@ -140,7 +140,7 @@ fn get_block_headers<'a, T: Config>(
             Some(current_block_num)
         };
 
-        current_block_num = current_block_num + 1;
+        current_block_num += 1;
         res
     });
 

--- a/subxt/src/events/event_subscription.rs
+++ b/subxt/src/events/event_subscription.rs
@@ -126,6 +126,7 @@ pub async fn subscribe_finalized<'a, T: Config, Evs: Decode + 'static>(
     Ok(EventSubscription::new(client, Box::pin(block_subscription)))
 }
 
+/// Return a Stream of all block headers starting from `current_block_num` and ending just before `end_num`.
 fn get_block_headers<'a, T: Config>(
     client: &'a Client<T>,
     mut current_block_num: T::BlockNumber,

--- a/subxt/src/events/mod.rs
+++ b/subxt/src/events/mod.rs
@@ -26,6 +26,8 @@ pub use event_subscription::{
     subscribe,
     subscribe_finalized,
     EventSubscription,
+    JsonRpcSub,
+    BoxedJsonRpcSub,
 };
 pub use events_type::{
     at,

--- a/subxt/src/events/mod.rs
+++ b/subxt/src/events/mod.rs
@@ -25,6 +25,7 @@ pub use decoding::EventsDecodingError;
 pub use event_subscription::{
     subscribe,
     subscribe_finalized,
+    subscribe_to_block_headers_filling_in_gaps,
     EventSub,
     EventSubscription,
     FinalizedEventSub,

--- a/subxt/src/events/mod.rs
+++ b/subxt/src/events/mod.rs
@@ -25,8 +25,8 @@ pub use decoding::EventsDecodingError;
 pub use event_subscription::{
     subscribe,
     subscribe_finalized,
-    EventSubscription,
     EventSub,
+    EventSubscription,
     FinalizedEventSub,
 };
 pub use events_type::{

--- a/subxt/src/events/mod.rs
+++ b/subxt/src/events/mod.rs
@@ -26,8 +26,8 @@ pub use event_subscription::{
     subscribe,
     subscribe_finalized,
     EventSubscription,
-    JsonRpcSub,
-    BoxedJsonRpcSub,
+    EventSub,
+    FinalizedEventSub,
 };
 pub use events_type::{
     at,

--- a/subxt/src/rpc.rs
+++ b/subxt/src/rpc.rs
@@ -355,6 +355,23 @@ impl<T: Config> Rpc<T> {
         }
     }
 
+    /// Get a block hash given a T::BlockNumber from our config.
+    /// This may not be useful externally, but we need to be able to
+    /// get detail for T::BlockNumbers.
+    #[doc(hidden)]
+    pub async fn block_hash_internal(
+        &self,
+        block_number: T::BlockNumber,
+    ) -> Result<Option<T::Hash>, BasicError> {
+        let block_number = ListOrValue::Value(block_number);
+        let params = rpc_params![block_number];
+        let list_or_value = self.client.request("chain_getBlockHash", params).await?;
+        match list_or_value {
+            ListOrValue::Value(hash) => Ok(hash),
+            ListOrValue::List(_) => Err("Expected a Value, got a List".into()),
+        }
+    }
+
     /// Get a block hash of the latest finalized block
     pub async fn finalized_head(&self) -> Result<T::Hash, BasicError> {
         let hash = self

--- a/subxt/src/rpc.rs
+++ b/subxt/src/rpc.rs
@@ -96,16 +96,6 @@ pub enum NumberOrHex {
     Hex(U256),
 }
 
-/// RPC list or value wrapper.
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
-#[serde(untagged)]
-pub enum ListOrValue<T> {
-    /// A list of values of given type.
-    List(Vec<T>),
-    /// A single value of given type.
-    Value(T),
-}
-
 /// Alias for the type of a block returned by `chain_getBlock`
 pub type ChainBlock<T> =
     SignedBlock<Block<<T as Config>::Header, <T as Config>::Extrinsic>>;
@@ -285,16 +275,11 @@ impl<T: Config> Rpc<T> {
 
     /// Fetch the genesis hash
     pub async fn genesis_hash(&self) -> Result<T::Hash, BasicError> {
-        let block_zero = Some(ListOrValue::Value(NumberOrHex::Number(0)));
+        let block_zero = 0u32;
         let params = rpc_params![block_zero];
-        let list_or_value: ListOrValue<Option<T::Hash>> =
+        let genesis_hash: Option<T::Hash> =
             self.client.request("chain_getBlockHash", params).await?;
-        match list_or_value {
-            ListOrValue::Value(genesis_hash) => {
-                genesis_hash.ok_or_else(|| "Genesis hash not found".into())
-            }
-            ListOrValue::List(_) => Err("Expected a Value, got a List".into()),
-        }
+        genesis_hash.ok_or_else(|| "Genesis hash not found".into())
     }
 
     /// Fetch the metadata
@@ -346,13 +331,9 @@ impl<T: Config> Rpc<T> {
         &self,
         block_number: Option<BlockNumber>,
     ) -> Result<Option<T::Hash>, BasicError> {
-        let block_number = block_number.map(ListOrValue::Value);
         let params = rpc_params![block_number];
-        let list_or_value = self.client.request("chain_getBlockHash", params).await?;
-        match list_or_value {
-            ListOrValue::Value(hash) => Ok(hash),
-            ListOrValue::List(_) => Err("Expected a Value, got a List".into()),
-        }
+        let block_hash = self.client.request("chain_getBlockHash", params).await?;
+        Ok(block_hash)
     }
 
     /// Get a block hash given a T::BlockNumber from our config.
@@ -363,13 +344,9 @@ impl<T: Config> Rpc<T> {
         &self,
         block_number: T::BlockNumber,
     ) -> Result<Option<T::Hash>, BasicError> {
-        let block_number = ListOrValue::Value(block_number);
         let params = rpc_params![block_number];
-        let list_or_value = self.client.request("chain_getBlockHash", params).await?;
-        match list_or_value {
-            ListOrValue::Value(hash) => Ok(hash),
-            ListOrValue::List(_) => Err("Expected a Value, got a List".into()),
-        }
+        let block_hash = self.client.request("chain_getBlockHash", params).await?;
+        Ok(block_hash)
     }
 
     /// Get a block hash of the latest finalized block

--- a/subxt/src/rpc.rs
+++ b/subxt/src/rpc.rs
@@ -91,7 +91,7 @@ use sp_runtime::generic::{
 #[serde(untagged)]
 pub enum NumberOrHex {
     /// The number represented directly.
-    Number(u128),
+    Number(u64),
     /// Hex representation of the number.
     Hex(U256),
 }
@@ -122,7 +122,7 @@ macro_rules! into_block_number {
         )+
     }
 }
-into_block_number!(u8 u16 u32 u64 u128);
+into_block_number!(u8 u16 u32 u64);
 
 /// Arbitrary properties defined in the chain spec as a JSON object.
 pub type SystemProperties = serde_json::Map<String, serde_json::Value>;

--- a/subxt/tests/integration/codegen/polkadot.rs
+++ b/subxt/tests/integration/codegen/polkadot.rs
@@ -27849,13 +27849,13 @@ pub mod api {
         }
         pub async fn subscribe(
             &self,
-        ) -> Result<::subxt::events::EventSubscription<'a, ::subxt::events::JsonRpcSub<T::Header>, T, Event>, ::subxt::BasicError>
+        ) -> Result<::subxt::events::EventSubscription<'a, ::subxt::events::EventSub<T::Header>, T, Event>, ::subxt::BasicError>
         {
             ::subxt::events::subscribe::<T, Event>(self.client).await
         }
         pub async fn subscribe_finalized(
             &self,
-        ) -> Result<::subxt::events::EventSubscription<'a, ::subxt::events::BoxedJsonRpcSub<T::Header>, T, Event>, ::subxt::BasicError>
+        ) -> Result<::subxt::events::EventSubscription<'a, ::subxt::events::FinalizedEventSub<T::Header>, T, Event>, ::subxt::BasicError>
         {
             ::subxt::events::subscribe_finalized::<T, Event>(self.client).await
         }

--- a/subxt/tests/integration/codegen/polkadot.rs
+++ b/subxt/tests/integration/codegen/polkadot.rs
@@ -27849,13 +27849,13 @@ pub mod api {
         }
         pub async fn subscribe(
             &self,
-        ) -> Result<::subxt::events::EventSubscription<'a, T, Event>, ::subxt::BasicError>
+        ) -> Result<::subxt::events::EventSubscription<'a, ::subxt::events::JsonRpcSub<T::Header>, T, Event>, ::subxt::BasicError>
         {
             ::subxt::events::subscribe::<T, Event>(self.client).await
         }
         pub async fn subscribe_finalized(
             &self,
-        ) -> Result<::subxt::events::EventSubscription<'a, T, Event>, ::subxt::BasicError>
+        ) -> Result<::subxt::events::EventSubscription<'a, ::subxt::events::BoxedJsonRpcSub<T::Header>, T, Event>, ::subxt::BasicError>
         {
             ::subxt::events::subscribe_finalized::<T, Event>(self.client).await
         }

--- a/subxt/tests/integration/codegen/polkadot.rs
+++ b/subxt/tests/integration/codegen/polkadot.rs
@@ -27855,7 +27855,7 @@ pub mod api {
         }
         pub async fn subscribe_finalized(
             &self,
-        ) -> Result<::subxt::events::EventSubscription<'a, ::subxt::events::FinalizedEventSub<T::Header>, T, Event>, ::subxt::BasicError>
+        ) -> Result<::subxt::events::EventSubscription<'a, ::subxt::events::FinalizedEventSub<'a, T::Header>, T, Event>, ::subxt::BasicError>
         {
             ::subxt::events::subscribe_finalized::<T, Event>(self.client).await
         }

--- a/subxt/tests/integration/events.rs
+++ b/subxt/tests/integration/events.rs
@@ -163,7 +163,7 @@ async fn missing_block_headers_will_be_filled_in() -> Result<(), subxt::BasicErr
         })
         .map(|(_, h)| h);
 
-    // This should spot the gap in the middle and fill it back in.
+    // This should spot any gaps in the middle and fill them back in.
     let all_finalized_blocks = subscribe_to_block_headers_filling_in_gaps(
         &ctx.api.client,
         None,

--- a/subxt/tests/integration/events.rs
+++ b/subxt/tests/integration/events.rs
@@ -146,8 +146,9 @@ async fn missing_block_headers_will_be_filled_in() -> Result<(), subxt::BasicErr
 
     let ctx = test_context().await;
 
-    // Manually subscribe to the next 4 finalized block headers, but deliberately
-    // filter out two in the middle.
+    // Manually subscribe to the next 6 finalized block headers, but deliberately
+    // filter out some in the middle so we get back b _ _ b _ b. This guarantees
+    // that there will be some gaps, even if there aren't any from the subscription.
     let some_finalized_blocks = ctx
         .api
         .client
@@ -155,10 +156,10 @@ async fn missing_block_headers_will_be_filled_in() -> Result<(), subxt::BasicErr
         .subscribe_finalized_blocks()
         .await?
         .enumerate()
-        .take(4)
+        .take(6)
         .filter(|(n, _)| {
             let n = *n;
-            async move { n == 0 || n == 3 }
+            async move { n == 0 || n == 3 || n == 5 }
         })
         .map(|(_, h)| h);
 


### PR DESCRIPTION
If you subscribe to receive finalized block headers, blocks may be skipped over whenever a bunch of them are finalized at the same time. This PR makes sure to return events from all of the skipped-over blocks too.

Closes #468 