### PR TITLE
test-runtime: Add exponential backoff

### DIFF
--- a/test-runtime/build.rs
+++ b/test-runtime/build.rs
@@ -64,7 +64,7 @@ async fn run() {
 
     // Download metadata from binary; retry until successful, or a limit is hit.
     let metadata_bytes: sp_core::Bytes = {
-        const MAX_RETRIES: usize = 20;
+        const MAX_RETRIES: usize = 6;
         let mut retries = 0;
 
         loop {
@@ -85,7 +85,7 @@ async fn run() {
                     break res
                 }
                 _ => {
-                    thread::sleep(time::Duration::from_secs(1));
+                    thread::sleep(time::Duration::from_secs(1 << retries));
                     retries += 1;
                 }
             };


### PR DESCRIPTION
The PR ensures that the `test-runtime`' can fetch the metadata from the spawned substrate binary.

Closes #517.