### PR TITLE
Don't hash constant values; only their types

### DIFF
--- a/metadata/src/lib.rs
+++ b/metadata/src/lib.rs
@@ -302,10 +302,8 @@ pub fn get_constant_hash(
         .find(|c| c.name == constant_name)
         .ok_or(NotFound::Item)?;
 
-    let mut bytes = get_type_hash(&metadata.types, constant.ty.id(), &mut HashSet::new());
-    bytes = xor(bytes, hash(constant.name.as_bytes()));
-    bytes = xor(bytes, hash(&constant.value));
-
+    // We only need to check that the type of the constant asked for matches.
+    let bytes = get_type_hash(&metadata.types, constant.ty.id(), &mut HashSet::new());
     Ok(bytes)
 }
 
@@ -363,7 +361,6 @@ pub fn get_pallet_hash(
     }
     for constant in pallet.constants.iter() {
         bytes = xor(bytes, hash(constant.name.as_bytes()));
-        bytes = xor(bytes, hash(&constant.value));
         bytes = xor(
             bytes,
             get_type_hash(registry, constant.ty.id(), &mut visited_ids),

--- a/testing/integration-tests/src/metadata/validation.rs
+++ b/testing/integration-tests/src/metadata/validation.rs
@@ -124,11 +124,7 @@ async fn constant_values_are_not_validated() {
     let new_api = metadata_to_api(metadata, &cxt).await;
 
     assert!(new_api.validate_metadata().is_ok());
-    assert!(new_api
-        .constants()
-        .balances()
-        .existential_deposit()
-        .is_ok());
+    assert!(new_api.constants().balances().existential_deposit().is_ok());
 
     // Other constant validation should not be impacted.
     assert!(new_api.constants().balances().max_locks().is_ok());

--- a/testing/integration-tests/src/metadata/validation.rs
+++ b/testing/integration-tests/src/metadata/validation.rs
@@ -94,7 +94,7 @@ async fn full_metadata_check() {
 }
 
 #[tokio::test]
-async fn constants_check() {
+async fn constant_values_are_not_validated() {
     let cxt = test_context().await;
     let api = &cxt.api;
 
@@ -117,16 +117,18 @@ async fn constants_check() {
         .iter_mut()
         .find(|constant| constant.name == "ExistentialDeposit")
         .expect("ExistentialDeposit constant must be present");
+
+    // Modifying a constant value should not lead to an error:
     existential.value = vec![0u8; 32];
 
     let new_api = metadata_to_api(metadata, &cxt).await;
 
-    assert!(new_api.validate_metadata().is_err());
+    assert!(new_api.validate_metadata().is_ok());
     assert!(new_api
         .constants()
         .balances()
         .existential_deposit()
-        .is_err());
+        .is_ok());
 
     // Other constant validation should not be impacted.
     assert!(new_api.constants().balances().max_locks().is_ok());


### PR DESCRIPTION
The goal of metadata validation is checking for compatibility between metadatas, not equality, so no need to hash the value of constants; that'll just lead to calls to obtain them failing that should succeed.

Also we don't need to hash the name of the constant when we are looking up the constant by name anyway.