### PR TITLE
Make Config::Extrinsic `Send`

### DIFF
--- a/subxt/src/config.rs
+++ b/subxt/src/config.rs
@@ -79,7 +79,7 @@ pub trait Config: 'static {
     type Signature: Verify + Encode + Send + Sync + 'static;
 
     /// Extrinsic type within blocks.
-    type Extrinsic: Parameter + Extrinsic + Debug + MaybeSerializeDeserialize;
+    type Extrinsic: Parameter + Extrinsic + Debug + MaybeSerializeDeserialize + Send;
 
     /// This type defines the extrinsic extra and additional parameters.
     type ExtrinsicParams: crate::tx::ExtrinsicParams<Self::Index, Self::Hash>;


### PR DESCRIPTION
This fixes the `future is not Send as this value is used across an await
` error  when calling `TxInBlock::wait_for_success`
Current Error I get when I call that function
![image](https://user-images.githubusercontent.com/31099392/194315692-e807df22-bb06-46e1-8d2f-32cc89f116c4.png)
