### PR TITLE
Fix changelog script for consistent PR links

### DIFF
--- a/scripts/generate_changelog.sh
+++ b/scripts/generate_changelog.sh
@@ -4,6 +4,8 @@
 
 set -eu
 
+REMOTE_LINK="https://github.com/paritytech/subxt/pull/"
+
 function usage() {
     cat <<HELP_USAGE
 This script obtains the changelog between the latest release tag and origin/master.
@@ -37,8 +39,6 @@ GIT_BIN=$(which git) || log_error 'git is not installed. Please follow https://g
 # Generate the changelog between the provided tag and origin/master.
 function generate_changelog() {
     local tag="$1"
-    # From the remote origin url, get a link to pull requests.
-    remote_link=$($GIT_BIN config --get remote.origin.url | sed 's/\.git/\/pull\//g') || log_error 'Failed to get remote origin url'
 
     prs=$($GIT_BIN --no-pager log --pretty=format:"%s" "$tag"..origin/master) || log_error 'Failed to obtain commit list'
 
@@ -52,7 +52,7 @@ function generate_changelog() {
         fi
 
         # Generate a valid PR link.
-        pr_link="$remote_link$pr_number"
+        pr_link="$REMOTE_LINK$pr_number"
         # Generate the link as markdown.
         pr_md_link=" ([#$pr_number]($pr_link))"
         # Print the changelog line as `- commit-title pr-link`.


### PR DESCRIPTION
We have noted during the release preparation (#481 ) that the script utilized for generating the changelog can result in inconsistent links.

### Generated
```
- Return events from blocks skipped over during Finalization, too ([#473](git@github.com:paritytech/subxt/pull/473))
```

### Expected
```
- Return events from blocks skipped over during Finalization, too ([#473](https://github.com/paritytech/subxt/pull/473))
```

The issue is related to how the pull request link is parsed.
For now, place a hardcoded link for uniform changelogs.


### Testing Done

* `./scripts/generate_changelog.sh`

```
[+] Latest release tag: v0.18.1
[+] Changelog

- Use RPC call to get account nonce ([#476](https://github.com/paritytech/subxt/pull/476))
- Generate release changelog based on commits ([#465](https://github.com/paritytech/subxt/pull/465))
- Update README ([#472](https://github.com/paritytech/subxt/pull/472))
- Return events from blocks skipped over during Finalization, too ([#473](https://github.com/paritytech/subxt/pull/473))
- Make EventSubscription and FilterEvents Send-able ([#471](https://github.com/paritytech/subxt/pull/471))
```

* `shellcheck ./scripts/generate_changelog.sh`