### PR TITLE
Add runtime_metadata_url to pull metadata directly from a node

### DIFF
--- a/cli/src/commands/compatibility.rs
+++ b/cli/src/commands/compatibility.rs
@@ -111,7 +111,7 @@ async fn handle_full_metadata(nodes: &[Uri]) -> color_eyre::Result<()> {
 }
 
 async fn fetch_runtime_metadata(url: &Uri) -> color_eyre::Result<RuntimeMetadataV14> {
-    let (_, bytes) = super::metadata::fetch_metadata(url).await?;
+    let bytes = subxt_codegen::utils::fetch_metadata_bytes(url).await?;
 
     let metadata = <RuntimeMetadataPrefixed as Decode>::decode(&mut &bytes[..])?;
     if metadata.0 != META_RESERVED {

--- a/cli/src/commands/metadata.rs
+++ b/cli/src/commands/metadata.rs
@@ -5,24 +5,13 @@
 use clap::Parser as ClapParser;
 use color_eyre::eyre;
 use frame_metadata::RuntimeMetadataPrefixed;
-use jsonrpsee::{
-    async_client::ClientBuilder,
-    client_transport::ws::{
-        Uri,
-        WsTransportClientBuilder,
-    },
-    core::{
-        client::ClientT,
-        Error,
-    },
-    http_client::HttpClientBuilder,
-    rpc_params,
-};
+use jsonrpsee::client_transport::ws::Uri;
 use scale::Decode;
 use std::io::{
     self,
     Write,
 };
+use subxt_codegen::utils::fetch_metadata_hex;
 
 /// Download metadata from a substrate node, for use with `subxt` codegen.
 #[derive(Debug, ClapParser)]
@@ -41,10 +30,11 @@ pub struct Opts {
 }
 
 pub async fn run(opts: Opts) -> color_eyre::Result<()> {
-    let (hex_data, bytes) = fetch_metadata(&opts.url).await?;
+    let hex_data = fetch_metadata_hex(&opts.url).await?;
 
     match opts.format.as_str() {
         "json" => {
+            let bytes = hex::decode(hex_data.trim_start_matches("0x"))?;
             let metadata = <RuntimeMetadataPrefixed as Decode>::decode(&mut &bytes[..])?;
             let json = serde_json::to_string_pretty(&metadata)?;
             println!("{}", json);
@@ -54,7 +44,10 @@ pub async fn run(opts: Opts) -> color_eyre::Result<()> {
             println!("{}", hex_data);
             Ok(())
         }
-        "bytes" => Ok(io::stdout().write_all(&bytes)?),
+        "bytes" => {
+            let bytes = hex::decode(hex_data.trim_start_matches("0x"))?;
+            Ok(io::stdout().write_all(&bytes)?)
+        }
         _ => {
             Err(eyre::eyre!(
                 "Unsupported format `{}`, expected `json`, `hex` or `bytes`",
@@ -62,41 +55,4 @@ pub async fn run(opts: Opts) -> color_eyre::Result<()> {
             ))
         }
     }
-}
-
-pub async fn fetch_metadata(url: &Uri) -> color_eyre::Result<(String, Vec<u8>)> {
-    let hex_data = match url.scheme_str() {
-        Some("http") => fetch_metadata_http(url).await,
-        Some("ws") | Some("wss") => fetch_metadata_ws(url).await,
-        invalid_scheme => {
-            let scheme = invalid_scheme.unwrap_or("no scheme");
-            Err(eyre::eyre!(format!(
-                "`{}` not supported, expects 'http', 'ws', or 'wss'",
-                scheme
-            )))
-        }
-    }?;
-
-    let bytes = hex::decode(hex_data.trim_start_matches("0x"))?;
-
-    Ok((hex_data, bytes))
-}
-
-async fn fetch_metadata_ws(url: &Uri) -> color_eyre::Result<String> {
-    let (sender, receiver) = WsTransportClientBuilder::default()
-        .build(url.to_string().parse::<Uri>().unwrap())
-        .await
-        .map_err(|e| Error::Transport(e.into()))?;
-
-    let client = ClientBuilder::default()
-        .max_notifs_per_subscription(4096)
-        .build_with_tokio(sender, receiver);
-
-    Ok(client.request("state_getMetadata", rpc_params![]).await?)
-}
-
-async fn fetch_metadata_http(url: &Uri) -> color_eyre::Result<String> {
-    let client = HttpClientBuilder::default().build(url.to_string())?;
-
-    Ok(client.request::<String>("state_getMetadata", None).await?)
 }

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -21,6 +21,9 @@ quote = "1.0.8"
 syn = "1.0.58"
 scale-info = { version = "2.0.0", features = ["bit-vec"] }
 subxt-metadata = { version = "0.24.0", path = "../metadata" }
+jsonrpsee = { version = "0.15.1", features = ["async-client", "client-ws-transport", "http-client"] }
+hex = "0.4.3"
+tokio = { version = "1.8", features = ["macros", "rt-multi-thread"] }
 
 [dev-dependencies]
 bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }

--- a/codegen/src/api/mod.rs
+++ b/codegen/src/api/mod.rs
@@ -78,7 +78,8 @@ where
 }
 
 /// Generates the API for interacting with a substrate runtime, using metadata
-/// that can be downloaded from a node at the provided URL.
+/// that can be downloaded from a node at the provided URL. This function blocks
+/// while retrieving the metadata.
 ///
 /// # Arguments
 ///
@@ -100,7 +101,7 @@ pub fn generate_runtime_api_from_url(
     generate_runtime_api_from_bytes(item_mod, &bytes, derives, crate_path)
 }
 
-/// Generates the API for interacting with a substrate runtime, using metadata bytes
+/// Generates the API for interacting with a substrate runtime, using metadata bytes.
 ///
 /// # Arguments
 ///
@@ -131,8 +132,9 @@ pub struct RuntimeGenerator {
 impl RuntimeGenerator {
     /// Create a new runtime generator from the provided metadata.
     ///
-    /// **Note:** If you have a path to the metadata, prefer to use [generate_runtime_api]
-    /// for generating the runtime API.
+    /// **Note:** If you have the metadata path, URL or bytes to hand, prefer to use
+    /// one of the `generate_runtime_api_from_*` functions for generating the runtime API
+    /// from that.
     pub fn new(metadata: RuntimeMetadataPrefixed) -> Self {
         match metadata.1 {
             RuntimeMetadata::V14(v14) => Self { metadata: v14 },

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -45,9 +45,13 @@ mod api;
 mod ir;
 mod types;
 
+pub mod utils;
+
 pub use self::{
     api::{
-        generate_runtime_api,
+        generate_runtime_api_from_bytes,
+        generate_runtime_api_from_path,
+        generate_runtime_api_from_url,
         RuntimeGenerator,
     },
     types::{

--- a/codegen/src/utils/fetch_metadata.rs
+++ b/codegen/src/utils/fetch_metadata.rs
@@ -1,0 +1,107 @@
+use jsonrpsee::{
+    async_client::ClientBuilder,
+    client_transport::ws::{
+        Uri,
+        WsTransportClientBuilder,
+    },
+    core::{
+        client::ClientT,
+        Error,
+    },
+    http_client::HttpClientBuilder,
+    rpc_params,
+};
+
+/// Returns the metadata bytes from the provided URL, blocking the current thread.
+pub fn fetch_metadata_bytes_blocking(url: &Uri) -> Result<Vec<u8>, FetchMetadataError> {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(fetch_metadata_bytes(url))
+}
+
+/// Returns the raw, 0x prefixed metadata hex from the provided URL, blocking the current thread.
+pub fn fetch_metadata_hex_blocking(url: &Uri) -> Result<String, FetchMetadataError> {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(fetch_metadata_hex(url))
+}
+
+/// Returns the metadata bytes from the provided URL.
+pub async fn fetch_metadata_bytes(url: &Uri) -> Result<Vec<u8>, FetchMetadataError> {
+    let hex = fetch_metadata_hex(url).await?;
+    let bytes = hex::decode(hex.trim_start_matches("0x"))?;
+    Ok(bytes)
+}
+
+/// Returns the raw, 0x prefixed metadata hex from the provided URL.
+pub async fn fetch_metadata_hex(url: &Uri) -> Result<String, FetchMetadataError> {
+    let hex_data = match url.scheme_str() {
+        Some("http") => fetch_metadata_http(url).await,
+        Some("ws") | Some("wss") => fetch_metadata_ws(url).await,
+        invalid_scheme => {
+            let scheme = invalid_scheme.unwrap_or("no scheme");
+            Err(FetchMetadataError::InvalidScheme(scheme.to_owned()))
+        }
+    }?;
+    Ok(hex_data)
+}
+
+async fn fetch_metadata_ws(url: &Uri) -> Result<String, FetchMetadataError> {
+    let (sender, receiver) = WsTransportClientBuilder::default()
+        .build(url.to_string().parse::<Uri>().unwrap())
+        .await
+        .map_err(|e| Error::Transport(e.into()))?;
+
+    let client = ClientBuilder::default()
+        .max_notifs_per_subscription(4096)
+        .build_with_tokio(sender, receiver);
+
+    Ok(client.request("state_getMetadata", rpc_params![]).await?)
+}
+
+async fn fetch_metadata_http(url: &Uri) -> Result<String, FetchMetadataError> {
+    let client = HttpClientBuilder::default().build(url.to_string())?;
+
+    Ok(client.request::<String>("state_getMetadata", None).await?)
+}
+
+#[derive(Debug)]
+pub enum FetchMetadataError {
+    DecodeError(hex::FromHexError),
+    RequestError(jsonrpsee::core::Error),
+    InvalidScheme(String),
+}
+
+impl std::fmt::Display for FetchMetadataError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FetchMetadataError::DecodeError(e) => {
+                write!(f, "Cannot decode hex value: {e}")
+            }
+            FetchMetadataError::RequestError(e) => write!(f, "Request error: {e}"),
+            FetchMetadataError::InvalidScheme(s) => {
+                write!(
+                    f,
+                    "'{s}' not supported, supported URl schemes are http, ws or wss."
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for FetchMetadataError {}
+
+impl From<hex::FromHexError> for FetchMetadataError {
+    fn from(e: hex::FromHexError) -> Self {
+        FetchMetadataError::DecodeError(e)
+    }
+}
+impl From<jsonrpsee::core::Error> for FetchMetadataError {
+    fn from(e: jsonrpsee::core::Error) -> Self {
+        FetchMetadataError::RequestError(e)
+    }
+}

--- a/codegen/src/utils/mod.rs
+++ b/codegen/src/utils/mod.rs
@@ -1,0 +1,12 @@
+mod fetch_metadata;
+
+// easy access to this type needed for fetching metadata:
+pub use jsonrpsee::client_transport::ws::Uri;
+
+pub use fetch_metadata::{
+    fetch_metadata_bytes,
+    fetch_metadata_bytes_blocking,
+    fetch_metadata_hex,
+    fetch_metadata_hex_blocking,
+    FetchMetadataError,
+};

--- a/examples/examples/custom_metadata_url.rs
+++ b/examples/examples/custom_metadata_url.rs
@@ -1,0 +1,11 @@
+// Copyright 2019-2022 Parity Technologies (UK) Ltd.
+// This file is dual-licensed as Apache-2.0 or GPL-3.0.
+// see LICENSE for license details.
+
+// If you'd like to use metadata directly from a running node, you
+// can provide a URL to that node here. Note that if the metadata cannot
+// be retrieved from this node URL at compile time, compilation will fail.
+#[subxt::subxt(runtime_metadata_url = "wss://rpc.polkadot.io:443")]
+pub mod polkadot {}
+
+fn main() {}

--- a/examples/examples/custom_metadata_url.rs
+++ b/examples/examples/custom_metadata_url.rs
@@ -3,8 +3,9 @@
 // see LICENSE for license details.
 
 // If you'd like to use metadata directly from a running node, you
-// can provide a URL to that node here. Note that if the metadata cannot
-// be retrieved from this node URL at compile time, compilation will fail.
+// can provide a URL to that node here. HTTP or WebSocket URLs can be
+// provided. Note that if the metadata cannot be retrieved from this
+// node URL at compile time, compilation will fail.
 #[subxt::subxt(runtime_metadata_url = "wss://rpc.polkadot.io:443")]
 pub mod polkadot {}
 

--- a/testing/ui-tests/src/incorrect/need_url_or_path.rs
+++ b/testing/ui-tests/src/incorrect/need_url_or_path.rs
@@ -1,0 +1,4 @@
+#[subxt::subxt()]
+pub mod node_runtime {}
+
+fn main() {}

--- a/testing/ui-tests/src/incorrect/need_url_or_path.stderr
+++ b/testing/ui-tests/src/incorrect/need_url_or_path.stderr
@@ -1,0 +1,7 @@
+error: One of 'runtime_metadata_path' or 'runtime_metadata_url' must be provided
+ --> src/incorrect/need_url_or_path.rs:1:1
+  |
+1 | #[subxt::subxt()]
+  | ^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the attribute macro `subxt::subxt` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/testing/ui-tests/src/incorrect/url_and_path_provided.rs
+++ b/testing/ui-tests/src/incorrect/url_and_path_provided.rs
@@ -1,0 +1,7 @@
+#[subxt::subxt(
+    runtime_metadata_path = "../../../artifacts/polkadot_metadata.scale",
+    runtime_metadata_url = "wss://rpc.polkadot.io:443"
+)]
+pub mod node_runtime {}
+
+fn main() {}

--- a/testing/ui-tests/src/incorrect/url_and_path_provided.stderr
+++ b/testing/ui-tests/src/incorrect/url_and_path_provided.stderr
@@ -1,0 +1,10 @@
+error: Only one of 'runtime_metadata_path' or 'runtime_metadata_url' can be provided
+ --> src/incorrect/url_and_path_provided.rs:1:1
+  |
+1 | / #[subxt::subxt(
+2 | |     runtime_metadata_path = "../../../artifacts/polkadot_metadata.scale",
+3 | |     runtime_metadata_url = "wss://rpc.polkadot.io:443"
+4 | | )]
+  | |__^
+  |
+  = note: this error originates in the attribute macro `subxt::subxt` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
And reuse this fetch functionality in the CLI crate to avoid duplication.

Closes #640 