### PR TITLE
Fix contracts integration test

### DIFF
--- a/testing/integration-tests/src/frame/contracts.rs
+++ b/testing/integration-tests/src/frame/contracts.rs
@@ -61,7 +61,7 @@ impl ContractsTestContext {
             100_000_000_000_000_000, // endowment
             Weight {
                 ref_time: 500_000_000_000,
-                proof_size: u64::MAX,
+                proof_size: 0,
             }, // gas_limit
             None,                    // storage_deposit_limit
             code,
@@ -106,7 +106,7 @@ impl ContractsTestContext {
             100_000_000_000_000_000, // endowment
             Weight {
                 ref_time: 500_000_000_000,
-                proof_size: u64::MAX,
+                proof_size: 0,
             }, // gas_limit
             None,                    // storage_deposit_limit
             code_hash,

--- a/testing/integration-tests/src/frame/contracts.rs
+++ b/testing/integration-tests/src/frame/contracts.rs
@@ -42,6 +42,8 @@ const CONTRACT: &str = r#"
     )
 "#;
 
+const PROOF_SIZE: u64 = u64::MAX / 2;
+
 impl ContractsTestContext {
     async fn init() -> Self {
         let cxt = test_context().await;
@@ -81,7 +83,7 @@ impl ContractsTestContext {
             100_000_000_000_000_000, // endowment
             Weight {
                 ref_time: 500_000_000_000,
-                proof_size: 0,
+                proof_size: PROOF_SIZE,
             }, // gas_limit
             None,                    // storage_deposit_limit
             code,
@@ -126,7 +128,7 @@ impl ContractsTestContext {
             100_000_000_000_000_000, // endowment
             Weight {
                 ref_time: 500_000_000_000,
-                proof_size: 0,
+                proof_size: PROOF_SIZE,
             }, // gas_limit
             None,                    // storage_deposit_limit
             code_hash,
@@ -161,7 +163,7 @@ impl ContractsTestContext {
             0, // value
             Weight {
                 ref_time: 500_000_000,
-                proof_size: 0,
+                proof_size: PROOF_SIZE,
             }, // gas_limit
             None, // storage_deposit_limit
             input_data,

--- a/testing/integration-tests/src/frame/contracts.rs
+++ b/testing/integration-tests/src/frame/contracts.rs
@@ -61,7 +61,7 @@ impl ContractsTestContext {
             100_000_000_000_000_000, // endowment
             Weight {
                 ref_time: 500_000_000_000,
-                proof_size: 0,
+                proof_size: u64::MAX,
             }, // gas_limit
             None,                    // storage_deposit_limit
             code,
@@ -106,7 +106,7 @@ impl ContractsTestContext {
             100_000_000_000_000_000, // endowment
             Weight {
                 ref_time: 500_000_000_000,
-                proof_size: 0,
+                proof_size: u64::MAX,
             }, // gas_limit
             None,                    // storage_deposit_limit
             code_hash,

--- a/testing/integration-tests/src/frame/contracts.rs
+++ b/testing/integration-tests/src/frame/contracts.rs
@@ -35,6 +35,13 @@ struct ContractsTestContext {
 type Hash = <SubstrateConfig as Config>::Hash;
 type AccountId = <SubstrateConfig as Config>::AccountId;
 
+const CONTRACT: &str = r#"
+    (module
+        (func (export "call"))
+        (func (export "deploy"))
+    )
+"#;
+
 impl ContractsTestContext {
     async fn init() -> Self {
         let cxt = test_context().await;
@@ -47,14 +54,27 @@ impl ContractsTestContext {
         self.cxt.client()
     }
 
+    async fn upload_code(&self) -> Result<Hash, Error> {
+        let code = wabt::wat2wasm(CONTRACT).expect("invalid wabt");
+
+        let upload_tx = node_runtime::tx().contracts().upload_code(code, None);
+
+        let events = self
+            .client()
+            .tx()
+            .sign_and_submit_then_watch_default(&upload_tx, &self.signer)
+            .await?
+            .wait_for_finalized_success()
+            .await?;
+
+        let code_stored = events
+            .find_first::<events::CodeStored>()?
+            .ok_or_else(|| Error::Other("Failed to find a CodeStored event".into()))?;
+        Ok(code_stored.code_hash)
+    }
+
     async fn instantiate_with_code(&self) -> Result<(Hash, AccountId), Error> {
         tracing::info!("instantiate_with_code:");
-        const CONTRACT: &str = r#"
-                (module
-                    (func (export "call"))
-                    (func (export "deploy"))
-                )
-            "#;
         let code = wabt::wat2wasm(CONTRACT).expect("invalid wabt");
 
         let instantiate_tx = node_runtime::tx().contracts().instantiate_with_code(
@@ -173,9 +193,9 @@ async fn tx_instantiate_with_code() {
 #[tokio::test]
 async fn tx_instantiate() {
     let ctx = ContractsTestContext::init().await;
-    let (code_hash, _) = ctx.instantiate_with_code().await.unwrap();
+    let code_hash = ctx.upload_code().await.unwrap();
 
-    let instantiated = ctx.instantiate(code_hash, vec![], vec![1u8]).await;
+    let instantiated = ctx.instantiate(code_hash, vec![], vec![]).await;
 
     assert!(
         instantiated.is_ok(),


### PR DESCRIPTION
Prior to https://github.com/paritytech/substrate/pull/12383, setting `proof_size` to `0` worked for all extrinsics. Following that a proper value needed to be supplied. However `u64::MAX` was too high as it breached the limit for normal class transactions weight (I think about `0.75 * MAX_BLOCK_WEIGHT`).

Interestingly `0` still worked for `instantiate_with_code` and `call`, but the fix was to set it to `u64::MAX / 2`.