### PR TITLE
Upgrade to scale-info 2.3 and fix errors

### DIFF
--- a/testing/ui-tests/Cargo.toml
+++ b/testing/ui-tests/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 
 [dev-dependencies]
 trybuild = "1.0.63"
-scale-info = { version = "2.0.0", features = ["bit-vec"] }
+scale-info = { version = "2.3.0", features = ["bit-vec"] }
 frame-metadata = "15.0.0"
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full", "bit-vec"] }
 subxt = { path = "../../subxt" }

--- a/testing/ui-tests/src/utils/dispatch_error.rs
+++ b/testing/ui-tests/src/utils/dispatch_error.rs
@@ -4,9 +4,7 @@
 
 use scale_info::{
     build::{
-        FieldsBuilder,
-        NamedFields,
-        UnnamedFields,
+        Fields,
         Variants,
     },
     Path,
@@ -30,7 +28,7 @@ impl TypeInfo for NamedFieldDispatchError {
             .variant(Variants::new().variant("Module", |builder| {
                 builder
                     .fields(
-                        FieldsBuilder::<NamedFields>::default()
+                        Fields::named()
                             .field(|b| b.name("error").ty::<u8>())
                             .field(|b| b.name("index").ty::<u8>()),
                     )
@@ -53,7 +51,7 @@ impl TypeInfo for LegacyDispatchError {
                 Type::builder()
                     .path(Path::new("ModuleError", "sp_runtime"))
                     .composite(
-                        FieldsBuilder::<NamedFields>::default()
+                        Fields::named()
                             .field(|b| b.name("index").ty::<u8>())
                             .field(|b| b.name("error").ty::<u8>()),
                     )
@@ -64,10 +62,7 @@ impl TypeInfo for LegacyDispatchError {
             .path(Path::new("DispatchError", "sp_runtime"))
             .variant(Variants::new().variant("Module", |builder| {
                 builder
-                    .fields(
-                        FieldsBuilder::<UnnamedFields>::default()
-                            .field(|b| b.ty::<ModuleError>()),
-                    )
+                    .fields(Fields::unnamed().field(|b| b.ty::<ModuleError>()))
                     .index(0)
             }))
     }
@@ -87,7 +82,7 @@ impl TypeInfo for ArrayDispatchError {
                 Type::builder()
                     .path(Path::new("ModuleError", "sp_runtime"))
                     .composite(
-                        FieldsBuilder::<NamedFields>::default()
+                        Fields::named()
                             .field(|b| b.name("index").ty::<u8>())
                             .field(|b| b.name("error").ty::<[u8; 4]>()),
                     )
@@ -98,10 +93,7 @@ impl TypeInfo for ArrayDispatchError {
             .path(Path::new("DispatchError", "sp_runtime"))
             .variant(Variants::new().variant("Module", |builder| {
                 builder
-                    .fields(
-                        FieldsBuilder::<UnnamedFields>::default()
-                            .field(|b| b.ty::<ModuleError>()),
-                    )
+                    .fields(Fields::unnamed().field(|b| b.ty::<ModuleError>()))
                     .index(0)
             }))
     }


### PR DESCRIPTION
Okay so it turns out `2.3` did have some breaking changes after all, we didn't see it in `substrate` or `ink` because none of those used the `FieldsBuilder::<NamedFields>::default()` method.

This PR uses the idiomatic convenience methods `Fields::named()` and `unnamed()` instead.