### PR TITLE
No need to entangle Signer and nonce now

### DIFF
--- a/subxt/src/tx/signer.rs
+++ b/subxt/src/tx/signer.rs
@@ -14,12 +14,8 @@ use sp_runtime::traits::{
 
 /// Signing transactions requires a [`Signer`]. This is responsible for
 /// providing the "from" account that the transaction is being signed by,
-/// as well as actually signing a SCALE encoded payload. Optionally, a
-/// signer can also provide the nonce for the transaction to use.
+/// as well as actually signing a SCALE encoded payload.
 pub trait Signer<T: Config> {
-    /// Optionally returns a nonce.
-    fn nonce(&self) -> Option<T::Index>;
-
     /// Return the "from" account ID.
     fn account_id(&self) -> &T::AccountId;
 
@@ -37,7 +33,6 @@ pub trait Signer<T: Config> {
 #[derive(Clone, Debug)]
 pub struct PairSigner<T: Config, P: Pair> {
     account_id: T::AccountId,
-    nonce: Option<T::Index>,
     signer: P,
 }
 
@@ -55,20 +50,8 @@ where
             <T::Signature as Verify>::Signer::from(signer.public()).into_account();
         Self {
             account_id,
-            nonce: None,
             signer,
         }
-    }
-
-    /// Sets the nonce to a new value. By default, the nonce will
-    /// be retrieved from the node. Setting one here will override that.
-    pub fn set_nonce(&mut self, nonce: T::Index) {
-        self.nonce = Some(nonce);
-    }
-
-    /// Increment the nonce.
-    pub fn increment_nonce(&mut self) {
-        self.nonce = self.nonce.map(|nonce| nonce + 1u32.into());
     }
 
     /// Returns the [`Pair`] implementation used to construct this.
@@ -89,10 +72,6 @@ where
     P: Pair + 'static,
     P::Signature: Into<T::Signature> + 'static,
 {
-    fn nonce(&self) -> Option<T::Index> {
-        self.nonce
-    }
-
     fn account_id(&self) -> &T::AccountId {
         &self.account_id
     }

--- a/subxt/src/tx/signer.rs
+++ b/subxt/src/tx/signer.rs
@@ -48,10 +48,7 @@ where
     pub fn new(signer: P) -> Self {
         let account_id =
             <T::Signature as Verify>::Signer::from(signer.public()).into_account();
-        Self {
-            account_id,
-            signer,
-        }
+        Self { account_id, signer }
     }
 
     /// Returns the [`Pair`] implementation used to construct this.

--- a/subxt/src/tx/tx_client.rs
+++ b/subxt/src/tx/tx_client.rs
@@ -224,14 +224,10 @@ where
         Call: TxPayload,
     {
         // Get nonce from the node.
-        let account_nonce = if let Some(nonce) = signer.nonce() {
-            nonce
-        } else {
-            self.client
-                .rpc()
-                .system_account_next_index(signer.account_id())
-                .await?
-        };
+        let account_nonce = self.client
+            .rpc()
+            .system_account_next_index(signer.account_id())
+            .await?;
 
         self.create_signed_with_nonce(call, signer, account_nonce, other_params)
     }

--- a/subxt/src/tx/tx_client.rs
+++ b/subxt/src/tx/tx_client.rs
@@ -224,7 +224,8 @@ where
         Call: TxPayload,
     {
         // Get nonce from the node.
-        let account_nonce = self.client
+        let account_nonce = self
+            .client
             .rpc()
             .system_account_next_index(signer.account_id())
             .await?;


### PR DESCRIPTION
We can create transactions and provide separate nonces now, so there is no need to expose this nonce functionality in the Signer trait, which shouldn't need to care.