### PR TITLE
Update substrate dependencies, removing `parity-util-mem` transitive dependency

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -14,7 +14,7 @@ description = "Subxt example usage"
 [dev-dependencies]
 subxt = { path = "../subxt" }
 tokio = { version = "1.8", features = ["rt-multi-thread", "macros", "time"] }
-sp-keyring = "6.0.0"
+sp-keyring = { version = "6.0.0", git = "https://github.com/paritytech/substrate", branch = "aj/sp-runtime-parity-util-mem", package = "sp-keyring", default-features = false }
 futures = "0.3.13"
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full", "bit-vec"] }
 hex = "0.4.3"

--- a/metadata/Cargo.toml
+++ b/metadata/Cargo.toml
@@ -15,7 +15,7 @@ description = "Command line utilities for checking metadata compatibility betwee
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full"] }
 frame-metadata = "15.0.0"
 scale-info = "2.0.0"
-sp-core = { version = "6.0.0"  }
+sp-core = { version = "6.0.0", git = "https://github.com/paritytech/substrate", branch = "aj/sp-runtime-parity-util-mem", package = "sp-core", default-features = false  }
 
 [dev-dependencies]
 bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }

--- a/subxt/Cargo.toml
+++ b/subxt/Cargo.toml
@@ -42,8 +42,9 @@ parking_lot = "0.12.0"
 subxt-macro = { version = "0.24.0", path = "../macro" }
 subxt-metadata = { version = "0.24.0", path = "../metadata" }
 
-sp-core = { version = "6.0.0", default-features = false  }
-sp-runtime = "6.0.0"
+# todo: release these from substrate and use crates.io packages
+sp-core = { version = "6.0.0", git = "https://github.com/paritytech/substrate", branch = "aj/sp-runtime-parity-util-mem", package = "sp-core", default-features = false  }
+sp-runtime = { version = "6.0.0", git = "https://github.com/paritytech/substrate", branch = "aj/sp-runtime-parity-util-mem", package = "sp-runtime", default-features = false  }
 
 frame-metadata = "15.0.0"
 derivative = "2.2.0"

--- a/testing/integration-tests/Cargo.toml
+++ b/testing/integration-tests/Cargo.toml
@@ -22,9 +22,9 @@ futures = "0.3.13"
 hex = "0.4.3"
 regex = "1.5.0"
 scale-info = { version = "2.0.0", features = ["bit-vec"] }
-sp-core = { version = "6.0.0", default-features = false  }
-sp-keyring = "6.0.0"
-sp-runtime = "6.0.0"
+sp-core = { version = "6.0.0", git = "https://github.com/paritytech/substrate", branch = "aj/sp-runtime-parity-util-mem", package = "sp-core", default-features = false  }
+sp-keyring = { version = "6.0.0", git = "https://github.com/paritytech/substrate", branch = "aj/sp-runtime-parity-util-mem", package = "sp-keyring", default-features = false  }
+sp-runtime = { version = "6.0.0", git = "https://github.com/paritytech/substrate", branch = "aj/sp-runtime-parity-util-mem", package = "sp-runtime", default-features = false  }
 syn = "1.0.0"
 subxt = { version = "0.24.0", path = "../../subxt" }
 subxt-codegen = { version = "0.24.0", path = "../../codegen" }

--- a/testing/test-runtime/Cargo.toml
+++ b/testing/test-runtime/Cargo.toml
@@ -5,12 +5,12 @@ edition = "2021"
 
 [dependencies]
 subxt = { path = "../../subxt" }
-sp-runtime = "6.0.0"
+sp-runtime = { version = "6.0.0", git = "https://github.com/paritytech/substrate", branch = "aj/sp-runtime-parity-util-mem", package = "sp-runtime", default-features = false  }
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full", "bit-vec"] }
 
 [build-dependencies]
 subxt = { path = "../../subxt" }
-sp-core = "6.0.0"
+sp-core = { version = "6.0.0", git = "https://github.com/paritytech/substrate", branch = "aj/sp-runtime-parity-util-mem", package = "sp-core", default-features = false  }
 tokio = { version = "1.8", features = ["macros", "rt-multi-thread"] }
 which = "4.2.2"
 jsonrpsee = { version = "0.15.1", features = ["async-client", "client-ws-transport"] }


### PR DESCRIPTION
*WIP* pending release of substrate dependencies, pointing at my PR https://github.com/paritytech/substrate/pull/12657.

![image](https://user-images.githubusercontent.com/75586/200804883-90857f29-f090-4304-9f11-e24e4a3b9199.png)