### PR TITLE
error: `RpcError` with custom client error

### DIFF
--- a/subxt/src/client/online_client.rs
+++ b/subxt/src/client/online_client.rs
@@ -74,7 +74,7 @@ impl<T: Config> OnlineClient<T> {
     pub async fn from_url(url: impl AsRef<str>) -> Result<OnlineClient<T>, Error> {
         let client = jsonrpsee_helpers::ws_client(url.as_ref())
             .await
-            .map_err(|e| crate::error::RpcError(e.to_string()))?;
+            .map_err(|e| crate::error::RpcError::ClientError(Box::new(e)))?;
         OnlineClient::from_rpc_client(Arc::new(client)).await
     }
 }

--- a/subxt/src/error.rs
+++ b/subxt/src/error.rs
@@ -104,14 +104,14 @@ impl From<DispatchError> for Error {
 /// An RPC error. Since we are generic over the RPC client that is used,
 /// the error is boxed and could be casted.
 #[derive(Debug, thiserror::Error)]
-#[error("RPC error: {0}")]
+#[error("RPC error")]
 pub enum RpcError {
     // Dev note: We need the error to be safely sent between threads
     // for `subscribe_to_block_headers_filling_in_gaps` and friends.
     /// Error related to the RPC client.
     ClientError(Box<dyn std::error::Error + Send + 'static>),
-    /// Custom error.
-    Custom(String),
+    /// The RPC subscription dropped.
+    SubscriptionDropped,
 }
 
 /// This is our attempt to decode a runtime DispatchError. We either

--- a/subxt/src/rpc/jsonrpsee_impl.rs
+++ b/subxt/src/rpc/jsonrpsee_impl.rs
@@ -35,7 +35,7 @@ impl RpcClientT for Client {
             let params = prep_params_for_jsonrpsee(params)?;
             let res = ClientT::request(self, method, Some(params))
                 .await
-                .map_err(|e| RpcError(e.to_string()))?;
+                .map_err(|e| RpcError::ClientError(Box::new(e)))?;
             Ok(res)
         })
     }
@@ -55,8 +55,8 @@ impl RpcClientT for Client {
                 unsub,
             )
             .await
-            .map_err(|e| RpcError(e.to_string()))?
-            .map_err(|e| RpcError(e.to_string()))
+            .map_err(|e| RpcError::ClientError(Box::new(e)))?
+            .map_err(|e| RpcError::ClientError(Box::new(e)))
             .boxed();
             Ok(sub)
         })
@@ -77,7 +77,7 @@ fn prep_params_for_jsonrpsee(
     let arr = match val {
         Value::Array(arr) => Ok(arr),
         _ => {
-            Err(RpcError(format!(
+            Err(RpcError::Custom(format!(
                 "RPC Params are expected to be an array but got {params}"
             )))
         }

--- a/subxt/src/rpc/rpc_client_t.rs
+++ b/subxt/src/rpc/rpc_client_t.rs
@@ -20,6 +20,11 @@ pub use serde_json::value::RawValue;
 /// the caller. This is the case because we want the methods to be object-safe (which prohibits
 /// generics), and want to avoid any unnecessary allocations in serializing/deserializing
 /// parameters.
+///
+/// # Note
+///
+/// Implementations are free to panic if the provided parameters are not a valid
+/// JSON Array.
 pub trait RpcClientT: Send + Sync + 'static {
     /// Make a raw request for which we expect a single response back from. Implementations
     /// should expect that the params will either be `None`, or be an already-serialized

--- a/subxt/src/rpc/rpc_client_t.rs
+++ b/subxt/src/rpc/rpc_client_t.rs
@@ -21,10 +21,10 @@ pub use serde_json::value::RawValue;
 /// generics), and want to avoid any unnecessary allocations in serializing/deserializing
 /// parameters.
 ///
-/// # Note
+/// # Panics
 ///
-/// Implementations are free to panic if the provided parameters are not a valid
-/// JSON Array.
+/// Implementations are free to panic if the `RawValue`'s passed to `request_raw` or 
+/// `subscribe_raw` are not JSON arrays. Internally, we ensure that this is always the case.
 pub trait RpcClientT: Send + Sync + 'static {
     /// Make a raw request for which we expect a single response back from. Implementations
     /// should expect that the params will either be `None`, or be an already-serialized

--- a/subxt/src/rpc/rpc_client_t.rs
+++ b/subxt/src/rpc/rpc_client_t.rs
@@ -23,7 +23,7 @@ pub use serde_json::value::RawValue;
 ///
 /// # Panics
 ///
-/// Implementations are free to panic if the `RawValue`'s passed to `request_raw` or 
+/// Implementations are free to panic if the `RawValue`'s passed to `request_raw` or
 /// `subscribe_raw` are not JSON arrays. Internally, we ensure that this is always the case.
 pub trait RpcClientT: Send + Sync + 'static {
     /// Make a raw request for which we expect a single response back from. Implementations

--- a/subxt/src/tx/tx_progress.rs
+++ b/subxt/src/tx/tx_progress.rs
@@ -107,7 +107,7 @@ where
                 _ => continue,
             }
         }
-        Err(RpcError::Custom("RPC subscription dropped".into()).into())
+        Err(RpcError::SubscriptionDropped.into())
     }
 
     /// Wait for the transaction to be finalized, and return a [`TxInBlock`]
@@ -133,7 +133,7 @@ where
                 _ => continue,
             }
         }
-        Err(RpcError::Custom("RPC subscription dropped".into()).into())
+        Err(RpcError::SubscriptionDropped.into())
     }
 
     /// Wait for the transaction to be finalized, and for the transaction events to indicate

--- a/subxt/src/tx/tx_progress.rs
+++ b/subxt/src/tx/tx_progress.rs
@@ -107,7 +107,7 @@ where
                 _ => continue,
             }
         }
-        Err(RpcError("RPC subscription dropped".to_string()).into())
+        Err(RpcError::Custom("RPC subscription dropped".into()).into())
     }
 
     /// Wait for the transaction to be finalized, and return a [`TxInBlock`]
@@ -133,7 +133,7 @@ where
                 _ => continue,
             }
         }
-        Err(RpcError("RPC subscription dropped".to_string()).into())
+        Err(RpcError::Custom("RPC subscription dropped".into()).into())
     }
 
     /// Wait for the transaction to be finalized, and for the transaction events to indicate


### PR DESCRIPTION
This PR extends the `RpcError` error to support two variants:
- custom error originated from the RPC client (this is boxed to allow users to cast the error, without needlessly having the error generic)
- custom string originated from subxt (ie, parsing parameters). 

Closes #692.
