### PR TITLE
use 'sp_core::Hxxx' for all hash types

### DIFF
--- a/codegen/src/api/mod.rs
+++ b/codegen/src/api/mod.rs
@@ -120,8 +120,16 @@ impl RuntimeGenerator {
                 parse_quote!(::subxt::ext::sp_core::crypto::AccountId32),
             ),
             (
+                "primitive_types::H160",
+                parse_quote!(::subxt::ext::sp_core::H160),
+            ),
+            (
                 "primitive_types::H256",
                 parse_quote!(::subxt::ext::sp_core::H256),
+            ),
+            (
+                "primitive_types::H512",
+                parse_quote!(::subxt::ext::sp_core::H512),
             ),
             (
                 "sp_runtime::multiaddress::MultiAddress",


### PR DESCRIPTION
Since we have a type override for H256 already, also add one for H160 and H512

Closes #619