### PR TITLE
Allow specifying the `subxt` crate path for generated code

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -321,8 +321,7 @@ fn codegen<I: Input>(
     let mut derives = DerivesRegistry::default();
     derives.extend_for_all(p.into_iter());
 
-    let runtime_api =
-        generator.generate_runtime(item_mod, derives, crate_path.map(Into::into));
+    let runtime_api = generator.generate_runtime(item_mod, derives, crate_path.into());
     println!("{}", runtime_api);
     Ok(())
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -318,7 +318,8 @@ fn codegen<I: Input>(
         .map(|raw| syn::parse_str(raw))
         .collect::<Result<Vec<_>, _>>()?;
 
-    let mut derives = DerivesRegistry::default();
+    let crate_path = crate_path.map(Into::into).unwrap_or_default();
+    let mut derives = DerivesRegistry::new(&crate_path);
     derives.extend_for_all(p.into_iter());
 
     let runtime_api = generator.generate_runtime(item_mod, derives, crate_path.into());

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -322,7 +322,7 @@ fn codegen<I: Input>(
     let mut derives = DerivesRegistry::new(&crate_path);
     derives.extend_for_all(p.into_iter());
 
-    let runtime_api = generator.generate_runtime(item_mod, derives, crate_path.into());
+    let runtime_api = generator.generate_runtime(item_mod, derives, crate_path);
     println!("{}", runtime_api);
     Ok(())
 }

--- a/codegen/src/api/calls.rs
+++ b/codegen/src/api/calls.rs
@@ -55,7 +55,6 @@ pub fn generate_calls(
         "Call",
         crate_path,
     );
-    let crate_path = crate_path.syn_path();
     let (call_structs, call_fns): (Vec<_>, Vec<_>) = struct_defs
         .iter_mut()
         .map(|(variant_name, struct_def)| {

--- a/codegen/src/api/constants.rs
+++ b/codegen/src/api/constants.rs
@@ -2,7 +2,10 @@
 // This file is dual-licensed as Apache-2.0 or GPL-3.0.
 // see LICENSE for license details.
 
-use crate::types::TypeGenerator;
+use crate::{
+    types::TypeGenerator,
+    CratePath,
+};
 use frame_metadata::{
     v14::RuntimeMetadataV14,
     PalletMetadata,
@@ -44,12 +47,14 @@ pub fn generate_constants(
     type_gen: &TypeGenerator,
     pallet: &PalletMetadata<PortableForm>,
     types_mod_ident: &syn::Ident,
+    crate_path: &CratePath,
 ) -> TokenStream2 {
     // Early return if the pallet has no constants.
     if pallet.constants.is_empty() {
         return quote!()
     }
     let constants = &pallet.constants;
+    let crate_path = crate_path.syn_path();
 
     let constant_fns = constants.iter().map(|constant| {
         let fn_name = format_ident!("{}", constant.name.to_snake_case());
@@ -63,8 +68,8 @@ pub fn generate_constants(
 
         quote! {
             #( #[doc = #docs ] )*
-            pub fn #fn_name(&self) -> ::subxt::constants::StaticConstantAddress<::subxt::metadata::DecodeStaticType<#return_ty>> {
-                ::subxt::constants::StaticConstantAddress::new(
+            pub fn #fn_name(&self) -> #crate_path::constants::StaticConstantAddress<#crate_path::metadata::DecodeStaticType<#return_ty>> {
+                #crate_path::constants::StaticConstantAddress::new(
                     #pallet_name,
                     #constant_name,
                     [#(#constant_hash,)*]

--- a/codegen/src/api/constants.rs
+++ b/codegen/src/api/constants.rs
@@ -54,7 +54,6 @@ pub fn generate_constants(
         return quote!()
     }
     let constants = &pallet.constants;
-    let crate_path = crate_path.syn_path();
 
     let constant_fns = constants.iter().map(|constant| {
         let fn_name = format_ident!("{}", constant.name.to_snake_case());

--- a/codegen/src/api/events.rs
+++ b/codegen/src/api/events.rs
@@ -60,7 +60,6 @@ pub fn generate_events(
         "Event",
         crate_path,
     );
-    let crate_path = crate_path.syn_path();
     let event_structs = struct_defs.iter().map(|(variant_name, struct_def)| {
         let pallet_name = &pallet.name;
         let event_struct = &struct_def.name;

--- a/codegen/src/api/events.rs
+++ b/codegen/src/api/events.rs
@@ -2,7 +2,10 @@
 // This file is dual-licensed as Apache-2.0 or GPL-3.0.
 // see LICENSE for license details.
 
-use crate::types::TypeGenerator;
+use crate::{
+    types::TypeGenerator,
+    CratePath,
+};
 use frame_metadata::PalletMetadata;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
@@ -41,6 +44,7 @@ pub fn generate_events(
     type_gen: &TypeGenerator,
     pallet: &PalletMetadata<PortableForm>,
     types_mod_ident: &syn::Ident,
+    crate_path: &CratePath,
 ) -> TokenStream2 {
     // Early return if the pallet has no events.
     let event = if let Some(ref event) = pallet.event {
@@ -54,7 +58,9 @@ pub fn generate_events(
         event.ty.id(),
         |name| name.into(),
         "Event",
+        crate_path,
     );
+    let crate_path = crate_path.syn_path();
     let event_structs = struct_defs.iter().map(|(variant_name, struct_def)| {
         let pallet_name = &pallet.name;
         let event_struct = &struct_def.name;
@@ -63,7 +69,7 @@ pub fn generate_events(
         quote! {
             #struct_def
 
-            impl ::subxt::events::StaticEvent for #event_struct {
+            impl #crate_path::events::StaticEvent for #event_struct {
                 const PALLET: &'static str = #pallet_name;
                 const EVENT: &'static str = #event_name;
             }

--- a/codegen/src/api/mod.rs
+++ b/codegen/src/api/mod.rs
@@ -166,7 +166,7 @@ impl RuntimeGenerator {
             derives.clone(),
             crate_path.clone(),
         );
-        let types_mod = type_gen.generate_types_mod(&crate_path);
+        let types_mod = type_gen.generate_types_mod();
         let types_mod_ident = types_mod.ident();
         let pallets_with_mod_names = self
             .metadata

--- a/codegen/src/api/mod.rs
+++ b/codegen/src/api/mod.rs
@@ -19,6 +19,7 @@ use crate::{
         CompositeDefFields,
         TypeGenerator,
     },
+    CratePath,
 };
 use codec::Decode;
 use frame_metadata::{
@@ -55,6 +56,7 @@ pub fn generate_runtime_api<P>(
     item_mod: syn::ItemMod,
     path: P,
     derives: DerivesRegistry,
+    crate_path: Option<CratePath>,
 ) -> TokenStream2
 where
     P: AsRef<path::Path>,
@@ -71,7 +73,7 @@ where
         .unwrap_or_else(|e| abort_call_site!("Failed to decode metadata: {}", e));
 
     let generator = RuntimeGenerator::new(metadata);
-    generator.generate_runtime(item_mod, derives)
+    generator.generate_runtime(item_mod, derives, crate_path)
 }
 
 /// Create the API for interacting with a Substrate runtime.
@@ -101,49 +103,58 @@ impl RuntimeGenerator {
         &self,
         item_mod: syn::ItemMod,
         derives: DerivesRegistry,
+        crate_path: Option<CratePath>,
     ) -> TokenStream2 {
         let item_mod_ir = ir::ItemMod::from(item_mod);
         let default_derives = derives.default_derives();
+
+        let crate_path = match crate_path {
+            Some(crate_path) => crate_path.syn_path().to_owned(),
+            None => {
+                let path = crate::CratePath::default();
+                path.syn_path().to_owned()
+            }
+        };
 
         // Some hardcoded default type substitutes, can be overridden by user
         let mut type_substitutes = [
             (
                 "bitvec::order::Lsb0",
-                parse_quote!(::subxt::ext::bitvec::order::Lsb0),
+                parse_quote!(#crate_path::ext::bitvec::order::Lsb0),
             ),
             (
                 "bitvec::order::Msb0",
-                parse_quote!(::subxt::ext::bitvec::order::Msb0),
+                parse_quote!(#crate_path::ext::bitvec::order::Msb0),
             ),
             (
                 "sp_core::crypto::AccountId32",
-                parse_quote!(::subxt::ext::sp_core::crypto::AccountId32),
+                parse_quote!(#crate_path::ext::sp_core::crypto::AccountId32),
             ),
             (
                 "primitive_types::H160",
-                parse_quote!(::subxt::ext::sp_core::H160),
+                parse_quote!(#crate_path::ext::sp_core::H160),
             ),
             (
                 "primitive_types::H256",
-                parse_quote!(::subxt::ext::sp_core::H256),
+                parse_quote!(#crate_path::ext::sp_core::H256),
             ),
             (
                 "primitive_types::H512",
-                parse_quote!(::subxt::ext::sp_core::H512),
+                parse_quote!(#crate_path::ext::sp_core::H512),
             ),
             (
                 "sp_runtime::multiaddress::MultiAddress",
-                parse_quote!(::subxt::ext::sp_runtime::MultiAddress),
+                parse_quote!(#crate_path::ext::sp_runtime::MultiAddress),
             ),
             (
                 "frame_support::traits::misc::WrapperKeepOpaque",
-                parse_quote!(::subxt::utils::WrapperKeepOpaque),
+                parse_quote!(#crate_path::utils::WrapperKeepOpaque),
             ),
             // BTreeMap and BTreeSet impose an `Ord` constraint on their key types. This
             // can cause an issue with generated code that doesn't impl `Ord` by default.
             // Decoding them to Vec by default (KeyedVec is just an alias for Vec with
             // suitable type params) avoids these issues.
-            ("BTreeMap", parse_quote!(::subxt::utils::KeyedVec)),
+            ("BTreeMap", parse_quote!(#crate_path::utils::KeyedVec)),
             ("BTreeSet", parse_quote!(::std::vec::Vec)),
         ]
         .iter()
@@ -162,7 +173,8 @@ impl RuntimeGenerator {
             type_substitutes,
             derives.clone(),
         );
-        let types_mod = type_gen.generate_types_mod();
+        let crate_path = CratePath::new(crate_path);
+        let types_mod = type_gen.generate_types_mod(&crate_path);
         let types_mod_ident = types_mod.ident();
         let pallets_with_mod_names = self
             .metadata
@@ -190,16 +202,23 @@ impl RuntimeGenerator {
         let metadata_hash = get_metadata_per_pallet_hash(&self.metadata, &pallet_names);
 
         let modules = pallets_with_mod_names.iter().map(|(pallet, mod_name)| {
-            let calls =
-                calls::generate_calls(&self.metadata, &type_gen, pallet, types_mod_ident);
+            let calls = calls::generate_calls(
+                &self.metadata,
+                &type_gen,
+                pallet,
+                types_mod_ident,
+                &crate_path,
+            );
 
-            let event = events::generate_events(&type_gen, pallet, types_mod_ident);
+            let event =
+                events::generate_events(&type_gen, pallet, types_mod_ident, &crate_path);
 
             let storage_mod = storage::generate_storage(
                 &self.metadata,
                 &type_gen,
                 pallet,
                 types_mod_ident,
+                &crate_path,
             );
 
             let constants_mod = constants::generate_constants(
@@ -207,6 +226,7 @@ impl RuntimeGenerator {
                 &type_gen,
                 pallet,
                 types_mod_ident,
+                &crate_path,
             );
 
             quote! {
@@ -338,6 +358,7 @@ pub fn generate_structs_from_variants<'a, F>(
     type_id: u32,
     variant_to_struct_name: F,
     error_message_type_name: &str,
+    crate_path: &CratePath,
 ) -> Vec<(String, CompositeDef)>
 where
     F: Fn(&str) -> std::borrow::Cow<str>,
@@ -363,6 +384,7 @@ where
                     Some(parse_quote!(pub)),
                     type_gen,
                     var.docs(),
+                    crate_path,
                 );
                 (var.name().to_string(), struct_def)
             })

--- a/codegen/src/api/mod.rs
+++ b/codegen/src/api/mod.rs
@@ -56,7 +56,7 @@ pub fn generate_runtime_api<P>(
     item_mod: syn::ItemMod,
     path: P,
     derives: DerivesRegistry,
-    crate_path: Option<CratePath>,
+    crate_path: CratePath,
 ) -> TokenStream2
 where
     P: AsRef<path::Path>,
@@ -103,18 +103,10 @@ impl RuntimeGenerator {
         &self,
         item_mod: syn::ItemMod,
         derives: DerivesRegistry,
-        crate_path: Option<CratePath>,
+        crate_path: CratePath,
     ) -> TokenStream2 {
         let item_mod_ir = ir::ItemMod::from(item_mod);
         let default_derives = derives.default_derives();
-
-        let crate_path = match crate_path {
-            Some(crate_path) => crate_path.syn_path().to_owned(),
-            None => {
-                let path = crate::CratePath::default();
-                path.syn_path().to_owned()
-            }
-        };
 
         // Some hardcoded default type substitutes, can be overridden by user
         let mut type_substitutes = [
@@ -172,8 +164,8 @@ impl RuntimeGenerator {
             "runtime_types",
             type_substitutes,
             derives.clone(),
+            crate_path.clone(),
         );
-        let crate_path = CratePath::new(crate_path);
         let types_mod = type_gen.generate_types_mod(&crate_path);
         let types_mod_ident = types_mod.ident();
         let pallets_with_mod_names = self

--- a/codegen/src/api/storage.rs
+++ b/codegen/src/api/storage.rs
@@ -76,7 +76,6 @@ fn generate_storage_entry_fns(
     storage_entry: &StorageEntryMetadata<PortableForm>,
     crate_path: &CratePath,
 ) -> TokenStream2 {
-    let crate_path = crate_path.syn_path();
     let (fields, key_impl) = match storage_entry.ty {
         StorageEntryType::Plain(_) => (vec![], quote!(vec![])),
         StorageEntryType::Map {

--- a/codegen/src/api/storage.rs
+++ b/codegen/src/api/storage.rs
@@ -2,7 +2,10 @@
 // This file is dual-licensed as Apache-2.0 or GPL-3.0.
 // see LICENSE for license details.
 
-use crate::types::TypeGenerator;
+use crate::{
+    types::TypeGenerator,
+    CratePath,
+};
 use frame_metadata::{
     v14::RuntimeMetadataV14,
     PalletMetadata,
@@ -37,6 +40,7 @@ pub fn generate_storage(
     type_gen: &TypeGenerator,
     pallet: &PalletMetadata<PortableForm>,
     types_mod_ident: &syn::Ident,
+    crate_path: &CratePath,
 ) -> TokenStream2 {
     let storage = if let Some(ref storage) = pallet.storage {
         storage
@@ -47,7 +51,9 @@ pub fn generate_storage(
     let storage_fns: Vec<_> = storage
         .entries
         .iter()
-        .map(|entry| generate_storage_entry_fns(metadata, type_gen, pallet, entry))
+        .map(|entry| {
+            generate_storage_entry_fns(metadata, type_gen, pallet, entry, crate_path)
+        })
         .collect();
 
     quote! {
@@ -68,7 +74,9 @@ fn generate_storage_entry_fns(
     type_gen: &TypeGenerator,
     pallet: &PalletMetadata<PortableForm>,
     storage_entry: &StorageEntryMetadata<PortableForm>,
+    crate_path: &CratePath,
 ) -> TokenStream2 {
+    let crate_path = crate_path.syn_path();
     let (fields, key_impl) = match storage_entry.ty {
         StorageEntryType::Plain(_) => (vec![], quote!(vec![])),
         StorageEntryType::Map {
@@ -90,7 +98,7 @@ fn generate_storage_entry_fns(
                         StorageHasher::Identity => "Identity",
                     };
                     let hasher = format_ident!("{}", hasher);
-                    quote!( ::subxt::storage::address::StorageHasher::#hasher )
+                    quote!( #crate_path::storage::address::StorageHasher::#hasher )
                 })
                 .collect::<Vec<_>>();
             match key_ty.type_def() {
@@ -114,7 +122,7 @@ fn generate_storage_entry_fns(
                             .into_iter()
                             .zip(&fields)
                             .map(|(hasher, (field_name, _))| {
-                                quote!( ::subxt::storage::address::StorageMapKey::new(#field_name.borrow(), #hasher) )
+                                quote!( #crate_path::storage::address::StorageMapKey::new(#field_name.borrow(), #hasher) )
                             });
                         quote! {
                             vec![ #( #keys ),* ]
@@ -127,7 +135,7 @@ fn generate_storage_entry_fns(
                         let items =
                             fields.iter().map(|(field_name, _)| quote!( #field_name ));
                         quote! {
-                            vec![ ::subxt::storage::address::StorageMapKey::new(&(#( #items.borrow() ),*), #hasher) ]
+                            vec![ #crate_path::storage::address::StorageMapKey::new(&(#( #items.borrow() ),*), #hasher) ]
                         }
                     } else {
                         // If we hit this condition, we don't know how to handle the number of hashes vs fields
@@ -148,7 +156,7 @@ fn generate_storage_entry_fns(
                         abort_call_site!("No hasher found for single key")
                     });
                     let key_impl = quote! {
-                        vec![ ::subxt::storage::address::StorageMapKey::new(_0.borrow(), #hasher) ]
+                        vec![ #crate_path::storage::address::StorageMapKey::new(_0.borrow(), #hasher) ]
                     };
                     (fields, key_impl)
                 }
@@ -195,7 +203,7 @@ fn generate_storage_entry_fns(
 
     // Is the entry iterable?
     let is_iterable_type = if is_map_type {
-        quote!(::subxt::storage::address::Yes)
+        quote!(#crate_path::storage::address::Yes)
     } else {
         quote!(())
     };
@@ -207,7 +215,7 @@ fn generate_storage_entry_fns(
 
     // Does the entry have a default value?
     let is_defaultable_type = if has_default_value {
-        quote!(::subxt::storage::address::Yes)
+        quote!(#crate_path::storage::address::Yes)
     } else {
         quote!(())
     };
@@ -220,8 +228,8 @@ fn generate_storage_entry_fns(
             #docs_token
             pub fn #fn_name_root(
                 &self,
-            ) -> ::subxt::storage::address::StaticStorageAddress::<::subxt::metadata::DecodeStaticType<#storage_entry_value_ty>, (), #is_defaultable_type, #is_iterable_type> {
-                ::subxt::storage::address::StaticStorageAddress::new(
+            ) -> #crate_path::storage::address::StaticStorageAddress::<#crate_path::metadata::DecodeStaticType<#storage_entry_value_ty>, (), #is_defaultable_type, #is_iterable_type> {
+                #crate_path::storage::address::StaticStorageAddress::new(
                     #pallet_name,
                     #storage_name,
                     Vec::new(),
@@ -239,8 +247,8 @@ fn generate_storage_entry_fns(
         pub fn #fn_name(
             &self,
             #( #key_args, )*
-        ) -> ::subxt::storage::address::StaticStorageAddress::<::subxt::metadata::DecodeStaticType<#storage_entry_value_ty>, ::subxt::storage::address::Yes, #is_defaultable_type, #is_iterable_type> {
-            ::subxt::storage::address::StaticStorageAddress::new(
+        ) -> #crate_path::storage::address::StaticStorageAddress::<#crate_path::metadata::DecodeStaticType<#storage_entry_value_ty>, #crate_path::storage::address::Yes, #is_defaultable_type, #is_iterable_type> {
+            #crate_path::storage::address::StaticStorageAddress::new(
                 #pallet_name,
                 #storage_name,
                 #key_impl,

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -35,7 +35,7 @@
 //! let mut derives = DerivesRegistry::default();
 //! // Generate the Runtime API.
 //! let generator = subxt_codegen::RuntimeGenerator::new(metadata);
-//! let runtime_api = generator.generate_runtime(item_mod, derives, None);
+//! let runtime_api = generator.generate_runtime(item_mod, derives, CratePath::default());
 //! println!("{}", runtime_api);
 //! ```
 

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -32,7 +32,7 @@
 //!     pub mod api {}
 //! );
 //! // Default module derivatives.
-//! let mut derives = DerivesRegistry::default();
+//! let mut derives = DerivesRegistry::new(&CratePath::default());
 //! // Generate the Runtime API.
 //! let generator = subxt_codegen::RuntimeGenerator::new(metadata);
 //! let runtime_api = generator.generate_runtime(item_mod, derives, CratePath::default());

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -21,7 +21,7 @@
 //! use std::fs;
 //! use codec::Decode;
 //! use frame_metadata::RuntimeMetadataPrefixed;
-//! use subxt_codegen::DerivesRegistry;
+//! use subxt_codegen::{CratePath, DerivesRegistry};
 //!
 //! let encoded = fs::read("../artifacts/polkadot_metadata.scale").unwrap();
 //!
@@ -35,7 +35,7 @@
 //! let mut derives = DerivesRegistry::default();
 //! // Generate the Runtime API.
 //! let generator = subxt_codegen::RuntimeGenerator::new(metadata);
-//! let runtime_api = generator.generate_runtime(item_mod, derives);
+//! let runtime_api = generator.generate_runtime(item_mod, derives, None);
 //! println!("{}", runtime_api);
 //! ```
 
@@ -51,6 +51,7 @@ pub use self::{
         RuntimeGenerator,
     },
     types::{
+        CratePath,
         Derives,
         DerivesRegistry,
         Module,

--- a/codegen/src/types/composite_def.rs
+++ b/codegen/src/types/composite_def.rs
@@ -76,7 +76,7 @@ impl CompositeDef {
                             | TypeDefPrimitive::U128
                     )
                 ) {
-                    derives.insert_codec_compact_as(&crate_path.clone())
+                    derives.insert_codec_compact_as(crate_path)
                 }
             }
         }

--- a/codegen/src/types/composite_def.rs
+++ b/codegen/src/types/composite_def.rs
@@ -3,6 +3,7 @@
 // see LICENSE for license details.
 
 use super::{
+    CratePath,
     Derives,
     Field,
     TypeDefParameters,
@@ -10,7 +11,6 @@ use super::{
     TypeParameter,
     TypePath,
 };
-use crate::CratePath;
 use proc_macro2::TokenStream;
 use proc_macro_error::abort_call_site;
 use quote::{

--- a/codegen/src/types/composite_def.rs
+++ b/codegen/src/types/composite_def.rs
@@ -10,6 +10,7 @@ use super::{
     TypeParameter,
     TypePath,
 };
+use crate::CratePath;
 use proc_macro2::TokenStream;
 use proc_macro_error::abort_call_site;
 use quote::{
@@ -41,6 +42,7 @@ pub struct CompositeDef {
 
 impl CompositeDef {
     /// Construct a definition which will generate code for a standalone `struct`.
+    #[allow(clippy::too_many_arguments)]
     pub fn struct_def(
         ty: &Type<PortableForm>,
         ident: &str,
@@ -49,6 +51,7 @@ impl CompositeDef {
         field_visibility: Option<syn::Visibility>,
         type_gen: &TypeGenerator,
         docs: &[String],
+        crate_path: &CratePath,
     ) -> Self {
         let mut derives = type_gen.type_derives(ty);
         let fields: Vec<_> = fields_def.field_types().collect();
@@ -73,7 +76,7 @@ impl CompositeDef {
                             | TypeDefPrimitive::U128
                     )
                 ) {
-                    derives.insert_codec_compact_as()
+                    derives.insert_codec_compact_as(&crate_path.clone())
                 }
             }
         }

--- a/codegen/src/types/derives.rs
+++ b/codegen/src/types/derives.rs
@@ -14,7 +14,7 @@ use std::collections::{
     HashSet,
 };
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct DerivesRegistry {
     default_derives: Derives,
     specific_type_derives: HashMap<syn::TypePath, Derives>,

--- a/codegen/src/types/derives.rs
+++ b/codegen/src/types/derives.rs
@@ -80,7 +80,6 @@ impl FromIterator<syn::Path> for Derives {
 impl Derives {
     /// Add `#crate_path::ext::codec::CompactAs` to the derives.
     pub fn insert_codec_compact_as(&mut self, crate_path: &CratePath) {
-        let crate_path = crate_path.syn_path();
         self.insert(parse_quote!(#crate_path::ext::codec::CompactAs));
     }
 
@@ -97,7 +96,6 @@ impl Derives {
     /// Creates a default instance of `Derives` with the `crate_path` prepended
     /// to the set of default derives that reside in `subxt`.
     pub fn default_with_crate_path(crate_path: &CratePath) -> Self {
-        let crate_path = crate_path.syn_path();
         let mut derives = HashSet::new();
         derives.insert(syn::parse_quote!(#crate_path::ext::codec::Encode));
         derives.insert(syn::parse_quote!(#crate_path::ext::codec::Decode));

--- a/codegen/src/types/derives.rs
+++ b/codegen/src/types/derives.rs
@@ -94,6 +94,8 @@ impl Derives {
         self.derives.insert(derive);
     }
 
+    /// Creates a default instance of `Derives` with the `crate_path` prepended
+    /// to the set of default derives that reside in `subxt`.
     pub fn default_with_crate_path(crate_path: &CratePath) -> Self {
         let crate_path = crate_path.syn_path();
         let mut derives = HashSet::new();

--- a/codegen/src/types/derives.rs
+++ b/codegen/src/types/derives.rs
@@ -14,13 +14,24 @@ use std::collections::{
     HashSet,
 };
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 pub struct DerivesRegistry {
     default_derives: Derives,
     specific_type_derives: HashMap<syn::TypePath, Derives>,
 }
 
 impl DerivesRegistry {
+    /// Creates a new `DeviceRegistry` with the supplied `crate_path`.
+    ///
+    /// The `crate_path` denotes the `subxt` crate access path in the
+    /// generated code.
+    pub fn new(crate_path: &CratePath) -> Self {
+        Self {
+            default_derives: Derives::new(crate_path),
+            specific_type_derives: Default::default(),
+        }
+    }
+
     /// Insert derives to be applied to all generated types.
     pub fn extend_for_all(&mut self, derives: impl IntoIterator<Item = syn::Path>) {
         self.default_derives.derives.extend(derives)
@@ -36,7 +47,7 @@ impl DerivesRegistry {
         let type_derives = self
             .specific_type_derives
             .entry(ty)
-            .or_insert_with(|| Derives::default_with_crate_path(crate_path));
+            .or_insert_with(|| Derives::new(crate_path));
         type_derives.derives.extend(derives)
     }
 
@@ -56,13 +67,6 @@ impl DerivesRegistry {
         }
         Derives { derives: defaults }
     }
-
-    pub fn default_with_crate_path(crate_path: &CratePath) -> Self {
-        Self {
-            default_derives: Derives::default_with_crate_path(crate_path),
-            specific_type_derives: Default::default(),
-        }
-    }
 }
 
 #[derive(Debug, Clone)]
@@ -78,6 +82,16 @@ impl FromIterator<syn::Path> for Derives {
 }
 
 impl Derives {
+    /// Creates a new instance of `Derives` with the `crate_path` prepended
+    /// to the set of default derives that reside in `subxt`.
+    pub fn new(crate_path: &CratePath) -> Self {
+        let mut derives = HashSet::new();
+        derives.insert(syn::parse_quote!(#crate_path::ext::codec::Encode));
+        derives.insert(syn::parse_quote!(#crate_path::ext::codec::Decode));
+        derives.insert(syn::parse_quote!(Debug));
+        Self { derives }
+    }
+
     /// Add `#crate_path::ext::codec::CompactAs` to the derives.
     pub fn insert_codec_compact_as(&mut self, crate_path: &CratePath) {
         self.insert(parse_quote!(#crate_path::ext::codec::CompactAs));
@@ -91,22 +105,6 @@ impl Derives {
 
     pub fn insert(&mut self, derive: syn::Path) {
         self.derives.insert(derive);
-    }
-
-    /// Creates a default instance of `Derives` with the `crate_path` prepended
-    /// to the set of default derives that reside in `subxt`.
-    pub fn default_with_crate_path(crate_path: &CratePath) -> Self {
-        let mut derives = HashSet::new();
-        derives.insert(syn::parse_quote!(#crate_path::ext::codec::Encode));
-        derives.insert(syn::parse_quote!(#crate_path::ext::codec::Decode));
-        derives.insert(syn::parse_quote!(Debug));
-        Self { derives }
-    }
-}
-
-impl Default for Derives {
-    fn default() -> Self {
-        Derives::default_with_crate_path(&CratePath::default())
     }
 }
 

--- a/codegen/src/types/mod.rs
+++ b/codegen/src/types/mod.rs
@@ -391,8 +391,7 @@ impl From<syn::Path> for CratePath {
 
 impl ToTokens for CratePath {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        let crate_path = &self.0;
-        tokens.extend(quote!(#crate_path))
+        self.0.to_tokens(tokens)
     }
 }
 

--- a/codegen/src/types/mod.rs
+++ b/codegen/src/types/mod.rs
@@ -367,11 +367,11 @@ impl Module {
     }
 }
 
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct CratePath(syn::Path);
 
 impl CratePath {
-    /// Crate a new `CratePath` from a `syn::Path`.
+    /// Create a new `CratePath` from a `syn::Path`.
     pub fn new(path: syn::Path) -> Self {
         Self(path)
     }

--- a/codegen/src/types/mod.rs
+++ b/codegen/src/types/mod.rs
@@ -64,7 +64,7 @@ pub struct TypeGenerator<'a> {
     type_substitutes: HashMap<String, syn::TypePath>,
     /// Set of derives with which to annotate generated types.
     derives: DerivesRegistry,
-    /// TODO
+    /// The `subxt` crate access path in the generated code.
     crate_path: CratePath,
 }
 

--- a/codegen/src/types/mod.rs
+++ b/codegen/src/types/mod.rs
@@ -88,7 +88,7 @@ impl<'a> TypeGenerator<'a> {
     }
 
     /// Generate a module containing all types defined in the supplied type registry.
-    pub fn generate_types_mod(&self, crate_path: &CratePath) -> Module {
+    pub fn generate_types_mod(&self) -> Module {
         let mut root_mod =
             Module::new(self.types_mod_ident.clone(), self.types_mod_ident.clone());
 
@@ -103,7 +103,6 @@ impl<'a> TypeGenerator<'a> {
                 ty.ty().path().namespace().to_vec(),
                 &self.types_mod_ident,
                 &mut root_mod,
-                crate_path,
             )
         }
 
@@ -117,7 +116,6 @@ impl<'a> TypeGenerator<'a> {
         path: Vec<String>,
         root_mod_ident: &Ident,
         module: &mut Module,
-        crate_path: &CratePath,
     ) {
         let joined_path = path.join("::");
         if self.type_substitutes.contains_key(&joined_path) {
@@ -135,17 +133,10 @@ impl<'a> TypeGenerator<'a> {
         if path.len() == 1 {
             child_mod.types.insert(
                 ty.path().clone(),
-                TypeDefGen::from_type(ty, self, crate_path),
+                TypeDefGen::from_type(ty, self, &self.crate_path),
             );
         } else {
-            self.insert_type(
-                ty,
-                id,
-                path[1..].to_vec(),
-                root_mod_ident,
-                child_mod,
-                crate_path,
-            )
+            self.insert_type(ty, id, path[1..].to_vec(), root_mod_ident, child_mod)
         }
     }
 

--- a/codegen/src/types/mod.rs
+++ b/codegen/src/types/mod.rs
@@ -410,7 +410,7 @@ impl From<String> for CratePath {
 
 impl From<&str> for CratePath {
     fn from(crate_path: &str) -> Self {
-        Self(syn::Path::from_string(&crate_path).unwrap_or_else(|err| {
+        Self(syn::Path::from_string(crate_path).unwrap_or_else(|err| {
             panic!(
                 "failed converting {:?} to `syn::Path`: {:?}",
                 crate_path, err

--- a/codegen/src/types/tests.rs
+++ b/codegen/src/types/tests.rs
@@ -456,45 +456,6 @@ fn generate_array_field() {
 }
 
 #[test]
-fn generate_array_field_with_custom_prefix() {
-    #[allow(unused)]
-    #[derive(TypeInfo)]
-    struct S {
-        a: [u8; 32],
-    }
-
-    let mut registry = Registry::new();
-    registry.register_type(&meta_type::<S>());
-    let portable_types: PortableRegistry = registry.into();
-
-    let type_gen = TypeGenerator::new(
-        &portable_types,
-        "root",
-        Default::default(),
-        Default::default(),
-    );
-    let types = type_gen.generate_types_mod(&"::foo".into());
-    let tests_mod = get_mod(&types, MOD_PATH).unwrap();
-
-    assert_eq!(
-        tests_mod
-            .into_token_stream()
-            .to_string()
-            .replace(":: subxt", ":: foo"),
-        quote! {
-            pub mod tests {
-                use super::root;
-                #[derive(::foo::ext::codec::Decode, ::foo::ext::codec::Encode, Debug)]
-                pub struct S {
-                    pub a: [::core::primitive::u8; 32usize],
-                }
-            }
-        }
-        .to_string()
-    )
-}
-
-#[test]
 fn option_fields() {
     #[allow(unused)]
     #[derive(TypeInfo)]

--- a/codegen/src/types/tests.rs
+++ b/codegen/src/types/tests.rs
@@ -43,7 +43,8 @@ fn generate_struct_with_primitives() {
         &portable_types,
         "root",
         Default::default(),
-        Default::default(),
+        DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
+        "::subxt_path".into(),
     );
     let types = type_gen.generate_types_mod(&CratePath::default());
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
@@ -54,7 +55,7 @@ fn generate_struct_with_primitives() {
             pub mod tests {
                 use super::root;
 
-                #[derive(::subxt::ext::codec::Decode, ::subxt::ext::codec::Encode, Debug)]
+                #[derive(::subxt_path::ext::codec::Decode, ::subxt_path::ext::codec::Encode, Debug)]
                 pub struct S {
                     pub a: ::core::primitive::bool,
                     pub b: ::core::primitive::u32,
@@ -89,9 +90,10 @@ fn generate_struct_with_a_struct_field() {
         &portable_types,
         "root",
         Default::default(),
-        Default::default(),
+        DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
+        "::subxt_path".into(),
     );
-    let types = type_gen.generate_types_mod(&CratePath::default());
+    let types = type_gen.generate_types_mod(&"::subxt_path".into());
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
 
     assert_eq!(
@@ -100,12 +102,12 @@ fn generate_struct_with_a_struct_field() {
             pub mod tests {
                 use super::root;
 
-                #[derive(::subxt::ext::codec::Decode, ::subxt::ext::codec::Encode, Debug)]
+                #[derive(::subxt_path::ext::codec::Decode, ::subxt_path::ext::codec::Encode, Debug)]
                 pub struct Child {
                     pub a: ::core::primitive::i32,
                 }
 
-                #[derive(::subxt::ext::codec::Decode, ::subxt::ext::codec::Encode, Debug)]
+                #[derive(::subxt_path::ext::codec::Decode, ::subxt_path::ext::codec::Encode, Debug)]
                 pub struct Parent {
                     pub a: ::core::primitive::bool,
                     pub b: root::subxt_codegen::types::tests::Child,
@@ -134,9 +136,10 @@ fn generate_tuple_struct() {
         &portable_types,
         "root",
         Default::default(),
-        Default::default(),
+        DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
+        "::subxt_path".into(),
     );
-    let types = type_gen.generate_types_mod(&CratePath::default());
+    let types = type_gen.generate_types_mod(&"::subxt_path".into());
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
 
     assert_eq!(
@@ -145,10 +148,10 @@ fn generate_tuple_struct() {
                 pub mod tests {
                     use super::root;
 
-                    #[derive(::subxt::ext::codec::Decode, ::subxt::ext::codec::Encode, Debug)]
+                    #[derive(::subxt_path::ext::codec::Decode, ::subxt_path::ext::codec::Encode, Debug)]
                     pub struct Child(pub ::core::primitive::i32,);
 
-                    #[derive(::subxt::ext::codec::Decode, ::subxt::ext::codec::Encode, Debug)]
+                    #[derive(::subxt_path::ext::codec::Decode, ::subxt_path::ext::codec::Encode, Debug)]
                     pub struct Parent(pub ::core::primitive::bool, pub root::subxt_codegen::types::tests::Child,);
                 }
             }
@@ -216,9 +219,10 @@ fn derive_compact_as_for_uint_wrapper_structs() {
         &portable_types,
         "root",
         Default::default(),
-        Default::default(),
+        DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
+        "::subxt_path".into(),
     );
-    let types = type_gen.generate_types_mod(&CratePath::default());
+    let types = type_gen.generate_types_mod(&"::subxt_path".into());
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
 
     assert_eq!(
@@ -227,34 +231,34 @@ fn derive_compact_as_for_uint_wrapper_structs() {
             pub mod tests {
                 use super::root;
 
-                #[derive(::subxt::ext::codec::CompactAs, ::subxt::ext::codec::Decode, ::subxt::ext::codec::Encode, Debug)]
+                #[derive(::subxt_path::ext::codec::CompactAs, ::subxt_path::ext::codec::Decode, ::subxt_path::ext::codec::Encode, Debug)]
                 pub struct Su128 { pub a: ::core::primitive::u128, }
 
-                #[derive(::subxt::ext::codec::CompactAs, ::subxt::ext::codec::Decode, ::subxt::ext::codec::Encode, Debug)]
+                #[derive(::subxt_path::ext::codec::CompactAs, ::subxt_path::ext::codec::Decode, ::subxt_path::ext::codec::Encode, Debug)]
                 pub struct Su16 { pub a: ::core::primitive::u16, }
 
-                #[derive(::subxt::ext::codec::CompactAs, ::subxt::ext::codec::Decode, ::subxt::ext::codec::Encode, Debug)]
+                #[derive(::subxt_path::ext::codec::CompactAs, ::subxt_path::ext::codec::Decode, ::subxt_path::ext::codec::Encode, Debug)]
                 pub struct Su32 { pub a: ::core::primitive::u32, }
 
-                #[derive(::subxt::ext::codec::CompactAs, ::subxt::ext::codec::Decode, ::subxt::ext::codec::Encode, Debug)]
+                #[derive(::subxt_path::ext::codec::CompactAs, ::subxt_path::ext::codec::Decode, ::subxt_path::ext::codec::Encode, Debug)]
                 pub struct Su64 { pub a: ::core::primitive::u64, }
 
-                #[derive(::subxt::ext::codec::CompactAs, ::subxt::ext::codec::Decode, ::subxt::ext::codec::Encode, Debug)]
+                #[derive(::subxt_path::ext::codec::CompactAs, ::subxt_path::ext::codec::Decode, ::subxt_path::ext::codec::Encode, Debug)]
                 pub struct Su8 { pub a: ::core::primitive::u8, }
 
-                #[derive(::subxt::ext::codec::CompactAs, ::subxt::ext::codec::Decode, ::subxt::ext::codec::Encode, Debug)]
+                #[derive(::subxt_path::ext::codec::CompactAs, ::subxt_path::ext::codec::Decode, ::subxt_path::ext::codec::Encode, Debug)]
                 pub struct TSu128(pub ::core::primitive::u128,);
 
-                #[derive(::subxt::ext::codec::CompactAs, ::subxt::ext::codec::Decode, ::subxt::ext::codec::Encode, Debug)]
+                #[derive(::subxt_path::ext::codec::CompactAs, ::subxt_path::ext::codec::Decode, ::subxt_path::ext::codec::Encode, Debug)]
                 pub struct TSu16(pub ::core::primitive::u16,);
 
-                #[derive(::subxt::ext::codec::CompactAs, ::subxt::ext::codec::Decode, ::subxt::ext::codec::Encode, Debug)]
+                #[derive(::subxt_path::ext::codec::CompactAs, ::subxt_path::ext::codec::Decode, ::subxt_path::ext::codec::Encode, Debug)]
                 pub struct TSu32(pub ::core::primitive::u32,);
 
-                #[derive(::subxt::ext::codec::CompactAs, ::subxt::ext::codec::Decode, ::subxt::ext::codec::Encode, Debug)]
+                #[derive(::subxt_path::ext::codec::CompactAs, ::subxt_path::ext::codec::Decode, ::subxt_path::ext::codec::Encode, Debug)]
                 pub struct TSu64(pub ::core::primitive::u64,);
 
-                #[derive(::subxt::ext::codec::CompactAs, ::subxt::ext::codec::Decode, ::subxt::ext::codec::Encode, Debug)]
+                #[derive(::subxt_path::ext::codec::CompactAs, ::subxt_path::ext::codec::Decode, ::subxt_path::ext::codec::Encode, Debug)]
                 pub struct TSu8(pub ::core::primitive::u8,);
             }
         }
@@ -280,7 +284,8 @@ fn generate_enum() {
         &portable_types,
         "root",
         Default::default(),
-        Default::default(),
+        DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
+        "::subxt_path".into(),
     );
     let types = type_gen.generate_types_mod(&CratePath::default());
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
@@ -290,7 +295,7 @@ fn generate_enum() {
         quote! {
             pub mod tests {
                 use super::root;
-                #[derive(::subxt::ext::codec::Decode, ::subxt::ext::codec::Encode, Debug)]
+                #[derive(::subxt_path::ext::codec::Decode, ::subxt_path::ext::codec::Encode, Debug)]
                 pub enum E {
                     # [codec (index = 0)]
                     A,
@@ -338,7 +343,8 @@ fn compact_fields() {
         &portable_types,
         "root",
         Default::default(),
-        Default::default(),
+        DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
+        "::subxt_path".into(),
     );
     let types = type_gen.generate_types_mod(&CratePath::default());
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
@@ -348,7 +354,7 @@ fn compact_fields() {
         quote! {
             pub mod tests {
                 use super::root;
-                #[derive(::subxt::ext::codec::Decode, ::subxt::ext::codec::Encode, Debug)]
+                #[derive(::subxt_path::ext::codec::Decode, ::subxt_path::ext::codec::Encode, Debug)]
                 pub enum E {
                     # [codec (index = 0)]
                     A {
@@ -359,12 +365,12 @@ fn compact_fields() {
                     B( #[codec(compact)] ::core::primitive::u32,),
                 }
 
-                #[derive(::subxt::ext::codec::Decode, ::subxt::ext::codec::Encode, Debug)]
+                #[derive(::subxt_path::ext::codec::Decode, ::subxt_path::ext::codec::Encode, Debug)]
                 pub struct S {
                     #[codec(compact)] pub a: ::core::primitive::u32,
                 }
 
-                #[derive(::subxt::ext::codec::Decode, ::subxt::ext::codec::Encode, Debug)]
+                #[derive(::subxt_path::ext::codec::Decode, ::subxt_path::ext::codec::Encode, Debug)]
                 pub struct TupleStruct(#[codec(compact)] pub ::core::primitive::u32,);
             }
         }
@@ -394,9 +400,10 @@ fn compact_generic_parameter() {
         &portable_types,
         "root",
         Default::default(),
-        Default::default(),
+        DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
+        "::subxt_path".into(),
     );
-    let types = type_gen.generate_types_mod(&CratePath::default());
+    let types = type_gen.generate_types_mod(&"::subxt_path".into());
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
 
     assert_eq!(
@@ -405,13 +412,13 @@ fn compact_generic_parameter() {
             pub mod tests {
                 use super::root;
 
-                #[derive(::subxt::ext::codec::Decode, ::subxt::ext::codec::Encode, Debug)]
+                #[derive(::subxt_path::ext::codec::Decode, ::subxt_path::ext::codec::Encode, Debug)]
                 pub struct S {
-                    pub a: ::core::option::Option<::subxt::ext::codec::Compact<::core::primitive::u128> >,
-                    pub nested: ::core::option::Option<::core::result::Result<::subxt::ext::codec::Compact<::core::primitive::u128>, ::core::primitive::u8 > >,
-                    pub vector: ::std::vec::Vec<::subxt::ext::codec::Compact<::core::primitive::u16> >,
-                    pub array: [::subxt::ext::codec::Compact<::core::primitive::u8>; 32usize],
-                    pub tuple: (::subxt::ext::codec::Compact<::core::primitive::u8>, ::subxt::ext::codec::Compact<::core::primitive::u16>,),
+                    pub a: ::core::option::Option<::subxt_path::ext::codec::Compact<::core::primitive::u128> >,
+                    pub nested: ::core::option::Option<::core::result::Result<::subxt_path::ext::codec::Compact<::core::primitive::u128>, ::core::primitive::u8 > >,
+                    pub vector: ::std::vec::Vec<::subxt_path::ext::codec::Compact<::core::primitive::u16> >,
+                    pub array: [::subxt_path::ext::codec::Compact<::core::primitive::u8>; 32usize],
+                    pub tuple: (::subxt_path::ext::codec::Compact<::core::primitive::u8>, ::subxt_path::ext::codec::Compact<::core::primitive::u16>,),
                 }
             }
         }
@@ -435,7 +442,8 @@ fn generate_array_field() {
         &portable_types,
         "root",
         Default::default(),
-        Default::default(),
+        DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
+        "::subxt_path".into(),
     );
     let types = type_gen.generate_types_mod(&CratePath::default());
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
@@ -445,7 +453,7 @@ fn generate_array_field() {
         quote! {
             pub mod tests {
                 use super::root;
-                #[derive(::subxt::ext::codec::Decode, ::subxt::ext::codec::Encode, Debug)]
+                #[derive(::subxt_path::ext::codec::Decode, ::subxt_path::ext::codec::Encode, Debug)]
                 pub struct S {
                     pub a: [::core::primitive::u8; 32usize],
                 }
@@ -472,7 +480,8 @@ fn option_fields() {
         &portable_types,
         "root",
         Default::default(),
-        Default::default(),
+        DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
+        "::subxt_path".into(),
     );
     let types = type_gen.generate_types_mod(&CratePath::default());
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
@@ -482,7 +491,7 @@ fn option_fields() {
         quote! {
             pub mod tests {
                 use super::root;
-                #[derive(::subxt::ext::codec::Decode, ::subxt::ext::codec::Encode, Debug)]
+                #[derive(::subxt_path::ext::codec::Decode, ::subxt_path::ext::codec::Encode, Debug)]
                 pub struct S {
                     pub a: ::core::option::Option<::core::primitive::bool>,
                     pub b: ::core::option::Option<::core::primitive::u32>,
@@ -512,7 +521,8 @@ fn box_fields_struct() {
         &portable_types,
         "root",
         Default::default(),
-        Default::default(),
+        DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
+        "::subxt_path".into(),
     );
     let types = type_gen.generate_types_mod(&CratePath::default());
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
@@ -522,7 +532,7 @@ fn box_fields_struct() {
         quote! {
             pub mod tests {
                 use super::root;
-                #[derive(::subxt::ext::codec::Decode, ::subxt::ext::codec::Encode, Debug)]
+                #[derive(::subxt_path::ext::codec::Decode, ::subxt_path::ext::codec::Encode, Debug)]
                 pub struct S {
                     pub a: ::std::boxed::Box<::core::primitive::bool>,
                     pub b: ::std::boxed::Box<::core::primitive::u32>,
@@ -552,7 +562,8 @@ fn box_fields_enum() {
         &portable_types,
         "root",
         Default::default(),
-        Default::default(),
+        DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
+        "::subxt_path".into(),
     );
     let types = type_gen.generate_types_mod(&CratePath::default());
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
@@ -562,7 +573,7 @@ fn box_fields_enum() {
         quote! {
             pub mod tests {
                 use super::root;
-                #[derive(::subxt::ext::codec::Decode, ::subxt::ext::codec::Encode, Debug)]
+                #[derive(::subxt_path::ext::codec::Decode, ::subxt_path::ext::codec::Encode, Debug)]
                 pub enum E {
                     # [codec (index = 0)]
                     A(::std::boxed::Box<::core::primitive::bool>,),
@@ -592,7 +603,8 @@ fn range_fields() {
         &portable_types,
         "root",
         Default::default(),
-        Default::default(),
+        DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
+        "::subxt_path".into(),
     );
     let types = type_gen.generate_types_mod(&CratePath::default());
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
@@ -602,7 +614,7 @@ fn range_fields() {
         quote! {
             pub mod tests {
                 use super::root;
-                #[derive(::subxt::ext::codec::Decode, ::subxt::ext::codec::Encode, Debug)]
+                #[derive(::subxt_path::ext::codec::Decode, ::subxt_path::ext::codec::Encode, Debug)]
                 pub struct S {
                     pub a: ::core::ops::Range<::core::primitive::u32>,
                     pub b: ::core::ops::RangeInclusive<::core::primitive::u32>,
@@ -636,9 +648,10 @@ fn generics() {
         &portable_types,
         "root",
         Default::default(),
-        Default::default(),
+        DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
+        "::subxt_path".into(),
     );
-    let types = type_gen.generate_types_mod(&CratePath::default());
+    let types = type_gen.generate_types_mod(&"::subxt_path".into());
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
 
     assert_eq!(
@@ -646,12 +659,12 @@ fn generics() {
         quote! {
             pub mod tests {
                 use super::root;
-                #[derive(::subxt::ext::codec::Decode, ::subxt::ext::codec::Encode, Debug)]
+                #[derive(::subxt_path::ext::codec::Decode, ::subxt_path::ext::codec::Encode, Debug)]
                 pub struct Bar {
                     pub b: root::subxt_codegen::types::tests::Foo<::core::primitive::u32>,
                     pub c: root::subxt_codegen::types::tests::Foo<::core::primitive::u8>,
                 }
-                #[derive(::subxt::ext::codec::Decode, ::subxt::ext::codec::Encode, Debug)]
+                #[derive(::subxt_path::ext::codec::Decode, ::subxt_path::ext::codec::Encode, Debug)]
                 pub struct Foo<_0> {
                     pub a: _0,
                 }
@@ -684,9 +697,10 @@ fn generics_nested() {
         &portable_types,
         "root",
         Default::default(),
-        Default::default(),
+        DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
+        "::subxt_path".into(),
     );
-    let types = type_gen.generate_types_mod(&CratePath::default());
+    let types = type_gen.generate_types_mod(&"::subxt_path".into());
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
 
     assert_eq!(
@@ -694,12 +708,12 @@ fn generics_nested() {
         quote! {
             pub mod tests {
                 use super::root;
-                #[derive(::subxt::ext::codec::Decode, ::subxt::ext::codec::Encode, Debug)]
+                #[derive(::subxt_path::ext::codec::Decode, ::subxt_path::ext::codec::Encode, Debug)]
                 pub struct Bar<_0> {
                     pub b: root::subxt_codegen::types::tests::Foo<_0, ::core::primitive::u32>,
                 }
 
-                #[derive(::subxt::ext::codec::Decode, ::subxt::ext::codec::Encode, Debug)]
+                #[derive(::subxt_path::ext::codec::Decode, ::subxt_path::ext::codec::Encode, Debug)]
                 pub struct Foo<_0, _1> {
                     pub a: _0,
                     pub b: ::core::option::Option<(_0, _1,)>,
@@ -735,9 +749,10 @@ fn generate_bitvec() {
         &portable_types,
         "root",
         Default::default(),
-        Default::default(),
+        DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
+        "::subxt_path".into(),
     );
-    let types = type_gen.generate_types_mod(&CratePath::default());
+    let types = type_gen.generate_types_mod(&"::subxt_path".into());
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
 
     assert_eq!(
@@ -745,10 +760,10 @@ fn generate_bitvec() {
         quote! {
             pub mod tests {
                 use super::root;
-                #[derive(::subxt::ext::codec::Decode, ::subxt::ext::codec::Encode, Debug)]
+                #[derive(::subxt_path::ext::codec::Decode, ::subxt_path::ext::codec::Encode, Debug)]
                 pub struct S {
-                    pub lsb: ::subxt::ext::bitvec::vec::BitVec<::core::primitive::u8, root::bitvec::order::Lsb0>,
-                    pub msb: ::subxt::ext::bitvec::vec::BitVec<::core::primitive::u16, root::bitvec::order::Msb0>,
+                    pub lsb: ::subxt_path::ext::bitvec::vec::BitVec<::core::primitive::u8, root::bitvec::order::Lsb0>,
+                    pub msb: ::subxt_path::ext::bitvec::vec::BitVec<::core::primitive::u16, root::bitvec::order::Msb0>,
                 }
             }
         }
@@ -788,9 +803,10 @@ fn generics_with_alias_adds_phantom_data_marker() {
         &portable_types,
         "root",
         Default::default(),
-        Default::default(),
+        DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
+        "::subxt_path".into(),
     );
-    let types = type_gen.generate_types_mod(&CratePath::default());
+    let types = type_gen.generate_types_mod(&"::subxt_path".into());
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
 
     assert_eq!(
@@ -798,12 +814,12 @@ fn generics_with_alias_adds_phantom_data_marker() {
             quote! {
                 pub mod tests {
                     use super::root;
-                    #[derive(::subxt::ext::codec::CompactAs, ::subxt::ext::codec::Decode, ::subxt::ext::codec::Encode, Debug)]
+                    #[derive(::subxt_path::ext::codec::CompactAs, ::subxt_path::ext::codec::Decode, ::subxt_path::ext::codec::Encode, Debug)]
                     pub struct NamedFields<_0> {
                         pub b: ::core::primitive::u32,
                         #[codec(skip)] pub __subxt_unused_type_params: ::core::marker::PhantomData<_0>
                     }
-                    #[derive(::subxt::ext::codec::Decode, ::subxt::ext::codec::Encode, Debug)]
+                    #[derive(::subxt_path::ext::codec::Decode, ::subxt_path::ext::codec::Encode, Debug)]
                     pub struct UnnamedFields<_0, _1> (
                         pub (::core::primitive::u32, ::core::primitive::u32,),
                         #[codec(skip)] pub ::core::marker::PhantomData<(_0, _1)>
@@ -848,9 +864,10 @@ fn modules() {
         &portable_types,
         "root",
         Default::default(),
-        Default::default(),
+        DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
+        "::subxt_path".into(),
     );
-    let types = type_gen.generate_types_mod(&CratePath::default());
+    let types = type_gen.generate_types_mod(&"::subxt_path".into());
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
 
     assert_eq!(
@@ -866,20 +883,20 @@ fn modules() {
                         pub mod b {
                             use super::root;
 
-                            #[derive(::subxt::ext::codec::Decode, ::subxt::ext::codec::Encode, Debug)]
+                            #[derive(::subxt_path::ext::codec::Decode, ::subxt_path::ext::codec::Encode, Debug)]
                             pub struct Bar {
                                 pub a: root::subxt_codegen::types::tests::m::a::Foo,
                             }
                         }
 
-                        #[derive(::subxt::ext::codec::Decode, ::subxt::ext::codec::Encode, Debug)]
+                        #[derive(::subxt_path::ext::codec::Decode, ::subxt_path::ext::codec::Encode, Debug)]
                         pub struct Foo;
                     }
 
                     pub mod c {
                         use super::root;
 
-                        #[derive(::subxt::ext::codec::Decode, ::subxt::ext::codec::Encode, Debug)]
+                        #[derive(::subxt_path::ext::codec::Decode, ::subxt_path::ext::codec::Encode, Debug)]
                         pub struct Foo {
                             pub a: root::subxt_codegen::types::tests::m::a::b::Bar,
                         }
@@ -905,7 +922,8 @@ fn dont_force_struct_names_camel_case() {
         &portable_types,
         "root",
         Default::default(),
-        Default::default(),
+        DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
+        "::subxt_path".into(),
     );
     let types = type_gen.generate_types_mod(&CratePath::default());
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
@@ -916,7 +934,7 @@ fn dont_force_struct_names_camel_case() {
             pub mod tests {
                 use super::root;
 
-                #[derive(::subxt::ext::codec::Decode, ::subxt::ext::codec::Encode, Debug)]
+                #[derive(::subxt_path::ext::codec::Decode, ::subxt_path::ext::codec::Encode, Debug)]
                 pub struct AB;
             }
         }
@@ -939,11 +957,16 @@ fn apply_user_defined_derives_for_all_types() {
     let portable_types: PortableRegistry = registry.into();
 
     // configure derives
-    let mut derives = DerivesRegistry::default();
+    let mut derives = DerivesRegistry::default_with_crate_path(&"::subxt_path".into());
     derives.extend_for_all(vec![parse_quote!(Clone), parse_quote!(Eq)]);
 
-    let type_gen =
-        TypeGenerator::new(&portable_types, "root", Default::default(), derives);
+    let type_gen = TypeGenerator::new(
+        &portable_types,
+        "root",
+        Default::default(),
+        derives,
+        "::subxt_path".into(),
+    );
     let types = type_gen.generate_types_mod(&CratePath::default());
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
 
@@ -953,10 +976,10 @@ fn apply_user_defined_derives_for_all_types() {
             pub mod tests {
                 use super::root;
 
-                #[derive(::subxt::ext::codec::Decode, ::subxt::ext::codec::Encode, Clone, Debug, Eq)]
+                #[derive(::subxt_path::ext::codec::Decode, ::subxt_path::ext::codec::Encode, Clone, Debug, Eq)]
                 pub struct A(pub root :: subxt_codegen :: types :: tests :: B,);
 
-                #[derive(::subxt::ext::codec::Decode, ::subxt::ext::codec::Encode, Clone, Debug, Eq)]
+                #[derive(::subxt_path::ext::codec::Decode, ::subxt_path::ext::codec::Encode, Clone, Debug, Eq)]
                 pub struct B;
             }
         }
@@ -983,14 +1006,14 @@ fn apply_user_defined_derives_for_specific_types() {
     let portable_types: PortableRegistry = registry.into();
 
     // configure derives
-    let mut derives = DerivesRegistry::default();
+    let mut derives = DerivesRegistry::default_with_crate_path(&"::subxt_path".into());
     // for all types
     derives.extend_for_all(vec![parse_quote!(Eq)]);
     // for specific types
     derives.extend_for_type(
         parse_quote!(subxt_codegen::types::tests::B),
         vec![parse_quote!(Hash)],
-        &CratePath::default(),
+        &"::subxt_path".into(),
     );
     // duplicates (in this case `Eq`) will be combined (i.e. a set union)
     derives.extend_for_type(
@@ -1000,12 +1023,17 @@ fn apply_user_defined_derives_for_specific_types() {
             parse_quote!(Ord),
             parse_quote!(PartialOrd),
         ],
-        &CratePath::default(),
+        &"::subxt_path".into(),
     );
 
-    let type_gen =
-        TypeGenerator::new(&portable_types, "root", Default::default(), derives);
-    let types = type_gen.generate_types_mod(&CratePath::default());
+    let type_gen = TypeGenerator::new(
+        &portable_types,
+        "root",
+        Default::default(),
+        derives,
+        "::subxt_path".into(),
+    );
+    let types = type_gen.generate_types_mod(&"::subxt_path".into());
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
 
     assert_eq!(
@@ -1014,13 +1042,13 @@ fn apply_user_defined_derives_for_specific_types() {
             pub mod tests {
                 use super::root;
 
-                #[derive(::subxt::ext::codec::Decode, ::subxt::ext::codec::Encode, Debug, Eq)]
+                #[derive(::subxt_path::ext::codec::Decode, ::subxt_path::ext::codec::Encode, Debug, Eq)]
                 pub struct A(pub root :: subxt_codegen :: types :: tests :: B,);
 
-                #[derive(::subxt::ext::codec::Decode, ::subxt::ext::codec::Encode, Debug, Eq, Hash)]
+                #[derive(::subxt_path::ext::codec::Decode, ::subxt_path::ext::codec::Encode, Debug, Eq, Hash)]
                 pub struct B(pub root :: subxt_codegen :: types :: tests :: C,);
 
-                #[derive(::subxt::ext::codec::Decode, ::subxt::ext::codec::Encode, Debug, Eq, Ord, PartialOrd)]
+                #[derive(::subxt_path::ext::codec::Decode, ::subxt_path::ext::codec::Encode, Debug, Eq, Ord, PartialOrd)]
                 pub struct C;
             }
         }

--- a/codegen/src/types/tests.rs
+++ b/codegen/src/types/tests.rs
@@ -46,7 +46,7 @@ fn generate_struct_with_primitives() {
         DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
         "::subxt_path".into(),
     );
-    let types = type_gen.generate_types_mod(&CratePath::default());
+    let types = type_gen.generate_types_mod();
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
 
     assert_eq!(
@@ -93,7 +93,7 @@ fn generate_struct_with_a_struct_field() {
         DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
         "::subxt_path".into(),
     );
-    let types = type_gen.generate_types_mod(&"::subxt_path".into());
+    let types = type_gen.generate_types_mod();
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
 
     assert_eq!(
@@ -139,7 +139,7 @@ fn generate_tuple_struct() {
         DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
         "::subxt_path".into(),
     );
-    let types = type_gen.generate_types_mod(&"::subxt_path".into());
+    let types = type_gen.generate_types_mod();
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
 
     assert_eq!(
@@ -222,7 +222,7 @@ fn derive_compact_as_for_uint_wrapper_structs() {
         DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
         "::subxt_path".into(),
     );
-    let types = type_gen.generate_types_mod(&"::subxt_path".into());
+    let types = type_gen.generate_types_mod();
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
 
     assert_eq!(
@@ -287,7 +287,7 @@ fn generate_enum() {
         DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
         "::subxt_path".into(),
     );
-    let types = type_gen.generate_types_mod(&CratePath::default());
+    let types = type_gen.generate_types_mod();
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
 
     assert_eq!(
@@ -346,7 +346,7 @@ fn compact_fields() {
         DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
         "::subxt_path".into(),
     );
-    let types = type_gen.generate_types_mod(&CratePath::default());
+    let types = type_gen.generate_types_mod();
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
 
     assert_eq!(
@@ -403,7 +403,7 @@ fn compact_generic_parameter() {
         DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
         "::subxt_path".into(),
     );
-    let types = type_gen.generate_types_mod(&"::subxt_path".into());
+    let types = type_gen.generate_types_mod();
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
 
     assert_eq!(
@@ -445,7 +445,7 @@ fn generate_array_field() {
         DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
         "::subxt_path".into(),
     );
-    let types = type_gen.generate_types_mod(&CratePath::default());
+    let types = type_gen.generate_types_mod();
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
 
     assert_eq!(
@@ -483,7 +483,7 @@ fn option_fields() {
         DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
         "::subxt_path".into(),
     );
-    let types = type_gen.generate_types_mod(&CratePath::default());
+    let types = type_gen.generate_types_mod();
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
 
     assert_eq!(
@@ -524,7 +524,7 @@ fn box_fields_struct() {
         DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
         "::subxt_path".into(),
     );
-    let types = type_gen.generate_types_mod(&CratePath::default());
+    let types = type_gen.generate_types_mod();
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
 
     assert_eq!(
@@ -565,7 +565,7 @@ fn box_fields_enum() {
         DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
         "::subxt_path".into(),
     );
-    let types = type_gen.generate_types_mod(&CratePath::default());
+    let types = type_gen.generate_types_mod();
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
 
     assert_eq!(
@@ -606,7 +606,7 @@ fn range_fields() {
         DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
         "::subxt_path".into(),
     );
-    let types = type_gen.generate_types_mod(&CratePath::default());
+    let types = type_gen.generate_types_mod();
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
 
     assert_eq!(
@@ -651,7 +651,7 @@ fn generics() {
         DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
         "::subxt_path".into(),
     );
-    let types = type_gen.generate_types_mod(&"::subxt_path".into());
+    let types = type_gen.generate_types_mod();
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
 
     assert_eq!(
@@ -700,7 +700,7 @@ fn generics_nested() {
         DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
         "::subxt_path".into(),
     );
-    let types = type_gen.generate_types_mod(&"::subxt_path".into());
+    let types = type_gen.generate_types_mod();
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
 
     assert_eq!(
@@ -752,7 +752,7 @@ fn generate_bitvec() {
         DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
         "::subxt_path".into(),
     );
-    let types = type_gen.generate_types_mod(&"::subxt_path".into());
+    let types = type_gen.generate_types_mod();
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
 
     assert_eq!(
@@ -806,7 +806,7 @@ fn generics_with_alias_adds_phantom_data_marker() {
         DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
         "::subxt_path".into(),
     );
-    let types = type_gen.generate_types_mod(&"::subxt_path".into());
+    let types = type_gen.generate_types_mod();
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
 
     assert_eq!(
@@ -867,7 +867,7 @@ fn modules() {
         DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
         "::subxt_path".into(),
     );
-    let types = type_gen.generate_types_mod(&"::subxt_path".into());
+    let types = type_gen.generate_types_mod();
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
 
     assert_eq!(
@@ -925,7 +925,7 @@ fn dont_force_struct_names_camel_case() {
         DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
         "::subxt_path".into(),
     );
-    let types = type_gen.generate_types_mod(&CratePath::default());
+    let types = type_gen.generate_types_mod();
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
 
     assert_eq!(
@@ -967,7 +967,7 @@ fn apply_user_defined_derives_for_all_types() {
         derives,
         "::subxt_path".into(),
     );
-    let types = type_gen.generate_types_mod(&CratePath::default());
+    let types = type_gen.generate_types_mod();
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
 
     assert_eq!(
@@ -1033,7 +1033,7 @@ fn apply_user_defined_derives_for_specific_types() {
         derives,
         "::subxt_path".into(),
     );
-    let types = type_gen.generate_types_mod(&"::subxt_path".into());
+    let types = type_gen.generate_types_mod();
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
 
     assert_eq!(

--- a/codegen/src/types/tests.rs
+++ b/codegen/src/types/tests.rs
@@ -43,7 +43,7 @@ fn generate_struct_with_primitives() {
         &portable_types,
         "root",
         Default::default(),
-        DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
+        DerivesRegistry::new(&"::subxt_path".into()),
         "::subxt_path".into(),
     );
     let types = type_gen.generate_types_mod();
@@ -90,7 +90,7 @@ fn generate_struct_with_a_struct_field() {
         &portable_types,
         "root",
         Default::default(),
-        DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
+        DerivesRegistry::new(&"::subxt_path".into()),
         "::subxt_path".into(),
     );
     let types = type_gen.generate_types_mod();
@@ -136,7 +136,7 @@ fn generate_tuple_struct() {
         &portable_types,
         "root",
         Default::default(),
-        DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
+        DerivesRegistry::new(&"::subxt_path".into()),
         "::subxt_path".into(),
     );
     let types = type_gen.generate_types_mod();
@@ -219,7 +219,7 @@ fn derive_compact_as_for_uint_wrapper_structs() {
         &portable_types,
         "root",
         Default::default(),
-        DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
+        DerivesRegistry::new(&"::subxt_path".into()),
         "::subxt_path".into(),
     );
     let types = type_gen.generate_types_mod();
@@ -284,7 +284,7 @@ fn generate_enum() {
         &portable_types,
         "root",
         Default::default(),
-        DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
+        DerivesRegistry::new(&"::subxt_path".into()),
         "::subxt_path".into(),
     );
     let types = type_gen.generate_types_mod();
@@ -343,7 +343,7 @@ fn compact_fields() {
         &portable_types,
         "root",
         Default::default(),
-        DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
+        DerivesRegistry::new(&"::subxt_path".into()),
         "::subxt_path".into(),
     );
     let types = type_gen.generate_types_mod();
@@ -400,7 +400,7 @@ fn compact_generic_parameter() {
         &portable_types,
         "root",
         Default::default(),
-        DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
+        DerivesRegistry::new(&"::subxt_path".into()),
         "::subxt_path".into(),
     );
     let types = type_gen.generate_types_mod();
@@ -442,7 +442,7 @@ fn generate_array_field() {
         &portable_types,
         "root",
         Default::default(),
-        DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
+        DerivesRegistry::new(&"::subxt_path".into()),
         "::subxt_path".into(),
     );
     let types = type_gen.generate_types_mod();
@@ -480,7 +480,7 @@ fn option_fields() {
         &portable_types,
         "root",
         Default::default(),
-        DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
+        DerivesRegistry::new(&"::subxt_path".into()),
         "::subxt_path".into(),
     );
     let types = type_gen.generate_types_mod();
@@ -521,7 +521,7 @@ fn box_fields_struct() {
         &portable_types,
         "root",
         Default::default(),
-        DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
+        DerivesRegistry::new(&"::subxt_path".into()),
         "::subxt_path".into(),
     );
     let types = type_gen.generate_types_mod();
@@ -562,7 +562,7 @@ fn box_fields_enum() {
         &portable_types,
         "root",
         Default::default(),
-        DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
+        DerivesRegistry::new(&"::subxt_path".into()),
         "::subxt_path".into(),
     );
     let types = type_gen.generate_types_mod();
@@ -603,7 +603,7 @@ fn range_fields() {
         &portable_types,
         "root",
         Default::default(),
-        DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
+        DerivesRegistry::new(&"::subxt_path".into()),
         "::subxt_path".into(),
     );
     let types = type_gen.generate_types_mod();
@@ -648,7 +648,7 @@ fn generics() {
         &portable_types,
         "root",
         Default::default(),
-        DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
+        DerivesRegistry::new(&"::subxt_path".into()),
         "::subxt_path".into(),
     );
     let types = type_gen.generate_types_mod();
@@ -697,7 +697,7 @@ fn generics_nested() {
         &portable_types,
         "root",
         Default::default(),
-        DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
+        DerivesRegistry::new(&"::subxt_path".into()),
         "::subxt_path".into(),
     );
     let types = type_gen.generate_types_mod();
@@ -749,7 +749,7 @@ fn generate_bitvec() {
         &portable_types,
         "root",
         Default::default(),
-        DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
+        DerivesRegistry::new(&"::subxt_path".into()),
         "::subxt_path".into(),
     );
     let types = type_gen.generate_types_mod();
@@ -803,7 +803,7 @@ fn generics_with_alias_adds_phantom_data_marker() {
         &portable_types,
         "root",
         Default::default(),
-        DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
+        DerivesRegistry::new(&"::subxt_path".into()),
         "::subxt_path".into(),
     );
     let types = type_gen.generate_types_mod();
@@ -864,7 +864,7 @@ fn modules() {
         &portable_types,
         "root",
         Default::default(),
-        DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
+        DerivesRegistry::new(&"::subxt_path".into()),
         "::subxt_path".into(),
     );
     let types = type_gen.generate_types_mod();
@@ -922,7 +922,7 @@ fn dont_force_struct_names_camel_case() {
         &portable_types,
         "root",
         Default::default(),
-        DerivesRegistry::default_with_crate_path(&"::subxt_path".into()),
+        DerivesRegistry::new(&"::subxt_path".into()),
         "::subxt_path".into(),
     );
     let types = type_gen.generate_types_mod();
@@ -957,7 +957,7 @@ fn apply_user_defined_derives_for_all_types() {
     let portable_types: PortableRegistry = registry.into();
 
     // configure derives
-    let mut derives = DerivesRegistry::default_with_crate_path(&"::subxt_path".into());
+    let mut derives = DerivesRegistry::new(&"::subxt_path".into());
     derives.extend_for_all(vec![parse_quote!(Clone), parse_quote!(Eq)]);
 
     let type_gen = TypeGenerator::new(
@@ -1006,7 +1006,7 @@ fn apply_user_defined_derives_for_specific_types() {
     let portable_types: PortableRegistry = registry.into();
 
     // configure derives
-    let mut derives = DerivesRegistry::default_with_crate_path(&"::subxt_path".into());
+    let mut derives = DerivesRegistry::new(&"::subxt_path".into());
     // for all types
     derives.extend_for_all(vec![parse_quote!(Eq)]);
     // for specific types

--- a/codegen/src/types/tests.rs
+++ b/codegen/src/types/tests.rs
@@ -45,7 +45,7 @@ fn generate_struct_with_primitives() {
         Default::default(),
         Default::default(),
     );
-    let types = type_gen.generate_types_mod();
+    let types = type_gen.generate_types_mod(&CratePath::default());
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
 
     assert_eq!(
@@ -91,7 +91,7 @@ fn generate_struct_with_a_struct_field() {
         Default::default(),
         Default::default(),
     );
-    let types = type_gen.generate_types_mod();
+    let types = type_gen.generate_types_mod(&CratePath::default());
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
 
     assert_eq!(
@@ -136,7 +136,7 @@ fn generate_tuple_struct() {
         Default::default(),
         Default::default(),
     );
-    let types = type_gen.generate_types_mod();
+    let types = type_gen.generate_types_mod(&CratePath::default());
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
 
     assert_eq!(
@@ -218,7 +218,7 @@ fn derive_compact_as_for_uint_wrapper_structs() {
         Default::default(),
         Default::default(),
     );
-    let types = type_gen.generate_types_mod();
+    let types = type_gen.generate_types_mod(&CratePath::default());
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
 
     assert_eq!(
@@ -282,7 +282,7 @@ fn generate_enum() {
         Default::default(),
         Default::default(),
     );
-    let types = type_gen.generate_types_mod();
+    let types = type_gen.generate_types_mod(&CratePath::default());
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
 
     assert_eq!(
@@ -340,7 +340,7 @@ fn compact_fields() {
         Default::default(),
         Default::default(),
     );
-    let types = type_gen.generate_types_mod();
+    let types = type_gen.generate_types_mod(&CratePath::default());
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
 
     assert_eq!(
@@ -396,7 +396,7 @@ fn compact_generic_parameter() {
         Default::default(),
         Default::default(),
     );
-    let types = type_gen.generate_types_mod();
+    let types = type_gen.generate_types_mod(&CratePath::default());
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
 
     assert_eq!(
@@ -437,7 +437,7 @@ fn generate_array_field() {
         Default::default(),
         Default::default(),
     );
-    let types = type_gen.generate_types_mod();
+    let types = type_gen.generate_types_mod(&CratePath::default());
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
 
     assert_eq!(
@@ -446,6 +446,45 @@ fn generate_array_field() {
             pub mod tests {
                 use super::root;
                 #[derive(::subxt::ext::codec::Decode, ::subxt::ext::codec::Encode, Debug)]
+                pub struct S {
+                    pub a: [::core::primitive::u8; 32usize],
+                }
+            }
+        }
+        .to_string()
+    )
+}
+
+#[test]
+fn generate_array_field_with_custom_prefix() {
+    #[allow(unused)]
+    #[derive(TypeInfo)]
+    struct S {
+        a: [u8; 32],
+    }
+
+    let mut registry = Registry::new();
+    registry.register_type(&meta_type::<S>());
+    let portable_types: PortableRegistry = registry.into();
+
+    let type_gen = TypeGenerator::new(
+        &portable_types,
+        "root",
+        Default::default(),
+        Default::default(),
+    );
+    let types = type_gen.generate_types_mod(&"::foo".into());
+    let tests_mod = get_mod(&types, MOD_PATH).unwrap();
+
+    assert_eq!(
+        tests_mod
+            .into_token_stream()
+            .to_string()
+            .replace(":: subxt", ":: foo"),
+        quote! {
+            pub mod tests {
+                use super::root;
+                #[derive(::foo::ext::codec::Decode, ::foo::ext::codec::Encode, Debug)]
                 pub struct S {
                     pub a: [::core::primitive::u8; 32usize],
                 }
@@ -474,7 +513,7 @@ fn option_fields() {
         Default::default(),
         Default::default(),
     );
-    let types = type_gen.generate_types_mod();
+    let types = type_gen.generate_types_mod(&CratePath::default());
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
 
     assert_eq!(
@@ -514,7 +553,7 @@ fn box_fields_struct() {
         Default::default(),
         Default::default(),
     );
-    let types = type_gen.generate_types_mod();
+    let types = type_gen.generate_types_mod(&CratePath::default());
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
 
     assert_eq!(
@@ -554,7 +593,7 @@ fn box_fields_enum() {
         Default::default(),
         Default::default(),
     );
-    let types = type_gen.generate_types_mod();
+    let types = type_gen.generate_types_mod(&CratePath::default());
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
 
     assert_eq!(
@@ -594,7 +633,7 @@ fn range_fields() {
         Default::default(),
         Default::default(),
     );
-    let types = type_gen.generate_types_mod();
+    let types = type_gen.generate_types_mod(&CratePath::default());
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
 
     assert_eq!(
@@ -638,7 +677,7 @@ fn generics() {
         Default::default(),
         Default::default(),
     );
-    let types = type_gen.generate_types_mod();
+    let types = type_gen.generate_types_mod(&CratePath::default());
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
 
     assert_eq!(
@@ -686,7 +725,7 @@ fn generics_nested() {
         Default::default(),
         Default::default(),
     );
-    let types = type_gen.generate_types_mod();
+    let types = type_gen.generate_types_mod(&CratePath::default());
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
 
     assert_eq!(
@@ -737,7 +776,7 @@ fn generate_bitvec() {
         Default::default(),
         Default::default(),
     );
-    let types = type_gen.generate_types_mod();
+    let types = type_gen.generate_types_mod(&CratePath::default());
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
 
     assert_eq!(
@@ -790,7 +829,7 @@ fn generics_with_alias_adds_phantom_data_marker() {
         Default::default(),
         Default::default(),
     );
-    let types = type_gen.generate_types_mod();
+    let types = type_gen.generate_types_mod(&CratePath::default());
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
 
     assert_eq!(
@@ -850,7 +889,7 @@ fn modules() {
         Default::default(),
         Default::default(),
     );
-    let types = type_gen.generate_types_mod();
+    let types = type_gen.generate_types_mod(&CratePath::default());
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
 
     assert_eq!(
@@ -907,7 +946,7 @@ fn dont_force_struct_names_camel_case() {
         Default::default(),
         Default::default(),
     );
-    let types = type_gen.generate_types_mod();
+    let types = type_gen.generate_types_mod(&CratePath::default());
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
 
     assert_eq!(
@@ -944,7 +983,7 @@ fn apply_user_defined_derives_for_all_types() {
 
     let type_gen =
         TypeGenerator::new(&portable_types, "root", Default::default(), derives);
-    let types = type_gen.generate_types_mod();
+    let types = type_gen.generate_types_mod(&CratePath::default());
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
 
     assert_eq!(
@@ -990,6 +1029,7 @@ fn apply_user_defined_derives_for_specific_types() {
     derives.extend_for_type(
         parse_quote!(subxt_codegen::types::tests::B),
         vec![parse_quote!(Hash)],
+        &CratePath::default(),
     );
     // duplicates (in this case `Eq`) will be combined (i.e. a set union)
     derives.extend_for_type(
@@ -999,11 +1039,12 @@ fn apply_user_defined_derives_for_specific_types() {
             parse_quote!(Ord),
             parse_quote!(PartialOrd),
         ],
+        &CratePath::default(),
     );
 
     let type_gen =
         TypeGenerator::new(&portable_types, "root", Default::default(), derives);
-    let types = type_gen.generate_types_mod();
+    let types = type_gen.generate_types_mod(&CratePath::default());
     let tests_mod = get_mod(&types, MOD_PATH).unwrap();
 
     assert_eq!(

--- a/codegen/src/types/type_def.rs
+++ b/codegen/src/types/type_def.rs
@@ -5,6 +5,7 @@
 use super::{
     CompositeDef,
     CompositeDefFields,
+    CratePath,
     Derives,
     TypeDefParameters,
     TypeGenerator,
@@ -40,7 +41,11 @@ pub struct TypeDefGen {
 
 impl TypeDefGen {
     /// Construct a type definition for codegen from the given [`scale_info::Type`].
-    pub fn from_type(ty: Type<PortableForm>, type_gen: &TypeGenerator) -> Self {
+    pub fn from_type(
+        ty: Type<PortableForm>,
+        type_gen: &TypeGenerator,
+        crate_path: &CratePath,
+    ) -> Self {
         let derives = type_gen.type_derives(&ty);
 
         let type_params = ty
@@ -82,6 +87,7 @@ impl TypeDefGen {
                     Some(parse_quote!(pub)),
                     type_gen,
                     ty.docs(),
+                    crate_path,
                 );
                 TypeDefGenKind::Struct(composite_def)
             }

--- a/codegen/src/types/type_path.rs
+++ b/codegen/src/types/type_path.rs
@@ -3,6 +3,7 @@
 // see LICENSE for license details.
 
 use crate::CratePath;
+
 use proc_macro2::{
     Ident,
     TokenStream,

--- a/codegen/src/types/type_path.rs
+++ b/codegen/src/types/type_path.rs
@@ -2,6 +2,7 @@
 // This file is dual-licensed as Apache-2.0 or GPL-3.0.
 // see LICENSE for license details.
 
+use crate::CratePath;
 use proc_macro2::{
     Ident,
     TokenStream,
@@ -96,10 +97,12 @@ pub enum TypePathType {
     Compact {
         inner: Box<TypePath>,
         is_field: bool,
+        crate_path: CratePath,
     },
     BitVec {
         bit_order_type: Box<TypePath>,
         bit_store_type: Box<TypePath>,
+        crate_path: CratePath,
     },
 }
 
@@ -170,6 +173,7 @@ impl TypePathType {
             TypePathType::BitVec {
                 bit_order_type,
                 bit_store_type,
+                crate_path: _,
             } => {
                 bit_order_type.parent_type_params(acc);
                 bit_store_type.parent_type_params(acc);
@@ -222,21 +226,26 @@ impl TypePathType {
                     TypeDefPrimitive::I256 => unimplemented!("not a rust primitive"),
                 })
             }
-            TypePathType::Compact { inner, is_field } => {
+            TypePathType::Compact {
+                inner,
+                is_field,
+                crate_path,
+            } => {
                 let path = if *is_field {
                     // compact fields can use the inner compact type directly and be annotated with
                     // the `compact` attribute e.g. `#[codec(compact)] my_compact_field: u128`
                     parse_quote! ( #inner )
                 } else {
-                    parse_quote! ( ::subxt::ext::codec::Compact<#inner> )
+                    parse_quote! ( #crate_path::ext::codec::Compact<#inner> )
                 };
                 syn::Type::Path(path)
             }
             TypePathType::BitVec {
                 bit_order_type,
                 bit_store_type,
+                crate_path,
             } => {
-                let type_path = parse_quote! { ::subxt::ext::bitvec::vec::BitVec<#bit_store_type, #bit_order_type> };
+                let type_path = parse_quote! { #crate_path::ext::bitvec::vec::BitVec<#bit_store_type, #bit_order_type> };
                 syn::Type::Path(type_path)
             }
         }

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -134,7 +134,7 @@ pub fn subxt(args: TokenStream, input: TokenStream) -> TokenStream {
         Some(crate_path) => crate_path.into(),
         None => subxt_codegen::CratePath::default(),
     };
-    let mut derives_registry = DerivesRegistry::default_with_crate_path(&crate_path);
+    let mut derives_registry = DerivesRegistry::new(&crate_path);
     if let Some(derive_for_all) = args.derive_for_all_types {
         derives_registry.extend_for_all(derive_for_all.iter().cloned());
     }

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -146,11 +146,6 @@ pub fn subxt(args: TokenStream, input: TokenStream) -> TokenStream {
         )
     }
 
-    subxt_codegen::generate_runtime_api(
-        item_mod,
-        &path,
-        derives_registry,
-        Some(crate_path),
-    )
-    .into()
+    subxt_codegen::generate_runtime_api(item_mod, &path, derives_registry, crate_path)
+        .into()
 }

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -95,6 +95,8 @@ struct RuntimeMetadataArgs {
     derive_for_all_types: Option<Punctuated<syn::Path, syn::Token![,]>>,
     #[darling(multiple)]
     derive_for_type: Vec<DeriveForType>,
+    #[darling(default, rename = "crate")]
+    crate_path: Option<String>,
 }
 
 #[derive(Debug, FromMeta)]
@@ -118,14 +120,27 @@ pub fn subxt(args: TokenStream, input: TokenStream) -> TokenStream {
     let root_path = std::path::Path::new(&root);
     let path = root_path.join(args.runtime_metadata_path);
 
-    let mut derives_registry = DerivesRegistry::default();
+    let crate_path = match args.crate_path {
+        Some(crate_path) => crate_path.into(),
+        None => subxt_codegen::CratePath::default(),
+    };
+    let mut derives_registry = DerivesRegistry::default_with_crate_path(&crate_path);
     if let Some(derive_for_all) = args.derive_for_all_types {
         derives_registry.extend_for_all(derive_for_all.iter().cloned());
     }
     for derives in &args.derive_for_type {
-        derives_registry
-            .extend_for_type(derives.ty.clone(), derives.derive.iter().cloned())
+        derives_registry.extend_for_type(
+            derives.ty.clone(),
+            derives.derive.iter().cloned(),
+            &crate_path,
+        )
     }
 
-    subxt_codegen::generate_runtime_api(item_mod, &path, derives_registry).into()
+    subxt_codegen::generate_runtime_api(
+        item_mod,
+        &path,
+        derives_registry,
+        Some(crate_path),
+    )
+    .into()
 }

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -74,6 +74,16 @@
 //! )]
 //! pub mod polkadot {}
 //! ```
+//!
+//! ### Custom crate path
+//!
+//! In order to specify a custom crate path to be used for the code generation:
+//!
+//! ```ignore
+//! #[subxt::subxt(crate = "crate::path::to::subxt")]
+//! ```
+//!
+//! By default the path `::subxt` is used.
 
 #![deny(unused_crate_dependencies)]
 

--- a/testing/integration-tests/src/codegen/codegen_documentation.rs
+++ b/testing/integration-tests/src/codegen/codegen_documentation.rs
@@ -54,7 +54,9 @@ fn generate_runtime_interface() -> String {
         pub mod api {}
     );
     let derives = DerivesRegistry::default();
-    generator.generate_runtime(item_mod, derives).to_string()
+    generator
+        .generate_runtime(item_mod, derives, None)
+        .to_string()
 }
 
 fn interface_docs() -> Vec<String> {

--- a/testing/integration-tests/src/codegen/codegen_documentation.rs
+++ b/testing/integration-tests/src/codegen/codegen_documentation.rs
@@ -54,7 +54,7 @@ fn generate_runtime_interface(crate_path: CratePath) -> String {
     let item_mod = syn::parse_quote!(
         pub mod api {}
     );
-    let derives = DerivesRegistry::default();
+    let derives = DerivesRegistry::new(&crate_path);
     generator
         .generate_runtime(item_mod, derives, crate_path)
         .to_string()

--- a/testing/integration-tests/src/codegen/codegen_documentation.rs
+++ b/testing/integration-tests/src/codegen/codegen_documentation.rs
@@ -4,6 +4,7 @@
 
 use regex::Regex;
 use subxt_codegen::{
+    CratePath,
     DerivesRegistry,
     RuntimeGenerator,
 };
@@ -42,7 +43,7 @@ fn metadata_docs() -> Vec<String> {
     docs
 }
 
-fn generate_runtime_interface() -> String {
+fn generate_runtime_interface(crate_path: CratePath) -> String {
     // Load the runtime metadata downloaded from a node via `test-runtime`.
     let bytes = test_runtime::METADATA;
     let metadata: frame_metadata::RuntimeMetadataPrefixed =
@@ -55,14 +56,14 @@ fn generate_runtime_interface() -> String {
     );
     let derives = DerivesRegistry::default();
     generator
-        .generate_runtime(item_mod, derives, None)
+        .generate_runtime(item_mod, derives, crate_path)
         .to_string()
 }
 
 fn interface_docs() -> Vec<String> {
     // Generate the runtime interface from the node's metadata.
     // Note: the API is generated on a single line.
-    let runtime_api = generate_runtime_interface();
+    let runtime_api = generate_runtime_interface(CratePath::default());
 
     // Documentation lines have the following format:
     //    # [ doc = "Upward message is invalid XCM."]

--- a/testing/ui-tests/src/incorrect/substitute_path_not_absolute.stderr
+++ b/testing/ui-tests/src/incorrect/substitute_path_not_absolute.stderr
@@ -2,4 +2,4 @@ error: The substitute path must be a global absolute path; try prefixing with `:
  --> src/incorrect/substitute_path_not_absolute.rs:4:9
   |
 4 |     use sp_runtime::Perbill;
-  |         ^^^^^^^^^^^^^^^^^^^
+  |         ^^^^^^^^^^

--- a/testing/ui-tests/src/incorrect/substitute_path_not_absolute.stderr
+++ b/testing/ui-tests/src/incorrect/substitute_path_not_absolute.stderr
@@ -2,4 +2,4 @@ error: The substitute path must be a global absolute path; try prefixing with `:
  --> src/incorrect/substitute_path_not_absolute.rs:4:9
   |
 4 |     use sp_runtime::Perbill;
-  |         ^^^^^^^^^^
+  |         ^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Closes https://github.com/paritytech/subxt/issues/655.

We need this in ink! for https://github.com/paritytech/ink/issues/1234.

I'm not particularly fond of the testing story for this feature, but I would also not duplicate all the existing tests. Hmm.