### PR TITLE
Fix clippy for holding locks between multiple awaits

### DIFF
--- a/integration-tests/src/metadata/validation.rs
+++ b/integration-tests/src/metadata/validation.rs
@@ -76,9 +76,11 @@ async fn full_metadata_check() {
     assert!(api.validate_metadata().is_ok());
 
     // Modify the metadata.
-    let locked_client_metadata = api.client.metadata();
-    let client_metadata = locked_client_metadata.read();
-    let mut metadata: RuntimeMetadataV14 = client_metadata.runtime_metadata().clone();
+    let mut metadata: RuntimeMetadataV14 = {
+        let locked_client_metadata = api.client.metadata();
+        let client_metadata = locked_client_metadata.read();
+        client_metadata.runtime_metadata().clone()
+    };
     metadata.pallets[0].name = "NewPallet".to_string();
 
     let new_api = metadata_to_api(metadata, &cxt).await;
@@ -100,9 +102,11 @@ async fn constants_check() {
     assert!(cxt.api.constants().balances().existential_deposit().is_ok());
 
     // Modify the metadata.
-    let locked_client_metadata = api.client.metadata();
-    let client_metadata = locked_client_metadata.read();
-    let mut metadata: RuntimeMetadataV14 = client_metadata.runtime_metadata().clone();
+    let mut metadata: RuntimeMetadataV14 = {
+        let locked_client_metadata = api.client.metadata();
+        let client_metadata = locked_client_metadata.read();
+        client_metadata.runtime_metadata().clone()
+    };
 
     let mut existential = metadata
         .pallets


### PR DESCRIPTION
The issue was related to holding the internal subxt's client metadata
`RwLock` between multiple await points.

This PR ensures the metadata is cloned and the lock guard dropped
immediately. 