### PR TITLE
update `sp-core`, `sp-runtime`, and `frame-metadata` to point to their masters

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -30,12 +30,16 @@ serde_json = "1.0.68"
 # hex encoded metadata to bytes
 hex = "0.4.3"
 # actual metadata types
-frame-metadata = { version = "15.0.0", features = ["v14", "std"] }
+frame-metadata = { version = "15.0.0", git = "https://github.com/paritytech/frame-metadata/" }
 # decode bytes into the metadata types
 scale = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
 # generate the item mod for codegen
 syn = "1.0.80"
 # communicate with the substrate nodes
-jsonrpsee = { version = "0.15.1", features = ["async-client", "client-ws-transport", "http-client"] }
+jsonrpsee = { version = "0.15.1", features = [
+    "async-client",
+    "client-ws-transport",
+    "http-client",
+] }
 # async runtime
 tokio = { version = "1.8", features = ["rt-multi-thread", "macros", "time"] }

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -11,9 +11,13 @@ homepage = "https://www.parity.io/"
 description = "Generate an API for interacting with a substrate node from FRAME metadata"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full", "bit-vec"] }
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [
+    "derive",
+    "full",
+    "bit-vec",
+] }
 darling = "0.14.0"
-frame-metadata = "15.0.0"
+frame-metadata = { version = "15.0.0", git = "https://github.com/paritytech/frame-metadata/" }
 heck = "0.4.0"
 proc-macro2 = "1.0.24"
 proc-macro-error = "1.0.4"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -14,8 +14,12 @@ description = "Subxt example usage"
 [dev-dependencies]
 subxt = { path = "../subxt" }
 tokio = { version = "1.8", features = ["rt-multi-thread", "macros", "time"] }
-sp-keyring = "6.0.0"
+sp-keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate" }
 futures = "0.3.13"
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full", "bit-vec"] }
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [
+    "derive",
+    "full",
+    "bit-vec",
+] }
 hex = "0.4.3"
 tracing-subscriber = "0.3.11"

--- a/metadata/Cargo.toml
+++ b/metadata/Cargo.toml
@@ -12,15 +12,18 @@ homepage = "https://www.parity.io/"
 description = "Command line utilities for checking metadata compatibility between nodes."
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full"] }
-frame-metadata = "15.0.0"
-scale-info = "2.0.0"
-sp-core = { version = "6.0.0"  }
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [
+    "derive",
+    "full",
+] }
+frame-metadata = { version = "15.0.0", git = "https://github.com/paritytech/frame-metadata/" }
+sp-core = { package = "sp-core", git = "https://github.com/paritytech/substrate" }
+scale-info = { version = "2.0.0", features = ["bit-vec"] }
+
 
 [dev-dependencies]
 bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }
 criterion = "0.4"
-scale-info = { version = "2.0.0", features = ["bit-vec"] }
 
 [lib]
 # Without this, libtest cli opts interfere with criteron benches:

--- a/subxt/Cargo.toml
+++ b/subxt/Cargo.toml
@@ -26,13 +26,21 @@ jsonrpsee = ["dep:jsonrpsee"]
 
 [dependencies]
 bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full", "bit-vec"] }
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [
+    "derive",
+    "full",
+    "bit-vec",
+] }
 scale-info = { version = "2.0.0", features = ["bit-vec"] }
 scale-value = "0.6.0"
 scale-decode = "0.4.0"
 futures = "0.3.13"
 hex = "0.4.3"
-jsonrpsee = { version = "0.15.1", features = ["async-client", "client-ws-transport", "jsonrpsee-types"], optional = true }
+jsonrpsee = { version = "0.15.1", features = [
+    "async-client",
+    "client-ws-transport",
+    "jsonrpsee-types",
+], optional = true }
 serde = { version = "1.0.124", features = ["derive"] }
 serde_json = "1.0.64"
 thiserror = "1.0.24"
@@ -42,10 +50,10 @@ parking_lot = "0.12.0"
 subxt-macro = { version = "0.24.0", path = "../macro" }
 subxt-metadata = { version = "0.24.0", path = "../metadata" }
 
-sp-core = { version = "6.0.0", default-features = false  }
-sp-runtime = "6.0.0"
+sp-core = { package = "sp-core", git = "https://github.com/paritytech/substrate", default-features = false }
+sp-runtime = { package = "sp-runtime", git = "https://github.com/paritytech/substrate", default-features = false }
 
-frame-metadata = "15.0.0"
+frame-metadata = { version = "15.0.0", git = "https://github.com/paritytech/frame-metadata/" }
 derivative = "2.2.0"
 
 [dev-dependencies]

--- a/subxt/Cargo.toml
+++ b/subxt/Cargo.toml
@@ -50,8 +50,8 @@ parking_lot = "0.12.0"
 subxt-macro = { version = "0.24.0", path = "../macro" }
 subxt-metadata = { version = "0.24.0", path = "../metadata" }
 
-sp-core = { package = "sp-core", git = "https://github.com/paritytech/substrate", default-features = false }
-sp-runtime = { package = "sp-runtime", git = "https://github.com/paritytech/substrate", default-features = false }
+sp-core = { package = "sp-core", git = "https://github.com/paritytech/substrate" }
+sp-runtime = { package = "sp-runtime", git = "https://github.com/paritytech/substrate" }
 
 frame-metadata = { version = "15.0.0", git = "https://github.com/paritytech/frame-metadata/" }
 derivative = "2.2.0"

--- a/testing/integration-tests/Cargo.toml
+++ b/testing/integration-tests/Cargo.toml
@@ -15,16 +15,20 @@ description = "Subxt integration tests that rely on the Substrate binary"
 default = ["subxt/integration-tests"]
 
 [dev-dependencies]
+sp-keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate" }
+sp-runtime = { package = "sp-runtime", git = "https://github.com/paritytech/substrate", default-features = false }
+sp-core = { package = "sp-core", git = "https://github.com/paritytech/substrate", default-features = false }
 assert_matches = "1.5.0"
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full", "bit-vec"] }
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [
+    "derive",
+    "full",
+    "bit-vec",
+] }
 frame-metadata = "15.0.0"
 futures = "0.3.13"
 hex = "0.4.3"
 regex = "1.5.0"
 scale-info = { version = "2.0.0", features = ["bit-vec"] }
-sp-core = { version = "6.0.0", default-features = false  }
-sp-keyring = "6.0.0"
-sp-runtime = "6.0.0"
 syn = "1.0.0"
 subxt = { version = "0.24.0", path = "../../subxt" }
 subxt-codegen = { version = "0.24.0", path = "../../codegen" }

--- a/testing/test-runtime/Cargo.toml
+++ b/testing/test-runtime/Cargo.toml
@@ -5,12 +5,19 @@ edition = "2021"
 
 [dependencies]
 subxt = { path = "../../subxt" }
-sp-runtime = "6.0.0"
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full", "bit-vec"] }
+sp-runtime = { package = "sp-runtime", git = "https://github.com/paritytech/substrate", default-features = false }
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [
+    "derive",
+    "full",
+    "bit-vec",
+] }
 
 [build-dependencies]
 subxt = { path = "../../subxt" }
-sp-core = "6.0.0"
+sp-core = { package = "sp-core", git = "https://github.com/paritytech/substrate", default-features = false }
 tokio = { version = "1.8", features = ["macros", "rt-multi-thread"] }
 which = "4.2.2"
-jsonrpsee = { version = "0.15.1", features = ["async-client", "client-ws-transport"] }
+jsonrpsee = { version = "0.15.1", features = [
+    "async-client",
+    "client-ws-transport",
+] }


### PR DESCRIPTION
These dependencies are reflecting the current docs.rs versions, which are quite out of date. Resultingly, its causing `parity-util-mem` versioning issues when using it in the same codebase as other substrate dependencies.