### PR TITLE
expose jsonrpc-core client

### DIFF
--- a/examples/examples/custom_rpc_client.rs
+++ b/examples/examples/custom_rpc_client.rs
@@ -88,7 +88,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Pass this into our OnlineClient to instantiate it. This will lead to some
     // RPC calls being made to fetch chain details/metadata, which will immediately
     // fail..
-    let _ = OnlineClient::<PolkadotConfig>::from_rpc_client(rpc_client).await;
+    let _ = OnlineClient::<PolkadotConfig>::from_rpc_client(Arc::new(rpc_client)).await;
 
     // But, we can see that the calls were made via our custom RPC client:
     println!("Log of calls made:\n\n{}", log.lock().unwrap().as_str());

--- a/subxt/src/client/online_client.rs
+++ b/subxt/src/client/online_client.rs
@@ -74,7 +74,7 @@ impl<T: Config> OnlineClient<T> {
         let client = jsonrpsee_helpers::ws_client(url.as_ref())
             .await
             .map_err(|e| crate::error::RpcError(e.to_string()))?;
-        OnlineClient::from_rpc_client(client).await
+        OnlineClient::from_rpc_client(Arc::new(client)).await
     }
 }
 
@@ -82,7 +82,7 @@ impl<T: Config> OnlineClient<T> {
     /// Construct a new [`OnlineClient`] by providing an underlying [`RpcClientT`]
     /// implementation to drive the connection.
     pub async fn from_rpc_client<R: RpcClientT>(
-        rpc_client: R,
+        rpc_client: Arc<R>,
     ) -> Result<OnlineClient<T>, Error> {
         let rpc = Rpc::new(rpc_client);
 

--- a/subxt/src/events/mod.rs
+++ b/subxt/src/events/mod.rs
@@ -17,7 +17,6 @@ pub use event_subscription::{
     FinalizedEventSub,
 };
 pub use events_client::{
-    // Exposed only for testing:
     subscribe_to_block_headers_filling_in_gaps,
     EventsClient,
 };

--- a/subxt/src/rpc/rpc.rs
+++ b/subxt/src/rpc/rpc.rs
@@ -77,6 +77,7 @@ use sp_runtime::{
     ApplyExtrinsicResult,
 };
 use std::collections::HashMap;
+use std::sync::Arc;
 
 /// A number type that can be serialized both as a number or a string that encodes a number in a
 /// string.
@@ -342,7 +343,7 @@ impl<T: Config> std::ops::Deref for Rpc<T> {
 
 impl<T: Config> Rpc<T> {
     /// Create a new [`Rpc`]
-    pub fn new<R: RpcClientT>(client: R) -> Self {
+    pub fn new<R: RpcClientT>(client: Arc<R>) -> Self {
         Self {
             client: RpcClient::new(client),
             _marker: PhantomDataSendSync::new(),

--- a/subxt/src/rpc/rpc.rs
+++ b/subxt/src/rpc/rpc.rs
@@ -76,8 +76,10 @@ use sp_runtime::{
     },
     ApplyExtrinsicResult,
 };
-use std::collections::HashMap;
-use std::sync::Arc;
+use std::{
+    collections::HashMap,
+    sync::Arc,
+};
 
 /// A number type that can be serialized both as a number or a string that encodes a number in a
 /// string.

--- a/subxt/src/rpc/rpc_client.rs
+++ b/subxt/src/rpc/rpc_client.rs
@@ -28,7 +28,7 @@ use std::{
 /// Wrapping [`RpcClientT`] in this way is simply a way to expose this additional functionality
 /// without getting into issues with non-object-safe methods or no `async` in traits.
 #[derive(Clone)]
-pub struct RpcClient(Arc<dyn RpcClientT>);
+pub struct RpcClient(pub Arc<dyn RpcClientT>);
 
 impl RpcClient {
     pub(crate) fn new<R: RpcClientT>(client: R) -> Self {

--- a/subxt/src/rpc/rpc_client.rs
+++ b/subxt/src/rpc/rpc_client.rs
@@ -28,7 +28,7 @@ use std::{
 /// Wrapping [`RpcClientT`] in this way is simply a way to expose this additional functionality
 /// without getting into issues with non-object-safe methods or no `async` in traits.
 #[derive(Clone)]
-pub struct RpcClient(pub Arc<dyn RpcClientT>);
+pub struct RpcClient(Arc<dyn RpcClientT>);
 
 impl RpcClient {
     pub(crate) fn new<R: RpcClientT>(client: Arc<R>) -> Self {

--- a/subxt/src/rpc/rpc_client.rs
+++ b/subxt/src/rpc/rpc_client.rs
@@ -31,8 +31,8 @@ use std::{
 pub struct RpcClient(pub Arc<dyn RpcClientT>);
 
 impl RpcClient {
-    pub(crate) fn new<R: RpcClientT>(client: R) -> Self {
-        RpcClient(Arc::new(client))
+    pub(crate) fn new<R: RpcClientT>(client: Arc<R>) -> Self {
+        RpcClient(client)
     }
 
     /// Make an RPC request, given a method name and some parameters.


### PR DESCRIPTION
We depend on the jsonrpc-core client so we can make typed rpc requests

eg: https://github.com/ComposableFi/hyperspace/blob/311bc18ac6d4b24ed4586ba98552e9e145b0b068/parachain/src/provider.rs#L335-L342

