### PR TITLE
Use git instead of crates.io for Substrate deps

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -14,7 +14,7 @@ description = "Subxt example usage"
 [dev-dependencies]
 subxt = { path = "../subxt" }
 tokio = { version = "1.8", features = ["rt-multi-thread", "macros", "time"] }
-sp-keyring = "6.0.0"
+sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "master" }
 futures = "0.3.13"
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full", "bit-vec"] }
 hex = "0.4.3"

--- a/metadata/Cargo.toml
+++ b/metadata/Cargo.toml
@@ -15,7 +15,7 @@ description = "Command line utilities for checking metadata compatibility betwee
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full"] }
 frame-metadata = "15.0.0"
 scale-info = "2.0.0"
-sp-core = { version = "6.0.0"  }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
 
 [dev-dependencies]
 bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }

--- a/subxt/Cargo.toml
+++ b/subxt/Cargo.toml
@@ -42,8 +42,8 @@ parking_lot = "0.12.0"
 subxt-macro = { version = "0.24.0", path = "../macro" }
 subxt-metadata = { version = "0.24.0", path = "../metadata" }
 
-sp-core = { version = "6.0.0", default-features = false  }
-sp-runtime = "6.0.0"
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" }
 
 frame-metadata = "15.0.0"
 derivative = "2.2.0"

--- a/testing/integration-tests/Cargo.toml
+++ b/testing/integration-tests/Cargo.toml
@@ -22,9 +22,9 @@ futures = "0.3.13"
 hex = "0.4.3"
 regex = "1.5.0"
 scale-info = { version = "2.0.0", features = ["bit-vec"] }
-sp-core = { version = "6.0.0", default-features = false  }
-sp-keyring = "6.0.0"
-sp-runtime = "6.0.0"
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "master" }
 syn = "1.0.0"
 subxt = { version = "0.24.0", path = "../../subxt" }
 subxt-codegen = { version = "0.24.0", path = "../../codegen" }

--- a/testing/test-runtime/Cargo.toml
+++ b/testing/test-runtime/Cargo.toml
@@ -5,12 +5,12 @@ edition = "2021"
 
 [dependencies]
 subxt = { path = "../../subxt" }
-sp-runtime = "6.0.0"
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" }
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full", "bit-vec"] }
 
 [build-dependencies]
 subxt = { path = "../../subxt" }
-sp-core = "6.0.0"
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
 tokio = { version = "1.8", features = ["macros", "rt-multi-thread"] }
 which = "4.2.2"
 jsonrpsee = { version = "0.15.1", features = ["async-client", "client-ws-transport"] }


### PR DESCRIPTION
Changes:  
- Use git instead of crates.io for Substrate

There are two reasons for this as far as I am concerned:  
- Parity is actually not in control of all Substrate crates on `crates.io`. So we risk pulling in something that is not Substrate at all.   
- Substrate is not being released regularly on `crates.io`, so the versions here are out-dated which prevents downstream projects like https://github.com/paritytech/polkadot-stps (cc @bernardoaraujor) from updating their Substrate versions.