### PR TITLE
Make storage futures only borrow client, not self, for better ergonomics

### DIFF
--- a/codegen/src/api/storage.rs
+++ b/codegen/src/api/storage.rs
@@ -265,7 +265,7 @@ fn generate_storage_entry_fns(
 
     let lifetime_param = match should_ref {
         true => quote!(<'a>),
-        false => quote!()
+        false => quote!(),
     };
     let client_iter_fn = if matches!(storage_entry.ty, StorageEntryType::Map { .. }) {
         quote! (
@@ -303,7 +303,7 @@ fn generate_storage_entry_fns(
 
     let key_args_ref = match should_ref {
         true => quote!(&'a),
-        false => quote!()
+        false => quote!(),
     };
     let key_args = fields.iter().map(|(field_name, field_type)| {
         // The field type is translated from `std::vec::Vec<T>` to `[T]`, if the

--- a/codegen/src/api/storage.rs
+++ b/codegen/src/api/storage.rs
@@ -277,7 +277,7 @@ fn generate_storage_entry_fns(
             ) -> impl ::core::future::Future<
                 Output = ::core::result::Result<::subxt::KeyIter<'a, T, #entry_struct_ident #lifetime_param>, ::subxt::BasicError>
             > + 'a {
-                // instead of an async fn which borrows all of self,
+                // Instead of an async fn which borrows all of self,
                 // we make sure that the returned future only borrows
                 // client, which allows you to chain calls a little better.
                 let client = self.client;

--- a/codegen/src/api/storage.rs
+++ b/codegen/src/api/storage.rs
@@ -257,7 +257,7 @@ fn generate_storage_entry_fns(
 
     let anon_lifetime = match should_ref {
         true => quote!(<'_>),
-        false => quote!()
+        false => quote!(),
     };
     let storage_entry_type = quote! {
         #entry_struct

--- a/codegen/src/api/storage.rs
+++ b/codegen/src/api/storage.rs
@@ -322,7 +322,7 @@ fn generate_storage_entry_fns(
         ) -> impl ::core::future::Future<
             Output = ::core::result::Result<#return_ty, ::subxt::BasicError>
         > + 'a {
-            // instead of an async fn which borrows all of self,
+            // Instead of an async fn which borrows all of self,
             // we make sure that the returned future only borrows
             // client, which allows you to chain calls a little better.
             let client = self.client;

--- a/examples/examples/concurrent_storage_requests.rs
+++ b/examples/examples/concurrent_storage_requests.rs
@@ -1,17 +1,32 @@
+// Copyright 2019-2022 Parity Technologies (UK) Ltd.
+// This file is part of subxt.
+//
+// subxt is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// subxt is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with subxt.  If not, see <http://www.gnu.org/licenses/>.
+
 use futures::join;
 use sp_keyring::AccountKeyring;
 use subxt::{
-    PolkadotExtrinsicParams,
     ClientBuilder,
     DefaultConfig,
+    PolkadotExtrinsicParams,
 };
 
 #[subxt::subxt(runtime_metadata_path = "../artifacts/polkadot_metadata.scale")]
 pub mod polkadot {}
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>>{
-
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let api = ClientBuilder::new()
         .build()
         .await?
@@ -21,9 +36,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>>{
 
     // For storage requests, we can join futures together to
     // await multiple futures concurrently:
-    let controller = api.storage().staking().bonded(&addr, None);
-    let ledger = api.storage().staking().ledger(&addr, None);
-    let (a, b) = join!(controller, ledger);
+    let a_fut = api.storage().staking().bonded(&addr, None);
+    let b_fut = api.storage().staking().ledger(&addr, None);
+    let (a, b) = join!(a_fut, b_fut);
 
     println!("{a:?}, {b:?}");
 

--- a/examples/examples/concurrent_storage_requests.rs
+++ b/examples/examples/concurrent_storage_requests.rs
@@ -1,0 +1,31 @@
+use futures::join;
+use sp_keyring::AccountKeyring;
+use subxt::{
+    PolkadotExtrinsicParams,
+    ClientBuilder,
+    DefaultConfig,
+};
+
+#[subxt::subxt(runtime_metadata_path = "../artifacts/polkadot_metadata.scale")]
+pub mod polkadot {}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>>{
+
+    let api = ClientBuilder::new()
+        .build()
+        .await?
+        .to_runtime_api::<polkadot::RuntimeApi<DefaultConfig, PolkadotExtrinsicParams<DefaultConfig>>>();
+
+    let addr = AccountKeyring::Bob.to_account_id().into();
+
+    // For storage requests, we can join futures together to
+    // await multiple futures concurrently:
+    let controller = api.storage().staking().bonded(&addr, None);
+    let ledger = api.storage().staking().ledger(&addr, None);
+    let (a, b) = join!(controller, ledger);
+
+    println!("{a:?}, {b:?}");
+
+    Ok(())
+}

--- a/examples/examples/concurrent_storage_requests.rs
+++ b/examples/examples/concurrent_storage_requests.rs
@@ -32,7 +32,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await?
         .to_runtime_api::<polkadot::RuntimeApi<DefaultConfig, PolkadotExtrinsicParams<DefaultConfig>>>();
 
-    let addr = AccountKeyring::Bob.to_account_id().into();
+    let addr = AccountKeyring::Bob.to_account_id();
 
     // For storage requests, we can join futures together to
     // await multiple futures concurrently:


### PR DESCRIPTION
Just a small qol improvement that allows one to get a future back from a storage query and await it later without needing to store any intermediate variables due to unnecessarily large lifetimes being captured by said futures.

Without this you'd need to write:

```rust
let staking = api.storage().staking();
let a_fut = staking.bonded(&addr, None);
let b_fut = staking.ledger(&addr, None);
let (a, b) = join!(a_fut, b_fut);
```

But with it you can chain all the way up to the future like so:

```rust
let a_fut = api.storage().staking().bonded(&addr, None);
let b_fut = api.storage().staking().ledger(&addr, None);
let (a, b) = join!(a_fut, b_fut);
```

Closes #558 