### PR TITLE
Deny unused crate dependencies

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,8 +19,6 @@ path = "src/main.rs"
 subxt-codegen = { version = "0.21.0", path = "../codegen" }
 # perform node compatibility
 subxt-metadata = { version = "0.21.0", path = "../metadata" }
-# information of portable registry
-scale-info = "2.0.0"
 # parse command line args
 structopt = "0.3.25"
 # make the request to a substrate node to get the metadata

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with subxt.  If not, see <http://www.gnu.org/licenses/>.
 
+#![deny(unused_crate_dependencies)]
+
 use color_eyre::eyre::{
     self,
     WrapErr,

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -16,6 +16,8 @@
 
 //! Library to generate an API for a Substrate runtime from its metadata.
 
+#![deny(unused_crate_dependencies)]
+
 mod api;
 mod ir;
 mod types;

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -16,7 +16,6 @@ default = ["subxt/integration-tests"]
 
 [dev-dependencies]
 assert_matches = "1.5.0"
-async-trait = "0.1.49"
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full", "bit-vec"] }
 frame-metadata = "15.0.0"
 futures = "0.3.13"

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with subxt.  If not, see <http://www.gnu.org/licenses/>.
 
+#![deny(unused_crate_dependencies)]
+
 #[cfg(test)]
 mod codegen;
 #[cfg(test)]

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -87,6 +87,8 @@
 //! pub mod polkadot {}
 //! ```
 
+#![deny(unused_crate_dependencies)]
+
 extern crate proc_macro;
 
 use darling::FromMeta;

--- a/subxt/Cargo.toml
+++ b/subxt/Cargo.toml
@@ -41,10 +41,5 @@ frame-metadata = "15.0.0"
 derivative = "2.2.0"
 
 [dev-dependencies]
-sp-arithmetic = { version = "5.0.0", default-features = false }
 assert_matches = "1.5.0"
 tokio = { version = "1.8", features = ["macros", "time"] }
-tempdir = "0.3.7"
-wabt = "0.10.0"
-which = "4.0.2"
-sp-keyring = "6.0.0"

--- a/subxt/src/lib.rs
+++ b/subxt/src/lib.rs
@@ -35,6 +35,7 @@
     while_true,
     trivial_casts,
     trivial_numeric_casts,
+    unused_crate_dependencies,
     unused_extern_crates,
     clippy::all
 )]


### PR DESCRIPTION
I haven't added it for the `metadata` crate since it wants to remove some benchmark target dev dependencies