### PR TITLE
Release prep for 0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.0] - 2022-03-21
+
+### Changed
+
+- Return events from blocks skipped over during Finalization, too ([#473](git@github.com:paritytech/subxt/pull/473))
+- Use RPC call to get account nonce ([#476](git@github.com:paritytech/subxt/pull/476))
+- Add script to generate release changelog based on commits ([#465](git@github.com:paritytech/subxt/pull/465))
+- README updates ([#472](git@github.com:paritytech/subxt/pull/472))
+- Make EventSubscription and FilterEvents Send-able ([#471](git@github.com:paritytech/subxt/pull/471))
+
 ## [0.18.1] - 2022-03-04
 
 # Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Return events from blocks skipped over during Finalization, too ([#473](git@github.com:paritytech/subxt/pull/473))
-- Use RPC call to get account nonce ([#476](git@github.com:paritytech/subxt/pull/476))
-- Add script to generate release changelog based on commits ([#465](git@github.com:paritytech/subxt/pull/465))
-- README updates ([#472](git@github.com:paritytech/subxt/pull/472))
-- Make EventSubscription and FilterEvents Send-able ([#471](git@github.com:paritytech/subxt/pull/471))
+- Return events from blocks skipped over during Finalization, too ([#473](https://github.com/paritytech/subxt/pull/473))
+- Use RPC call to get account nonce ([#476](https://github.com/paritytech/subxt/pull/476))
+- Add script to generate release changelog based on commits ([#465](https://github.com/paritytech/subxt/pull/465))
+- README updates ([#472](https://github.com/paritytech/subxt/pull/472))
+- Make EventSubscription and FilterEvents Send-able ([#471](https://github.com/paritytech/subxt/pull/471))
 
 ## [0.18.1] - 2022-03-04
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subxt-cli"
-version = "0.18.1"
+version = "0.19.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 
@@ -16,7 +16,7 @@ path = "src/main.rs"
 
 [dependencies]
 # perform subxt codegen
-subxt-codegen = { version = "0.18.1", path = "../codegen" }
+subxt-codegen = { version = "0.19.0", path = "../codegen" }
 # parse command line args
 structopt = "0.3.25"
 # make the request to a substrate node to get the metadata

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subxt-codegen"
-version = "0.18.1"
+version = "0.19.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subxt-examples"
-version = "0.18.1"
+version = "0.19.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subxt-macro"
-version = "0.18.1"
+version = "0.19.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 autotests = false
@@ -27,7 +27,7 @@ quote = "1.0.8"
 syn = "1.0.58"
 scale-info = "2.0.0"
 
-subxt-codegen = { path = "../codegen", version = "0.18.1" }
+subxt-codegen = { path = "../codegen", version = "0.19.0" }
 
 [dev-dependencies]
 pretty_assertions = "1.0.0"

--- a/subxt/Cargo.toml
+++ b/subxt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subxt"
-version = "0.18.1"
+version = "0.19.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 
@@ -26,7 +26,7 @@ serde = { version = "1.0.124", features = ["derive"] }
 serde_json = "1.0.64"
 thiserror = "1.0.24"
 
-subxt-macro = { version = "0.18.1", path = "../macro" }
+subxt-macro = { version = "0.19.0", path = "../macro" }
 
 sp-core = { version = "6.0.0", default-features = false  }
 sp-runtime = "6.0.0"

--- a/test-runtime/Cargo.toml
+++ b/test-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test-runtime"
-version = "0.18.1"
+version = "0.19.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
#471 in-particular has come up a few times now, so the main impetus for this release is getting that out there, so that event subscriptions are able to be carried out in things like tokio tasks without hitting `Send` related issues.

Changes:

- Return events from blocks skipped over during Finalization, too ([#473](git@github.com:paritytech/subxt/pull/473))
- Use RPC call to get account nonce ([#476](git@github.com:paritytech/subxt/pull/476))
- Add script to generate release changelog based on commits ([#465](git@github.com:paritytech/subxt/pull/465))
- README updates ([#472](git@github.com:paritytech/subxt/pull/472))
- Make EventSubscription and FilterEvents Send-able ([#471](git@github.com:paritytech/subxt/pull/471))