### PR TITLE
Tests: parse port from substrate binary output to avoid races

### DIFF
--- a/subxt/tests/integration/utils/context.rs
+++ b/subxt/tests/integration/utils/context.rs
@@ -46,7 +46,6 @@ pub async fn test_node_process_with(
 
     let proc = TestNodeProcess::<DefaultConfig>::build(path.as_str())
         .with_authority(key)
-        .scan_for_open_ports()
         .spawn::<DefaultConfig>()
         .await;
     proc.unwrap()

--- a/subxt/tests/integration/utils/node_proc.rs
+++ b/subxt/tests/integration/utils/node_proc.rs
@@ -20,6 +20,11 @@ use std::{
         OsStr,
         OsString,
     },
+    io::{
+        BufRead,
+        BufReader,
+        Read,
+    },
     process,
 };
 use subxt::{
@@ -27,7 +32,6 @@ use subxt::{
     ClientBuilder,
     Config,
 };
-use std::io::{ Read, BufRead, BufReader };
 
 /// Spawn a local substrate node for testing subxt.
 pub struct TestNodeProcess<R: Config> {
@@ -135,10 +139,7 @@ impl TestNodeProcessBuilder {
         match client {
             Ok(client) => Ok(TestNodeProcess { proc, client }),
             Err(err) => {
-                let err = format!(
-                    "Failed to connect to node rpc at {}: {}",
-                    ws_url, err
-                );
+                let err = format!("Failed to connect to node rpc at {}: {}", ws_url, err);
                 log::error!("{}", err);
                 proc.kill().map_err(|e| {
                     format!("Error killing substrate process '{}': {}", proc.id(), e)

--- a/subxt/tests/integration/utils/node_proc.rs
+++ b/subxt/tests/integration/utils/node_proc.rs
@@ -171,7 +171,7 @@ fn find_substrate_port_from_output(r: impl Read + Send + 'static) -> u16 {
             // expect to have a number here (the chars after '127.0.0.1:') and parse them into a u16.
             let port_num = port_str
                 .parse()
-                .expect(&format!("valid port expected on 'Listening for new connecitons' line, got '{port_str}'"));
+                .unwrap_or_else(|_| panic!("valid port expected on 'Listening for new connections' line, got '{port_str}'"));
 
             Some(port_num)
         })

--- a/test-runtime/Cargo.toml
+++ b/test-runtime/Cargo.toml
@@ -11,5 +11,5 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
 [build-dependencies]
 subxt = { path = "../subxt" }
 sp-core = "6.0.0"
-tokio = { version = "1.8", features = ["rt", "macros", "rt-multi-thread"] }
+tokio = { version = "1.8", features = ["macros", "rt-multi-thread"] }
 which = "4.2.2"

--- a/test-runtime/Cargo.toml
+++ b/test-runtime/Cargo.toml
@@ -11,5 +11,5 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
 [build-dependencies]
 subxt = { path = "../subxt" }
 sp-core = "6.0.0"
-tokio = { version = "1.8", features = ["rt", "macros"] }
+tokio = { version = "1.8", features = ["rt", "macros", "rt-multi-thread"] }
 which = "4.2.2"


### PR DESCRIPTION
Start the binary with port=0 and parse out the actual port number it starts on from its output. This (hopefully) avoids any races between finding and makign use of available ports. It also has the nice side effect of avoiding the need for any arbitrary sleeping to wait for the RPC server to start up.