### PR TITLE
Use minimum amount of dependencies for crates 

### DIFF
--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -11,18 +11,15 @@ homepage = "https://www.parity.io/"
 description = "Generate an API for interacting with a substrate node from FRAME metadata"
 
 [dependencies]
-async-trait = "0.1.49"
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full", "bit-vec"] }
 darling = "0.14.0"
 frame-metadata = "15.0.0"
 heck = "0.4.0"
 proc-macro2 = "1.0.24"
-proc-macro-crate = "0.1.5"
 proc-macro-error = "1.0.4"
 quote = "1.0.8"
 syn = "1.0.58"
 scale-info = { version = "2.0.0", features = ["bit-vec"] }
-sp-core = { version = "6.0.0"  }
 subxt-metadata = { version = "0.20.0", path = "../metadata" }
 
 [dev-dependencies]

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -15,16 +15,8 @@ description = "Generate types and helpers for interacting with Substrate runtime
 proc-macro = true
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full"] }
 darling = "0.14.0"
 proc-macro-error = "1.0.4"
-quote = "1.0.8"
 syn = "1.0.58"
 
 subxt-codegen = { path = "../codegen", version = "0.20.0" }
-
-[dev-dependencies]
-pretty_assertions = "1.0.0"
-subxt = { path = "../subxt" }
-trybuild = "1.0.38"
-sp-keyring = "6.0.0"

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -15,17 +15,11 @@ description = "Generate types and helpers for interacting with Substrate runtime
 proc-macro = true
 
 [dependencies]
-async-trait = "0.1.49"
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full"] }
 darling = "0.14.0"
-frame-metadata = "15.0.0"
-heck = "0.4.0"
-proc-macro2 = "1.0.24"
-proc-macro-crate = "0.1.5"
 proc-macro-error = "1.0.4"
 quote = "1.0.8"
 syn = "1.0.58"
-scale-info = "2.0.0"
 
 subxt-codegen = { path = "../codegen", version = "0.20.0" }
 

--- a/subxt/Cargo.toml
+++ b/subxt/Cargo.toml
@@ -13,10 +13,8 @@ description = "Submit extrinsics (transactions) to a substrate node via RPC"
 keywords = ["parity", "substrate", "blockchain"]
 
 [dependencies]
-async-trait = "0.1.49"
 bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full", "bit-vec"] }
-chameleon = "0.1.0"
 scale-info = { version = "2.0.0", features = ["bit-vec"] }
 futures = "0.3.13"
 hex = "0.4.3"


### PR DESCRIPTION
Reduce the number of dependencies for isolated crates.
This will greatly benefit developers that want to work with a subset of
`subxt` crates, as redundant crates are no longer included in the `Cargo.toml`.

One real benefit of the trimming of dependencies is the `chameleon` crate.