### PR TITLE
Store type name of a field in event metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.23.1] - 2022-09-15
-
-Fields in `EventMetadata` now also store name of a type specified in the pallet's source code.
-
 ## [0.23.0] - 2022-08-11
 
 This is one of the most significant releases to date in Subxt, and carries with it a number of significant breaking changes, but in exchange, a number of significant improvements. The most significant PR is [#593](https://github.com/paritytech/subxt/pull/593); the fundamental change that this makes is to separate creating a query/transaction/address from submitting it. This gives us flexibility when creating queries; they can be either dynamically or statically generated, but also flexibility in our client, enabling methods to be exposed for online or offline use.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.23.1] - 2022-09-15
+
+Fields in `EventMetadata` now also store name of a type specified in the pallet's source code.
+
 ## [0.23.0] - 2022-08-11
 
 This is one of the most significant releases to date in Subxt, and carries with it a number of significant breaking changes, but in exchange, a number of significant improvements. The most significant PR is [#593](https://github.com/paritytech/subxt/pull/593); the fundamental change that this makes is to separate creating a query/transaction/address from submitting it. This gives us flexibility when creating queries; they can be either dynamically or statically generated, but also flexibility in our client, enabling methods to be exposed for online or offline use.

--- a/subxt/src/events/events_type.rs
+++ b/subxt/src/events/events_type.rs
@@ -187,7 +187,7 @@ impl EventDetails {
         );
 
         // Skip over the bytes belonging to this event.
-        for (_name, type_id) in event_metadata.fields() {
+        for (_name, _type_name, type_id) in event_metadata.fields() {
             // Skip over the bytes for this field:
             scale_decode::decode(
                 input,
@@ -288,12 +288,12 @@ impl EventDetails {
         let is_named = event_metadata
             .fields()
             .get(0)
-            .map(|(n, _)| n.is_some())
+            .map(|(n, _, _)| n.is_some())
             .unwrap_or(false);
 
         if !is_named {
             let mut event_values = vec![];
-            for (_, type_id) in event_metadata.fields() {
+            for (_, _, type_id) in event_metadata.fields() {
                 let value = scale_value::scale::decode_as_type(
                     bytes,
                     *type_id,
@@ -305,7 +305,7 @@ impl EventDetails {
             Ok(scale_value::Composite::Unnamed(event_values))
         } else {
             let mut event_values = vec![];
-            for (name, type_id) in event_metadata.fields() {
+            for (name, _, type_id) in event_metadata.fields() {
                 let value = scale_value::scale::decode_as_type(
                     bytes,
                     *type_id,

--- a/subxt/src/metadata/metadata_type.rs
+++ b/subxt/src/metadata/metadata_type.rs
@@ -457,7 +457,13 @@ impl TryFrom<RuntimeMetadataPrefixed> for Metadata {
                             fields: variant
                                 .fields()
                                 .iter()
-                                .map(|f| (f.name().map(|n| n.to_owned()), f.type_name().map(|n| n.to_owned()), f.ty().id()))
+                                .map(|f| {
+                                    (
+                                        f.name().map(|n| n.to_owned()),
+                                        f.type_name().map(|n| n.to_owned()),
+                                        f.ty().id(),
+                                    )
+                                })
                                 .collect(),
                             docs: variant.docs().to_vec(),
                         },

--- a/subxt/src/metadata/metadata_type.rs
+++ b/subxt/src/metadata/metadata_type.rs
@@ -297,6 +297,39 @@ impl PalletMetadata {
     }
 }
 
+/// Metadata for specific field.
+#[derive(Clone, Debug)]
+pub struct EventFieldMetadata {
+    name: Option<String>,
+    type_name: Option<String>,
+    type_id: u32,
+}
+
+impl EventFieldMetadata {
+    pub fn new(name: Option<String>, type_name: Option<String>, type_id: u32) -> Self {
+        EventFieldMetadata {
+            name,
+            type_name,
+            type_id,
+        }
+    }
+
+    /// Get the name of the field.
+    pub fn name(&self) -> Option<&str> {
+        self.name.as_deref()
+    }
+
+    // Get the type name of the field as it appears in the code
+    pub fn type_name(&self) -> Option<&str> {
+        self.type_name.as_deref()
+    }
+
+    /// Get the id of a type
+    pub fn type_id(&self) -> u32 {
+        self.type_id
+    }
+}
+
 /// Metadata for specific events.
 #[derive(Clone, Debug)]
 pub struct EventMetadata {
@@ -304,7 +337,7 @@ pub struct EventMetadata {
     // behind an Arc to avoid lots of needless clones of it existing.
     pallet: Arc<str>,
     event: String,
-    fields: Vec<(Option<String>, Option<String>, u32)>,
+    fields: Vec<EventFieldMetadata>,
     docs: Vec<String>,
 }
 
@@ -320,7 +353,7 @@ impl EventMetadata {
     }
 
     /// The names, type names & types of each field in the event.
-    pub fn fields(&self) -> &[(Option<String>, Option<String>, u32)] {
+    pub fn fields(&self) -> &[EventFieldMetadata] {
         &self.fields
     }
 
@@ -458,7 +491,7 @@ impl TryFrom<RuntimeMetadataPrefixed> for Metadata {
                                 .fields()
                                 .iter()
                                 .map(|f| {
-                                    (
+                                    EventFieldMetadata::new(
                                         f.name().map(|n| n.to_owned()),
                                         f.type_name().map(|n| n.to_owned()),
                                         f.ty().id(),

--- a/subxt/src/metadata/metadata_type.rs
+++ b/subxt/src/metadata/metadata_type.rs
@@ -304,7 +304,7 @@ pub struct EventMetadata {
     // behind an Arc to avoid lots of needless clones of it existing.
     pallet: Arc<str>,
     event: String,
-    fields: Vec<(Option<String>, u32)>,
+    fields: Vec<(Option<String>, Option<String>, u32)>,
     docs: Vec<String>,
 }
 
@@ -319,8 +319,8 @@ impl EventMetadata {
         &self.event
     }
 
-    /// The names and types of each field in the event.
-    pub fn fields(&self) -> &[(Option<String>, u32)] {
+    /// The names, type names & types of each field in the event.
+    pub fn fields(&self) -> &[(Option<String>, Option<String>, u32)] {
         &self.fields
     }
 
@@ -457,7 +457,7 @@ impl TryFrom<RuntimeMetadataPrefixed> for Metadata {
                             fields: variant
                                 .fields()
                                 .iter()
-                                .map(|f| (f.name().map(|n| n.to_owned()), f.ty().id()))
+                                .map(|f| (f.name().map(|n| n.to_owned()), f.type_name().map(|n| n.to_owned()), f.ty().id()))
                                 .collect(),
                             docs: variant.docs().to_vec(),
                         },


### PR DESCRIPTION
Fields in `EventMetadata` now also store name of a type specified in the pallet's source code.

Required for [#673](https://github.com/paritytech/cargo-contract/issues/673) in `cargo-contract`