### PR TITLE
Export EventFieldMetadata

### DIFF
--- a/subxt/src/metadata/metadata_type.rs
+++ b/subxt/src/metadata/metadata_type.rs
@@ -306,6 +306,7 @@ pub struct EventFieldMetadata {
 }
 
 impl EventFieldMetadata {
+    /// Construct a new [`EventFieldMetadata`]
     pub fn new(name: Option<String>, type_name: Option<String>, type_id: u32) -> Self {
         EventFieldMetadata {
             name,
@@ -319,7 +320,7 @@ impl EventFieldMetadata {
         self.name.as_deref()
     }
 
-    // Get the type name of the field as it appears in the code
+    /// Get the type name of the field as it appears in the code
     pub fn type_name(&self) -> Option<&str> {
         self.type_name.as_deref()
     }

--- a/subxt/src/metadata/mod.rs
+++ b/subxt/src/metadata/mod.rs
@@ -14,6 +14,7 @@ pub use metadata_location::MetadataLocation;
 
 pub use metadata_type::{
     ErrorMetadata,
+    EventFieldMetadata,
     EventMetadata,
     InvalidMetadataError,
     Metadata,


### PR DESCRIPTION
Follow up to #654, the type should be exported.