### PR TITLE
fix: Find substrate port on different log lines

### DIFF
--- a/integration-tests/src/utils/node_proc.rs
+++ b/integration-tests/src/utils/node_proc.rs
@@ -168,22 +168,30 @@ fn find_substrate_port_from_output(r: impl Read + Send + 'static) -> u16 {
     BufReader::new(r)
         .lines()
         .find_map(|line| {
-            let line = line
-                .expect("failed to obtain next line from stdout for port discovery");
+            let line =
+                line.expect("failed to obtain next line from stdout for port discovery");
 
             // does the line contain our port (we expect this specific output from substrate).
-            let line_end = match line.rsplit_once("Listening for new connections on 127.0.0.1:") {
-                None => return None,
-                Some((_, after)) => after
+            let line_end = match line
+                .rsplit_once("Listening for new connections on 127.0.0.1:")
+            {
+                None => {
+                    match line.rsplit_once("Running JSON-RPC WS server: addr=127.0.0.1:")
+                    {
+                        None => return None,
+                        Some((_, after)) => after,
+                    }
+                }
+                Some((_, after)) => after,
             };
 
             // trim non-numeric chars from the end of the port part of the line.
             let port_str = line_end.trim_end_matches(|b| !('0'..='9').contains(&b));
 
             // expect to have a number here (the chars after '127.0.0.1:') and parse them into a u16.
-            let port_num = port_str
-                .parse()
-                .unwrap_or_else(|_| panic!("valid port expected on 'Listening for new connections' line, got '{port_str}'"));
+            let port_num = port_str.parse().unwrap_or_else(|_| {
+                panic!("valid port expected for log line, got '{port_str}'")
+            });
 
             Some(port_num)
         })


### PR DESCRIPTION
Updating `substrate` node to the latest version would result in an infinite loop for our integration testing.

The root cause of this issue is that the `substrate` switched to json-rpsee.
This included changing the log message we are looking for when finding the port of the substrate.

Ensure that the port can be obtained from both new and old versions of the substrate node.

### Testing Done

#### Before
```
test client::chain_subscribe_blocks has been running for over 60 seconds
test client::chain_subscribe_finalized_blocks has been running for over 60 seconds
test client::fetch_block has been running for over 60 seconds
```

### After

```
test client::chain_subscribe_finalized_blocks ... ok
test client::fetch_block ... ok
test client::chain_subscribe_blocks ... ok
test client::fetch_read_proof ... ok
```