### PR TITLE
fix: Add `proof_size` field for the `Weight`

### DIFF
--- a/testing/integration-tests/src/frame/contracts.rs
+++ b/testing/integration-tests/src/frame/contracts.rs
@@ -61,6 +61,7 @@ impl ContractsTestContext {
             100_000_000_000_000_000, // endowment
             Weight {
                 ref_time: 500_000_000_000,
+                proof_size: 0,
             }, // gas_limit
             None,                    // storage_deposit_limit
             code,
@@ -105,6 +106,7 @@ impl ContractsTestContext {
             100_000_000_000_000_000, // endowment
             Weight {
                 ref_time: 500_000_000_000,
+                proof_size: 0,
             }, // gas_limit
             None,                    // storage_deposit_limit
             code_hash,
@@ -139,6 +141,7 @@ impl ContractsTestContext {
             0, // value
             Weight {
                 ref_time: 500_000_000,
+                proof_size: 0,
             }, // gas_limit
             None, // storage_deposit_limit
             input_data,

--- a/testing/integration-tests/src/frame/sudo.rs
+++ b/testing/integration-tests/src/frame/sudo.rs
@@ -57,9 +57,13 @@ async fn test_sudo_unchecked_weight() -> Result<(), subxt::Error> {
         dest: bob,
         value: 10_000,
     });
-    let tx = node_runtime::tx()
-        .sudo()
-        .sudo_unchecked_weight(call, Weight { ref_time: 0 });
+    let tx = node_runtime::tx().sudo().sudo_unchecked_weight(
+        call,
+        Weight {
+            ref_time: 0,
+            proof_size: 0,
+        },
+    );
 
     let found_event = api
         .tx()


### PR DESCRIPTION
Fix the subxt testing against the latest substrate binary regarding the following errors

```rust
  --> testing/integration-tests/src/frame/sudo.rs:62:38
   |
62 |         .sudo_unchecked_weight(call, Weight { ref_time: 0 });
   |                                      ^^^^^^ missing `proof_size`
```