### PR TITLE
export ModuleError for downstream matching

### DIFF
--- a/subxt/src/lib.rs
+++ b/subxt/src/lib.rs
@@ -81,6 +81,7 @@ pub use crate::{
         Error,
         GenericError,
         HasModuleError,
+        ModuleError,
         ModuleErrorData,
         RuntimeError,
         TransactionError,


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

Without this we cannot match on error variants produced by calls.