### PR TITLE
Use tokio instead of async-std

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -13,7 +13,7 @@ description = "Subxt example usage"
 
 [dev-dependencies]
 subxt = { path = "../subxt" }
-async-std = { version = "1.9.0", features = ["attributes", "tokio1"] }
+tokio = { version = "1.8", features = ["full"] }
 sp-keyring = "6.0.0"
 env_logger = "0.9.0"
 futures = "0.3.13"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -13,7 +13,7 @@ description = "Subxt example usage"
 
 [dev-dependencies]
 subxt = { path = "../subxt" }
-tokio = { version = "1.8", features = ["full"] }
+tokio = { version = "1.8", features = ["rt-multi-thread", "macros", "time"] }
 sp-keyring = "6.0.0"
 env_logger = "0.9.0"
 futures = "0.3.13"

--- a/examples/examples/balance_transfer.rs
+++ b/examples/examples/balance_transfer.rs
@@ -33,7 +33,7 @@ use subxt::{
 #[subxt::subxt(runtime_metadata_path = "examples/polkadot_metadata.scale")]
 pub mod polkadot {}
 
-#[async_std::main]
+#[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
 

--- a/examples/examples/balance_transfer_with_params.rs
+++ b/examples/examples/balance_transfer_with_params.rs
@@ -38,7 +38,7 @@ use subxt::{
 #[subxt::subxt(runtime_metadata_path = "examples/polkadot_metadata.scale")]
 pub mod polkadot {}
 
-#[async_std::main]
+#[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
 

--- a/examples/examples/custom_config.rs
+++ b/examples/examples/custom_config.rs
@@ -55,7 +55,7 @@ impl Config for MyConfig {
     type Extrinsic = <DefaultConfig as Config>::Extrinsic;
 }
 
-#[async_std::main]
+#[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let api = ClientBuilder::new()
         .build()

--- a/examples/examples/custom_type_derives.rs
+++ b/examples/examples/custom_type_derives.rs
@@ -30,7 +30,7 @@ pub mod polkadot {}
 
 use polkadot::runtime_types::frame_support::PalletId;
 
-#[async_std::main]
+#[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let pallet_id = PalletId([1u8; 8]);
     let _ = pallet_id.clone();

--- a/examples/examples/fetch_all_accounts.rs
+++ b/examples/examples/fetch_all_accounts.rs
@@ -31,7 +31,7 @@ use subxt::{
 #[subxt::subxt(runtime_metadata_path = "examples/polkadot_metadata.scale")]
 pub mod polkadot {}
 
-#[async_std::main]
+#[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
 

--- a/examples/examples/fetch_staking_details.rs
+++ b/examples/examples/fetch_staking_details.rs
@@ -37,7 +37,7 @@ use subxt::{
 #[subxt::subxt(runtime_metadata_path = "examples/polkadot_metadata.scale")]
 pub mod polkadot {}
 
-#[async_std::main]
+#[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
 

--- a/examples/examples/rpc_call.rs
+++ b/examples/examples/rpc_call.rs
@@ -31,7 +31,7 @@ use subxt::{
 #[subxt::subxt(runtime_metadata_path = "examples/polkadot_metadata.scale")]
 pub mod polkadot {}
 
-#[async_std::main]
+#[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
 

--- a/examples/examples/submit_and_watch.rs
+++ b/examples/examples/submit_and_watch.rs
@@ -34,7 +34,7 @@ use subxt::{
 #[subxt::subxt(runtime_metadata_path = "examples/polkadot_metadata.scale")]
 pub mod polkadot {}
 
-#[async_std::main]
+#[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
 

--- a/examples/examples/subscribe_all_events.rs
+++ b/examples/examples/subscribe_all_events.rs
@@ -37,7 +37,7 @@ pub mod polkadot {}
 
 /// Subscribe to all events, and then manually look through them and
 /// pluck out the events that we care about.
-#[async_std::main]
+#[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
 
@@ -50,7 +50,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut event_sub = api.events().subscribe().await?;
 
     // While this subscription is active, balance transfers are made somewhere:
-    async_std::task::spawn(async {
+    tokio::task::spawn(async {
         let signer = PairSigner::new(AccountKeyring::Alice.pair());
         let api =
             ClientBuilder::new()
@@ -73,7 +73,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .await
                 .unwrap();
 
-            async_std::task::sleep(Duration::from_secs(10)).await;
+            tokio::time::sleep(Duration::from_secs(10)).await;
             transfer_amount += 100_000_000;
         }
     });

--- a/examples/examples/subscribe_one_event.rs
+++ b/examples/examples/subscribe_one_event.rs
@@ -37,7 +37,7 @@ pub mod polkadot {}
 
 /// Subscribe to all events, and then manually look through them and
 /// pluck out the events that we care about.
-#[async_std::main]
+#[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
 
@@ -56,7 +56,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .filter_events::<(polkadot::balances::events::Transfer,)>();
 
     // While this subscription is active, we imagine some balance transfers are made somewhere else:
-    async_std::task::spawn(async {
+    tokio::task::spawn(async {
         let signer = PairSigner::new(AccountKeyring::Alice.pair());
         let api =
             ClientBuilder::new()
@@ -76,7 +76,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .sign_and_submit_default(&signer)
                 .await
                 .unwrap();
-            async_std::task::sleep(Duration::from_secs(10)).await;
+            tokio::time::sleep(Duration::from_secs(10)).await;
         }
     });
 

--- a/examples/examples/subscribe_some_events.rs
+++ b/examples/examples/subscribe_some_events.rs
@@ -37,7 +37,7 @@ pub mod polkadot {}
 
 /// Subscribe to all events, and then manually look through them and
 /// pluck out the events that we care about.
-#[async_std::main]
+#[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
 
@@ -57,7 +57,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     )>();
 
     // While this subscription is active, we imagine some balance transfers are made somewhere else:
-    async_std::task::spawn(async {
+    tokio::task::spawn(async {
         let signer = PairSigner::new(AccountKeyring::Alice.pair());
         let api =
             ClientBuilder::new()
@@ -77,7 +77,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .sign_and_submit_default(&signer)
                 .await
                 .unwrap();
-            async_std::task::sleep(Duration::from_secs(10)).await;
+            tokio::time::sleep(Duration::from_secs(10)).await;
         }
     });
 

--- a/subxt/Cargo.toml
+++ b/subxt/Cargo.toml
@@ -37,7 +37,7 @@ derivative = "2.2.0"
 [dev-dependencies]
 sp-arithmetic = { version = "5.0.0", default-features = false }
 assert_matches = "1.5.0"
-async-std = { version = "1.9.0", features = ["attributes", "tokio1"] }
+tokio = { version = "1.8", features = ["macros", "time"] }
 env_logger = "0.9.0"
 tempdir = "0.3.7"
 wabt = "0.10.0"

--- a/subxt/src/events/filter_events.rs
+++ b/subxt/src/events/filter_events.rs
@@ -326,7 +326,7 @@ mod test {
         .map(Ok::<_, BasicError>)
     }
 
-    #[async_std::test]
+    #[tokio::test]
     async fn filter_one_event_from_stream() {
         let metadata = metadata::<PalletEvents>();
 
@@ -358,7 +358,7 @@ mod test {
         assert_eq!(actual, expected);
     }
 
-    #[async_std::test]
+    #[tokio::test]
     async fn filter_some_events_from_stream() {
         let metadata = metadata::<PalletEvents>();
 
@@ -406,7 +406,7 @@ mod test {
         assert_eq!(actual, expected);
     }
 
-    #[async_std::test]
+    #[tokio::test]
     async fn filter_no_events_from_stream() {
         let metadata = metadata::<PalletEvents>();
 

--- a/subxt/tests/integration/client.rs
+++ b/subxt/tests/integration/client.rs
@@ -26,7 +26,7 @@ use sp_core::storage::{
 };
 use sp_keyring::AccountKeyring;
 
-#[async_std::test]
+#[tokio::test]
 async fn insert_key() {
     let test_node_process = test_node_process_with(AccountKeyring::Bob).await;
     let client = test_node_process.client();
@@ -47,13 +47,13 @@ async fn insert_key() {
         .unwrap());
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn fetch_block_hash() {
     let node_process = test_node_process().await;
     node_process.client().rpc().block_hash(None).await.unwrap();
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn fetch_block() {
     let node_process = test_node_process().await;
     let client = node_process.client();
@@ -61,7 +61,7 @@ async fn fetch_block() {
     client.rpc().block(block_hash).await.unwrap();
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn fetch_read_proof() {
     let node_process = test_node_process().await;
     let client = node_process.client();
@@ -79,7 +79,7 @@ async fn fetch_read_proof() {
         .unwrap();
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn chain_subscribe_blocks() {
     let node_process = test_node_process().await;
     let client = node_process.client();
@@ -87,7 +87,7 @@ async fn chain_subscribe_blocks() {
     blocks.next().await.unwrap().unwrap();
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn chain_subscribe_finalized_blocks() {
     let node_process = test_node_process().await;
     let client = node_process.client();
@@ -95,7 +95,7 @@ async fn chain_subscribe_finalized_blocks() {
     blocks.next().await.unwrap().unwrap();
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn fetch_keys() {
     let node_process = test_node_process().await;
     let client = node_process.client();
@@ -107,7 +107,7 @@ async fn fetch_keys() {
     assert_eq!(keys.len(), 4)
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn test_iter() {
     let node_process = test_node_process().await;
     let client = node_process.client();
@@ -123,7 +123,7 @@ async fn test_iter() {
     assert_eq!(i, 13);
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn fetch_system_info() {
     let node_process = test_node_process().await;
     let client = node_process.client();

--- a/subxt/tests/integration/events.rs
+++ b/subxt/tests/integration/events.rs
@@ -26,7 +26,7 @@ use futures::StreamExt;
 use sp_keyring::AccountKeyring;
 
 // Check that we can subscribe to non-finalized block events.
-#[async_std::test]
+#[tokio::test]
 async fn non_finalized_block_subscription() -> Result<(), subxt::BasicError> {
     env_logger::try_init().ok();
     let ctx = test_context().await;
@@ -44,7 +44,7 @@ async fn non_finalized_block_subscription() -> Result<(), subxt::BasicError> {
 }
 
 // Check that we can subscribe to finalized block events.
-#[async_std::test]
+#[tokio::test]
 async fn finalized_block_subscription() -> Result<(), subxt::BasicError> {
     env_logger::try_init().ok();
     let ctx = test_context().await;
@@ -64,7 +64,7 @@ async fn finalized_block_subscription() -> Result<(), subxt::BasicError> {
 
 // Check that our subscription actually keeps producing events for
 // a few blocks.
-#[async_std::test]
+#[tokio::test]
 async fn subscription_produces_events_each_block() -> Result<(), subxt::BasicError> {
     env_logger::try_init().ok();
     let ctx = test_context().await;
@@ -93,7 +93,7 @@ async fn subscription_produces_events_each_block() -> Result<(), subxt::BasicErr
 
 // Check that our subscription receives events, and we can filter them based on
 // it's Stream impl, and ultimately see the event we expect.
-#[async_std::test]
+#[tokio::test]
 async fn balance_transfer_subscription() -> Result<(), subxt::BasicError> {
     env_logger::try_init().ok();
     let ctx = test_context().await;
@@ -135,7 +135,7 @@ async fn balance_transfer_subscription() -> Result<(), subxt::BasicError> {
     Ok(())
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn missing_block_headers_will_be_filled_in() -> Result<(), subxt::BasicError> {
     // This function is not publically available to use, but contains
     // the key logic for filling in missing blocks, so we want to test it.
@@ -194,7 +194,7 @@ async fn missing_block_headers_will_be_filled_in() -> Result<(), subxt::BasicErr
 #[allow(unused)]
 async fn check_events_are_sendable() {
     // check that EventSubscription can be used across await points.
-    async_std::task::spawn(async {
+    tokio::task::spawn(async {
         let ctx = test_context().await;
 
         let mut event_sub = ctx.api.events().subscribe().await?;
@@ -209,7 +209,7 @@ async fn check_events_are_sendable() {
     });
 
     // Check that FilterEvents can be used across await points.
-    async_std::task::spawn(async {
+    tokio::task::spawn(async {
         let ctx = test_context().await;
 
         let mut event_sub = ctx

--- a/subxt/tests/integration/frame/balances.rs
+++ b/subxt/tests/integration/frame/balances.rs
@@ -36,7 +36,7 @@ use sp_runtime::{
 };
 use subxt::Error;
 
-#[async_std::test]
+#[tokio::test]
 async fn tx_basic_transfer() -> Result<(), subxt::Error<DispatchError>> {
     let alice = pair_signer(AccountKeyring::Alice.pair());
     let bob = pair_signer(AccountKeyring::Bob.pair());
@@ -95,7 +95,7 @@ async fn tx_basic_transfer() -> Result<(), subxt::Error<DispatchError>> {
     Ok(())
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn multiple_transfers_work_nonce_incremented(
 ) -> Result<(), subxt::Error<DispatchError>> {
     let alice = pair_signer(AccountKeyring::Alice.pair());
@@ -133,7 +133,7 @@ async fn multiple_transfers_work_nonce_incremented(
     Ok(())
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn storage_total_issuance() {
     let cxt = test_context().await;
     let total_issuance = cxt
@@ -146,7 +146,7 @@ async fn storage_total_issuance() {
     assert_ne!(total_issuance, 0);
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn storage_balance_lock() -> Result<(), subxt::Error<DispatchError>> {
     let bob = pair_signer(AccountKeyring::Bob.pair());
     let charlie = AccountKeyring::Charlie.to_account_id();
@@ -187,7 +187,7 @@ async fn storage_balance_lock() -> Result<(), subxt::Error<DispatchError>> {
     Ok(())
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn transfer_error() {
     env_logger::try_init().ok();
     let alice = pair_signer(AccountKeyring::Alice.pair());
@@ -226,7 +226,7 @@ async fn transfer_error() {
     }
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn transfer_implicit_subscription() {
     env_logger::try_init().ok();
     let alice = pair_signer(AccountKeyring::Alice.pair());
@@ -259,7 +259,7 @@ async fn transfer_implicit_subscription() {
     );
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn constant_existential_deposit() {
     let cxt = test_context().await;
     let balances_metadata = cxt.client().metadata().pallet("Balances").unwrap();

--- a/subxt/tests/integration/frame/contracts.rs
+++ b/subxt/tests/integration/frame/contracts.rs
@@ -170,7 +170,7 @@ impl ContractsTestContext {
     }
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn tx_instantiate_with_code() {
     let ctx = ContractsTestContext::init().await;
     let result = ctx.instantiate_with_code().await;
@@ -182,7 +182,7 @@ async fn tx_instantiate_with_code() {
     );
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn tx_instantiate() {
     let ctx = ContractsTestContext::init().await;
     let (code_hash, _) = ctx.instantiate_with_code().await.unwrap();
@@ -196,7 +196,7 @@ async fn tx_instantiate() {
     );
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn tx_call() {
     let cxt = ContractsTestContext::init().await;
     let (_, contract) = cxt.instantiate_with_code().await.unwrap();

--- a/subxt/tests/integration/frame/staking.rs
+++ b/subxt/tests/integration/frame/staking.rs
@@ -47,7 +47,7 @@ fn default_validator_prefs() -> ValidatorPrefs {
     }
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn validate_with_controller_account() {
     let alice = pair_signer(AccountKeyring::Alice.pair());
     let ctx = test_context().await;
@@ -63,7 +63,7 @@ async fn validate_with_controller_account() {
         .expect("should be successful");
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn validate_not_possible_for_stash_account() -> Result<(), Error<DispatchError>> {
     let alice_stash = pair_signer(get_from_seed("Alice//stash"));
     let ctx = test_context().await;
@@ -83,7 +83,7 @@ async fn validate_not_possible_for_stash_account() -> Result<(), Error<DispatchE
     Ok(())
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn nominate_with_controller_account() {
     let alice = pair_signer(AccountKeyring::Alice.pair());
     let bob = pair_signer(AccountKeyring::Bob.pair());
@@ -101,7 +101,7 @@ async fn nominate_with_controller_account() {
         .expect("should be successful");
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn nominate_not_possible_for_stash_account() -> Result<(), Error<DispatchError>> {
     let alice_stash = pair_signer(get_from_seed("Alice//stash"));
     let bob = pair_signer(AccountKeyring::Bob.pair());
@@ -124,7 +124,7 @@ async fn nominate_not_possible_for_stash_account() -> Result<(), Error<DispatchE
     Ok(())
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn chill_works_for_controller_only() -> Result<(), Error<DispatchError>> {
     let alice_stash = pair_signer(get_from_seed("Alice//stash"));
     let bob_stash = pair_signer(get_from_seed("Bob//stash"));
@@ -180,7 +180,7 @@ async fn chill_works_for_controller_only() -> Result<(), Error<DispatchError>> {
     Ok(())
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn tx_bond() -> Result<(), Error<DispatchError>> {
     let alice = pair_signer(AccountKeyring::Alice.pair());
     let ctx = test_context().await;
@@ -222,7 +222,7 @@ async fn tx_bond() -> Result<(), Error<DispatchError>> {
     Ok(())
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn storage_history_depth() -> Result<(), Error<DispatchError>> {
     let ctx = test_context().await;
     let history_depth = ctx.api.storage().staking().history_depth(None).await?;
@@ -230,7 +230,7 @@ async fn storage_history_depth() -> Result<(), Error<DispatchError>> {
     Ok(())
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn storage_current_era() -> Result<(), Error<DispatchError>> {
     let ctx = test_context().await;
     let _current_era = ctx
@@ -243,7 +243,7 @@ async fn storage_current_era() -> Result<(), Error<DispatchError>> {
     Ok(())
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn storage_era_reward_points() -> Result<(), Error<DispatchError>> {
     let cxt = test_context().await;
     let current_era_result = cxt

--- a/subxt/tests/integration/frame/sudo.rs
+++ b/subxt/tests/integration/frame/sudo.rs
@@ -28,7 +28,7 @@ use sp_keyring::AccountKeyring;
 type Call = runtime_types::node_runtime::Call;
 type BalancesCall = runtime_types::pallet_balances::pallet::Call;
 
-#[async_std::test]
+#[tokio::test]
 async fn test_sudo() -> Result<(), subxt::Error<DispatchError>> {
     let alice = pair_signer(AccountKeyring::Alice.pair());
     let bob = AccountKeyring::Bob.to_account_id().into();
@@ -54,7 +54,7 @@ async fn test_sudo() -> Result<(), subxt::Error<DispatchError>> {
     Ok(())
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn test_sudo_unchecked_weight() -> Result<(), subxt::Error<DispatchError>> {
     let alice = pair_signer(AccountKeyring::Alice.pair());
     let bob = AccountKeyring::Bob.to_account_id().into();

--- a/subxt/tests/integration/frame/system.rs
+++ b/subxt/tests/integration/frame/system.rs
@@ -25,7 +25,7 @@ use crate::{
 use assert_matches::assert_matches;
 use sp_keyring::AccountKeyring;
 
-#[async_std::test]
+#[tokio::test]
 async fn storage_account() -> Result<(), subxt::Error<DispatchError>> {
     let alice = pair_signer(AccountKeyring::Alice.pair());
 
@@ -41,7 +41,7 @@ async fn storage_account() -> Result<(), subxt::Error<DispatchError>> {
     Ok(())
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn tx_remark_with_event() -> Result<(), subxt::Error<DispatchError>> {
     let alice = pair_signer(AccountKeyring::Alice.pair());
     let cxt = test_context().await;

--- a/subxt/tests/integration/frame/timestamp.rs
+++ b/subxt/tests/integration/frame/timestamp.rs
@@ -16,7 +16,7 @@
 
 use crate::test_context;
 
-#[async_std::test]
+#[tokio::test]
 async fn storage_get_current_timestamp() {
     let cxt = test_context().await;
 

--- a/subxt/tests/integration/storage.rs
+++ b/subxt/tests/integration/storage.rs
@@ -24,20 +24,20 @@ use crate::{
 };
 use sp_keyring::AccountKeyring;
 
-#[async_std::test]
+#[tokio::test]
 async fn storage_plain_lookup() -> Result<(), subxt::Error<DispatchError>> {
     let ctx = test_context().await;
 
     // Look up a plain value. Wait long enough that we don't get the genesis block data,
     // because it may have no storage associated with it.
-    async_std::task::sleep(std::time::Duration::from_secs(6)).await;
+    tokio::time::sleep(std::time::Duration::from_secs(6)).await;
     let entry = ctx.api.storage().timestamp().now(None).await?;
     assert!(entry > 0);
 
     Ok(())
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn storage_map_lookup() -> Result<(), subxt::Error<DispatchError>> {
     let ctx = test_context().await;
 
@@ -65,7 +65,7 @@ async fn storage_map_lookup() -> Result<(), subxt::Error<DispatchError>> {
 // Here we create a key that looks a bit like a StorageNMap key, but should in fact be
 // treated as a StorageKey (ie we should hash both values together with one hasher, rather
 // than hash both values separately, or ignore the second value).
-#[async_std::test]
+#[tokio::test]
 async fn storage_n_mapish_key_is_properly_created(
 ) -> Result<(), subxt::Error<DispatchError>> {
     use codec::Encode;
@@ -100,7 +100,7 @@ async fn storage_n_mapish_key_is_properly_created(
     Ok(())
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn storage_n_map_storage_lookup() -> Result<(), subxt::Error<DispatchError>> {
     let ctx = test_context().await;
 

--- a/test-runtime/Cargo.toml
+++ b/test-runtime/Cargo.toml
@@ -11,5 +11,5 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
 [build-dependencies]
 subxt = { path = "../subxt" }
 sp-core = "6.0.0"
-async-std = { version = "1.9.0", features = ["attributes", "tokio1"] }
+tokio = { version = "1.8", features = ["rt", "macros"] }
 which = "4.2.2"

--- a/test-runtime/build.rs
+++ b/test-runtime/build.rs
@@ -38,7 +38,7 @@ use subxt::rpc::{
 
 static SUBSTRATE_BIN_ENV_VAR: &str = "SUBSTRATE_NODE_PATH";
 
-#[async_std::main]
+#[tokio::main]
 async fn main() {
     run().await;
 }


### PR DESCRIPTION
Remove the `async-std` dependency and utilize `tokio` instead.
This is motivated by the fact that `jsonrpsee` utilizes under the hood `tokio`.

Closes #485.
 