### PR TITLE
Add GitHub Actions to Dependabot and CODEOWNERS

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: daily

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,22 @@
+# Lists some code owners.
+#
+# A codeowner just oversees some part of the codebase. If an owned file is changed then the
+# corresponding codeowner receives a review request. An approval of the codeowner might be
+# required for merging a PR (depends on repository settings).
+#
+# For details about syntax, see:
+# https://help.github.com/en/articles/about-code-owners
+# But here are some important notes:
+#
+# - Glob syntax is git-like, e.g. `/core` means the core directory in the root, unlike `core`
+#   which can be everywhere.
+# - Multiple owners are supported.
+# - Either handle (e.g, @github_user or @github_org/team) or email can be used. Keep in mind,
+#   that handles might work better because they are more recognizable on GitHub,
+#   eyou can use them for mentioning unlike an email.
+# - The latest matching rule, if multiple, takes precedence.
+
+# main codeowner
+
+# CI
+/.github/ @paritytech/ci


### PR DESCRIPTION
This PR adds GitHub Actions monitoring to the Dependabot

As well CODEOWNERS file added with @paritytech/ci team added as `./.github/` folder codeowner. This is needed for us to receive notifications and track changes mainly about GHA changes. Related issues https://github.com/paritytech/ci_cd/issues/407 and https://github.com/paritytech/ci_cd/issues/464

Feel free to propose/add additional entries to CODEOWNERS