### PR TITLE
add config attr to replace without type parameters

### DIFF
--- a/codegen/src/api/mod.rs
+++ b/codegen/src/api/mod.rs
@@ -148,7 +148,7 @@ impl RuntimeGenerator {
         ]
         .iter()
         .map(|(path, substitute): &(&str, syn::TypePath)| {
-            (path.to_string(), substitute.clone())
+            (path.to_string(), (substitute.clone(), false))
         })
         .collect::<HashMap<_, _>>();
 


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

Resolves #604 

Allows the substitution of a type without inheriting generic type parameters. The following example would fail with `substitute_type` because the generated code would include `DefaultVaultId<_0, _3>` - see [this comment](https://github.com/paritytech/subxt/issues/604#issuecomment-1222219978). The new config attribute `substitute_type_no_params` allows an import to be used directly.

```rust
type DefaultVaultId = VaultId<
    subxt::ext::sp_runtime::AccountId32,
    kintsugi_testnet::runtime_types::interbtc_primitives::CurrencyId,
>;

#[subxt::subxt(
    runtime_metadata_path = "./metadata.scale",
    derive_for_type(type = "interbtc_primitives::TokenSymbol", derive = "Copy, Clone"),
    derive_for_type(type = "interbtc_primitives::CurrencyId", derive = "Copy, Clone")
)]
pub mod kintsugi_testnet {
    #[subxt(substitute_type_no_params = "interbtc_primitives::VaultId")]
    use crate::DefaultVaultId;
}
```
There is probably a cleaner solution to the problem at hand, the code in this PR is quite rough. I'm hoping someone has a better alternative which may not necessarily require a separate config attribute.