### PR TITLE
Add accessor for `StaticTxPayload::call_data`

### DIFF
--- a/subxt/src/tx/tx_payload.rs
+++ b/subxt/src/tx/tx_payload.rs
@@ -75,6 +75,11 @@ impl<CallData> StaticTxPayload<CallData> {
             ..self
         }
     }
+
+    /// Returns the call data.
+    pub fn call_data(&self) -> &CallData {
+        &self.call_data
+    }
 }
 
 impl<CallData: Encode> TxPayload for StaticTxPayload<CallData> {


### PR DESCRIPTION
This might be required e.g. for `state_call` RPCs where the encoded `call_data` is without pallet and call index prefixes.