### PR TITLE
Add conversion and default functions for `NumberOrHex`

### DIFF
--- a/subxt/src/rpc.rs
+++ b/subxt/src/rpc.rs
@@ -177,7 +177,8 @@ impl From<U256> for NumberOrHex {
 
 /// An error type that signals an out-of-range conversion attempt.
 #[derive(Debug, thiserror::Error)]
-pub struct TryFromIntError(pub(crate) ());
+#[error("Out-of-range conversion attempt")]
+pub struct TryFromIntError();
 
 impl TryFrom<NumberOrHex> for u32 {
     type Error = TryFromIntError;
@@ -185,7 +186,7 @@ impl TryFrom<NumberOrHex> for u32 {
         num_or_hex
             .into_u256()
             .try_into()
-            .map_err(|_| TryFromIntError(()))
+            .map_err(|_| TryFromIntError())
     }
 }
 
@@ -195,7 +196,7 @@ impl TryFrom<NumberOrHex> for u64 {
         num_or_hex
             .into_u256()
             .try_into()
-            .map_err(|_| TryFromIntError(()))
+            .map_err(|_| TryFromIntError())
     }
 }
 
@@ -205,7 +206,7 @@ impl TryFrom<NumberOrHex> for u128 {
         num_or_hex
             .into_u256()
             .try_into()
-            .map_err(|_| TryFromIntError(()))
+            .map_err(|_| TryFromIntError())
     }
 }
 

--- a/subxt/src/rpc.rs
+++ b/subxt/src/rpc.rs
@@ -178,7 +178,7 @@ impl From<U256> for NumberOrHex {
 /// An error type that signals an out-of-range conversion attempt.
 #[derive(Debug, thiserror::Error)]
 #[error("Out-of-range conversion attempt")]
-pub struct TryFromIntError();
+pub struct TryFromIntError;
 
 impl TryFrom<NumberOrHex> for u32 {
     type Error = TryFromIntError;
@@ -186,7 +186,7 @@ impl TryFrom<NumberOrHex> for u32 {
         num_or_hex
             .into_u256()
             .try_into()
-            .map_err(|_| TryFromIntError())
+            .map_err(|_| TryFromIntError)
     }
 }
 
@@ -196,7 +196,7 @@ impl TryFrom<NumberOrHex> for u64 {
         num_or_hex
             .into_u256()
             .try_into()
-            .map_err(|_| TryFromIntError())
+            .map_err(|_| TryFromIntError)
     }
 }
 
@@ -206,7 +206,7 @@ impl TryFrom<NumberOrHex> for u128 {
         num_or_hex
             .into_u256()
             .try_into()
-            .map_err(|_| TryFromIntError())
+            .map_err(|_| TryFromIntError)
     }
 }
 

--- a/subxt/src/rpc.rs
+++ b/subxt/src/rpc.rs
@@ -720,7 +720,6 @@ mod test {
     use super::*;
 
     /// A util function to assert the result of serialization and deserialization is the same.
-    #[cfg(test)]
     pub(crate) fn assert_deser<T>(s: &str, expected: T)
     where
         T: std::fmt::Debug

--- a/subxt/src/rpc.rs
+++ b/subxt/src/rpc.rs
@@ -135,6 +135,85 @@ impl From<NumberOrHex> for BlockNumber {
     }
 }
 
+impl Default for NumberOrHex {
+    fn default() -> Self {
+        Self::Number(Default::default())
+    }
+}
+
+impl NumberOrHex {
+    /// Converts this number into an U256.
+    pub fn into_u256(self) -> U256 {
+        match self {
+            NumberOrHex::Number(n) => n.into(),
+            NumberOrHex::Hex(h) => h,
+        }
+    }
+}
+
+impl From<u32> for NumberOrHex {
+    fn from(n: u32) -> Self {
+        NumberOrHex::Number(n.into())
+    }
+}
+
+impl From<u64> for NumberOrHex {
+    fn from(n: u64) -> Self {
+        NumberOrHex::Number(n)
+    }
+}
+
+impl From<u128> for NumberOrHex {
+    fn from(n: u128) -> Self {
+        NumberOrHex::Hex(n.into())
+    }
+}
+
+impl From<U256> for NumberOrHex {
+    fn from(n: U256) -> Self {
+        NumberOrHex::Hex(n)
+    }
+}
+
+/// An error type that signals an out-of-range conversion attempt.
+pub struct TryFromIntError(pub(crate) ());
+
+impl TryFrom<NumberOrHex> for u32 {
+    type Error = TryFromIntError;
+    fn try_from(num_or_hex: NumberOrHex) -> Result<u32, Self::Error> {
+        num_or_hex
+            .into_u256()
+            .try_into()
+            .map_err(|_| TryFromIntError(()))
+    }
+}
+
+impl TryFrom<NumberOrHex> for u64 {
+    type Error = TryFromIntError;
+    fn try_from(num_or_hex: NumberOrHex) -> Result<u64, Self::Error> {
+        num_or_hex
+            .into_u256()
+            .try_into()
+            .map_err(|_| TryFromIntError(()))
+    }
+}
+
+impl TryFrom<NumberOrHex> for u128 {
+    type Error = TryFromIntError;
+    fn try_from(num_or_hex: NumberOrHex) -> Result<u128, Self::Error> {
+        num_or_hex
+            .into_u256()
+            .try_into()
+            .map_err(|_| TryFromIntError(()))
+    }
+}
+
+impl From<NumberOrHex> for U256 {
+    fn from(num_or_hex: NumberOrHex) -> U256 {
+        num_or_hex.into_u256()
+    }
+}
+
 // All unsigned ints can be converted into a BlockNumber:
 macro_rules! into_block_number {
     ($($t: ty)+) => {
@@ -639,6 +718,19 @@ fn to_hex(bytes: impl AsRef<[u8]>) -> String {
 mod test {
     use super::*;
 
+    /// A util function to assert the result of serialization and deserialization is the same.
+    #[cfg(test)]
+    pub(crate) fn assert_deser<T>(s: &str, expected: T)
+    where
+        T: std::fmt::Debug
+            + serde::ser::Serialize
+            + serde::de::DeserializeOwned
+            + PartialEq,
+    {
+        assert_eq!(serde_json::from_str::<T>(s).unwrap(), expected);
+        assert_eq!(serde_json::to_string(&expected).unwrap(), s);
+    }
+
     #[test]
     fn test_deser_runtime_version() {
         let val: RuntimeVersion = serde_json::from_str(
@@ -663,5 +755,15 @@ mod test {
                 other: m
             }
         );
+    }
+
+    #[test]
+    fn should_serialize_and_deserialize() {
+        assert_deser(r#""0x1234""#, NumberOrHex::Hex(0x1234.into()));
+        assert_deser(r#""0x0""#, NumberOrHex::Hex(0.into()));
+        assert_deser(r#"5"#, NumberOrHex::Number(5));
+        assert_deser(r#"10000"#, NumberOrHex::Number(10000));
+        assert_deser(r#"0"#, NumberOrHex::Number(0));
+        assert_deser(r#"1000000000000"#, NumberOrHex::Number(1000000000000));
     }
 }

--- a/subxt/src/rpc.rs
+++ b/subxt/src/rpc.rs
@@ -176,7 +176,7 @@ impl From<U256> for NumberOrHex {
 }
 
 /// An error type that signals an out-of-range conversion attempt.
-#[derive(thiserror::Error)]
+#[derive(Debug, thiserror::Error)]
 pub struct TryFromIntError(pub(crate) ());
 
 impl TryFrom<NumberOrHex> for u32 {

--- a/subxt/src/rpc.rs
+++ b/subxt/src/rpc.rs
@@ -176,6 +176,7 @@ impl From<U256> for NumberOrHex {
 }
 
 /// An error type that signals an out-of-range conversion attempt.
+#[derive(thiserror::Error)]
 pub struct TryFromIntError(pub(crate) ());
 
 impl TryFrom<NumberOrHex> for u32 {


### PR DESCRIPTION
Needed for https://github.com/paritytech/ink/issues/1234.

Shamelessly copied from `sp-rc`, which I guess you wanted to avoid as a dep.