### PR TITLE
metadata: Exclude `field::type_name` from metadata validation

### DIFF
--- a/codegen/src/types/type_def_params.rs
+++ b/codegen/src/types/type_def_params.rs
@@ -65,7 +65,7 @@ impl TypeDefParameters {
     }
 }
 
-impl<'a> quote::ToTokens for TypeDefParameters {
+impl quote::ToTokens for TypeDefParameters {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
         if !self.params.is_empty() {
             let params = &self.params;

--- a/metadata/src/lib.rs
+++ b/metadata/src/lib.rs
@@ -72,9 +72,6 @@ fn get_field_hash(
     if let Some(name) = field.name() {
         bytes = xor(bytes, hash(name.as_bytes()));
     }
-    if let Some(name) = field.type_name() {
-        bytes = xor(bytes, hash(name.as_bytes()));
-    }
 
     bytes
 }

--- a/subxt/src/events/event_subscription.rs
+++ b/subxt/src/events/event_subscription.rs
@@ -47,9 +47,9 @@ pub use super::{
 /// and is exposed only to be called via the codegen. It may
 /// break between minor releases.
 #[doc(hidden)]
-pub async fn subscribe<'a, T: Config, Evs: Decode + 'static>(
-    client: &'a Client<T>,
-) -> Result<EventSubscription<'a, EventSub<T::Header>, T, Evs>, BasicError> {
+pub async fn subscribe<T: Config, Evs: Decode + 'static>(
+    client: &Client<T>,
+) -> Result<EventSubscription<EventSub<T::Header>, T, Evs>, BasicError> {
     let block_subscription = client.rpc().subscribe_blocks().await?;
     Ok(EventSubscription::new(client, block_subscription))
 }
@@ -60,9 +60,9 @@ pub async fn subscribe<'a, T: Config, Evs: Decode + 'static>(
 /// and is exposed only to be called via the codegen. It may
 /// break between minor releases.
 #[doc(hidden)]
-pub async fn subscribe_finalized<'a, T: Config, Evs: Decode + 'static>(
-    client: &'a Client<T>,
-) -> Result<EventSubscription<'a, FinalizedEventSub<'a, T::Header>, T, Evs>, BasicError> {
+pub async fn subscribe_finalized<T: Config, Evs: Decode + 'static>(
+    client: &Client<T>,
+) -> Result<EventSubscription<FinalizedEventSub<T::Header>, T, Evs>, BasicError> {
     // fetch the last finalised block details immediately, so that we'll get
     // events for each block after this one.
     let last_finalized_block_hash = client.rpc().finalized_head().await?;

--- a/testing/integration-tests/src/metadata/validation.rs
+++ b/testing/integration-tests/src/metadata/validation.rs
@@ -75,8 +75,7 @@ async fn full_metadata_check() {
     assert_eq!(
         new_api
             .validate_metadata()
-            .err()
-            .expect("Validation should fail for incompatible metadata"),
+            .expect_err("Validation should fail for incompatible metadata"),
         ::subxt::MetadataError::IncompatibleMetadata
     );
 }


### PR DESCRIPTION
The #591 presented a metadata validation issue detected on the [Snowbridge](https://github.com/Snowfork/snowbridge) parachain.

The metadata validation would reject extrinsics due to the following difference in metadata:

| Source|  Metadata |
| --- | --- |
| snowbridge | "typeName": "/*«*/ u32 /*»*/" |
| polkadot | "typeName": "u32"|


This PR removes the hashing of the `typeName` as the unique deterministic representation of the field is deduced from its `type` and `name`. 

### Testing
Utilizing the metadata provided in the issue:

```bash
subxt-cli -- codegen --file ours.metadata.scale > ours.rs
subxt-cli -- codegen --file theirs.metadata.scale > theirs.rs

diff ours.rs theirs.rs
#ok - identical hashes for validation
```
