### PR TITLE
Allow taking out raw bytes from a SubmittableExtrinsic

### DIFF
--- a/subxt/src/tx/tx_client.rs
+++ b/subxt/src/tx/tx_client.rs
@@ -350,6 +350,12 @@ where
     pub fn encoded(&self) -> &[u8] {
         &self.encoded.0
     }
+
+    /// Consumes [`SubmittableExtrinsic`] and returns the SCALE encoded
+    /// extrinsic bytes.
+    pub fn into_encoded(self) -> Vec<u8> {
+        self.encoded.0
+    }
 }
 
 impl<T, C> SubmittableExtrinsic<T, C>


### PR DESCRIPTION
This is useful for something like this:

```rust
    let balances_transfer_tx = ...;

    let signed_balances_transfer_tx = api
        .tx()
        .create_signed(&balances_transfer_tx, signer, Default::default())
        .await?;

    let extrinsic_hash = Hashing::hash(signed_balances_transfer_tx.encoded());

    // We need `extrinsic_hash` because we want to log it, before we try to submit and watch the extrinsic.
    // We can't use `signed_balances_transfer_tx.submit_and_watch()` as we want to avoid doing the work twice.
    debug!(
        message = "Balance transfer extrinsic signed",
        ?address,
        ?extrinsic_hash
    );

    // Manually do the `watch_extrinsic`.
    let sub = api
      .rpc()
      .watch_extrinsic(Encoded(signed_balances_transfer_tx.into_encoded())) // <---- this is where we need the new API
      .await?

     let mut progress =
        TxProgress::<chain::HumanodeConfig, _>::new(sub, api.clone(), extrinsic_hash);

    // Continue as if we called `signed_balances_transfer_tx.submit_and_watch()`...
```