### PR TITLE
Rely on the kernel for port allocation

### DIFF
--- a/subxt/tests/integration/utils/node_proc.rs
+++ b/subxt/tests/integration/utils/node_proc.rs
@@ -212,7 +212,8 @@ fn next_open_port() -> Option<(u16, u16, u16)> {
             Ordering::SeqCst,
         );
         let next = PORT.fetch_add(1, Ordering::SeqCst);
-        if TcpListener::bind(("0.0.0.0", next)).is_ok() {
+        // Bind to localhost address to find an available port.
+        if TcpListener::bind(("127.0.0.1", next)).is_ok() {
             ports.push(next);
             if ports.len() == 3 {
                 return Some((ports[0], ports[1], ports[2]))

--- a/test-runtime/build.rs
+++ b/test-runtime/build.rs
@@ -158,7 +158,7 @@ fn next_open_port() -> Option<u16> {
             Ordering::SeqCst,
         );
         let next = next_port.fetch_add(1, Ordering::SeqCst);
-        if TcpListener::bind(("0.0.0.0", next)).is_ok() {
+        if TcpListener::bind(("127.0.0.1", next)).is_ok() {
             return Some(next)
         }
         ports_scanned += 1;

--- a/test-runtime/build.rs
+++ b/test-runtime/build.rs
@@ -24,10 +24,6 @@ use std::{
     },
     path::Path,
     process::Command,
-    sync::atomic::{
-        AtomicU16,
-        Ordering,
-    },
     thread,
     time,
 };
@@ -49,8 +45,7 @@ async fn run() {
         env::var(SUBSTRATE_BIN_ENV_VAR).unwrap_or_else(|_| "substrate".to_owned());
 
     // Run binary.
-    let port = next_open_port()
-        .expect("Cannot spawn substrate: no available ports in the given port range");
+    let port = next_open_port().expect("Cannot spawn substrate: no available ports");
     let cmd = Command::new(&substrate_bin)
         .arg("--dev")
         .arg("--tmp")
@@ -138,33 +133,17 @@ async fn run() {
     println!("cargo:rerun-if-changed=build.rs");
 }
 
-/// Returns the next open port, or None if no port found in range.
+/// Returns the next open port, or None if no port found.
 fn next_open_port() -> Option<u16> {
-    /// The start of the port range to scan.
-    const START_PORT: u16 = 9900;
-    /// The end of the port range to scan.
-    const END_PORT: u16 = 10000;
-    /// The maximum number of ports to scan before giving up.
-    const MAX_PORTS: u16 = 1000;
-
-    let next_port: AtomicU16 = AtomicU16::new(START_PORT);
-    let mut ports_scanned = 0u16;
-    loop {
-        // Loop back from the beginning if needed
-        let _ = next_port.compare_exchange(
-            END_PORT,
-            START_PORT,
-            Ordering::SeqCst,
-            Ordering::SeqCst,
-        );
-        let next = next_port.fetch_add(1, Ordering::SeqCst);
-        if TcpListener::bind(("127.0.0.1", next)).is_ok() {
-            return Some(next)
+    match TcpListener::bind(("127.0.0.1", 0)) {
+        Ok(listener) => {
+            if let Ok(address) = listener.local_addr() {
+                Some(address.port())
+            } else {
+                None
+            }
         }
-        ports_scanned += 1;
-        if ports_scanned == MAX_PORTS {
-            return None
-        }
+        Err(_) => None,
     }
 }
 


### PR DESCRIPTION
The testing infrastructure requires that a `substrate` binary is present for individual testing.
However, having a different `polkadot` binary running resulted in failing tests.

### Root Cause

The function `next_open_port()` in `subxt` crate produced 3 port numbers by inspecting
a range of ports. 
To validate that a given port is opened the `TcpListener::bind(("0.0.0.0", 0))` bind call is executed.
However, the address "0.0.0.0" is not representative of the localhost, but of a non-routable unknown address.

This observation is validated using the `polkadot` binary which starts by default on `127.0.0.1:9944`. Any `TcpListener::bind(("0.0.0.0", 0))` will result in success even with the binary started.

### Port Allocation

While at it, remove the scanning logic and rely entirely on the Kernel to provide 3 available ports.
The port allocation is performed by the [inet_csk_get_port()](https://elixir.bootlin.com/linux/v5.8/source/net/ipv4/inet_connection_sock.c#L303) function.
When providing a zero port, asking for allocation, the code path goes to [inet_csk_find_open_port()](https://elixir.bootlin.com/linux/v5.8/source/net/ipv4/inet_connection_sock.c#L182).
A port scanning is performed that uses a spinlock for concurrent access with the addition of checking for bind conflicts.

The kernel should provide 3 different ports if they are available. 

### Testing Done
Started 100 threads, each requesting for 100 new ports. Multiple runs of the binary presented no duplicates.
However, when requesting more ports than available (ie from 1000 threads), the ports are reutilized and values eventually wrap from `net.inet.ip.portrange.last` to `net.inet.ip.portrange.first`.

Closes #497.