### PR TITLE
Bump scale-value and scale-decode

### DIFF
--- a/subxt/Cargo.toml
+++ b/subxt/Cargo.toml
@@ -28,8 +28,8 @@ jsonrpsee = ["dep:jsonrpsee"]
 bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full", "bit-vec"] }
 scale-info = { version = "2.0.0", features = ["bit-vec"] }
-scale-value = "0.5.0"
-scale-decode = "0.3.0"
+scale-value = "0.6.0"
+scale-decode = "0.4.0"
 futures = "0.3.13"
 hex = "0.4.3"
 jsonrpsee = { version = "0.15.1", features = ["async-client", "client-ws-transport", "jsonrpsee-types"], optional = true }

--- a/subxt/src/events/events_type.rs
+++ b/subxt/src/events/events_type.rs
@@ -470,7 +470,7 @@ mod tests {
     /// [`RawEventDetails`] can be annoying to test, because it contains
     /// type info in the decoded field Values. Strip that here so that
     /// we can compare fields more easily.
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(Debug, PartialEq, Eq, Clone)]
     pub struct TestRawEventDetails {
         pub phase: Phase,
         pub index: u32,


### PR DESCRIPTION
These both compile to WASM, and so push us a little closer to getting the core of subxt also compiling to WASM