### PR TITLE
Specialize incompatible metadata errors

### DIFF
--- a/subxt/src/constants/constants_client.rs
+++ b/subxt/src/constants/constants_client.rs
@@ -47,7 +47,11 @@ impl<T: Config, Client: OfflineClientT<T>> ConstantsClient<T, Client> {
                 .metadata()
                 .constant_hash(address.pallet_name(), address.constant_name())?;
             if actual_hash != expected_hash {
-                return Err(MetadataError::IncompatibleMetadata.into())
+                return Err(MetadataError::IncompatibleConstantMetadata(
+                    address.pallet_name().into(),
+                    address.constant_name().into(),
+                )
+                .into())
             }
         }
         Ok(())

--- a/subxt/src/metadata/metadata_type.rs
+++ b/subxt/src/metadata/metadata_type.rs
@@ -60,9 +60,15 @@ pub enum MetadataError {
     /// Type is not in metadata.
     #[error("Type {0} missing from type registry")]
     TypeNotFound(u32),
-    /// Runtime pallet metadata is incompatible with the static one.
-    #[error("Pallet {0} has incompatible metadata")]
-    IncompatiblePalletMetadata(&'static str),
+    /// Runtime constant metadata is incompatible with the static one.
+    #[error("Pallet {0} Constant {0} has incompatible metadata")]
+    IncompatibleConstantMetadata(String, String),
+    /// Runtime call metadata is incompatible with the static one.
+    #[error("Pallet {0} Call {0} has incompatible metadata")]
+    IncompatibleCallMetadata(String, String),
+    /// Runtime storage metadata is incompatible with the static one.
+    #[error("Pallet {0} Storage {0} has incompatible metadata")]
+    IncompatibleStorageMetadata(String, String),
     /// Runtime metadata is not fully compatible with the static one.
     #[error("Node metadata is not fully compatible")]
     IncompatibleMetadata,

--- a/subxt/src/storage/storage_client.rs
+++ b/subxt/src/storage/storage_client.rs
@@ -386,7 +386,13 @@ fn validate_storage(
     };
     match expected_hash == hash {
         true => Ok(()),
-        false => Err(crate::error::MetadataError::IncompatibleMetadata.into()),
+        false => {
+            Err(crate::error::MetadataError::IncompatibleStorageMetadata(
+                pallet_name.into(),
+                storage_name.into(),
+            )
+            .into())
+        }
     }
 }
 

--- a/subxt/src/tx/tx_client.rs
+++ b/subxt/src/tx/tx_client.rs
@@ -62,7 +62,11 @@ impl<T: Config, C: OfflineClientT<T>> TxClient<T, C> {
             let expected_hash =
                 metadata.call_hash(call.pallet_name(), call.call_name())?;
             if actual_hash != expected_hash {
-                return Err(crate::metadata::MetadataError::IncompatibleMetadata.into())
+                return Err(crate::metadata::MetadataError::IncompatibleCallMetadata(
+                    call.pallet_name().into(),
+                    call.call_name().into(),
+                )
+                .into())
             }
         }
         Ok(())


### PR DESCRIPTION
This PR specializes the metadata errors to contain information
about the incompatible components, for static validation purposes.

Closes #584.