### PR TITLE
Add bitvec-like generic support to the scale-bits type for use in codegen

### DIFF
--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://www.parity.io/"
 description = "Generate an API for interacting with a substrate node from FRAME metadata"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full", "bit-vec"] }
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full"] }
 darling = "0.14.0"
 frame-metadata = "15.0.0"
 heck = "0.4.0"
@@ -19,7 +19,7 @@ proc-macro2 = "1.0.24"
 proc-macro-error = "1.0.4"
 quote = "1.0.8"
 syn = "1.0.58"
-scale-info = { version = "2.0.0", features = ["bit-vec"] }
+scale-info = "2.0.0"
 subxt-metadata = { version = "0.25.0", path = "../metadata" }
 jsonrpsee = { version = "0.16.0", features = ["async-client", "client-ws-transport", "http-client"] }
 hex = "0.4.3"
@@ -27,4 +27,5 @@ tokio = { version = "1.8", features = ["macros", "rt-multi-thread"] }
 
 [dev-dependencies]
 bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }
+scale-info = { version = "2.0.0", features = ["bit-vec"] }
 pretty_assertions = "1.0.0"

--- a/codegen/src/api/mod.rs
+++ b/codegen/src/api/mod.rs
@@ -161,11 +161,11 @@ impl RuntimeGenerator {
         let mut type_substitutes = [
             (
                 "bitvec::order::Lsb0",
-                parse_quote!(#crate_path::ext::bitvec::order::Lsb0),
+                parse_quote!(#crate_path::utils::bits::Lsb0),
             ),
             (
                 "bitvec::order::Msb0",
-                parse_quote!(#crate_path::ext::bitvec::order::Msb0),
+                parse_quote!(#crate_path::utils::bits::Msb0),
             ),
             (
                 "sp_core::crypto::AccountId32",

--- a/codegen/src/types/tests.rs
+++ b/codegen/src/types/tests.rs
@@ -745,10 +745,22 @@ fn generate_bitvec() {
     registry.register_type(&meta_type::<S>());
     let portable_types: PortableRegistry = registry.into();
 
+    let substitutes = [
+        (
+            String::from("bitvec::order::Lsb0"),
+            parse_quote!(::subxt_path::utils::bits::Lsb0),
+        ),
+        (
+            String::from("bitvec::order::Msb0"),
+            parse_quote!(::subxt_path::utils::bits::Msb0),
+        ),
+    ]
+    .into();
+
     let type_gen = TypeGenerator::new(
         &portable_types,
         "root",
-        Default::default(),
+        substitutes,
         DerivesRegistry::new(&"::subxt_path".into()),
         "::subxt_path".into(),
     );
@@ -762,8 +774,8 @@ fn generate_bitvec() {
                 use super::root;
                 #[derive(::subxt_path::ext::codec::Decode, ::subxt_path::ext::codec::Encode, Debug)]
                 pub struct S {
-                    pub lsb: ::subxt_path::ext::bitvec::vec::BitVec<::core::primitive::u8, root::bitvec::order::Lsb0>,
-                    pub msb: ::subxt_path::ext::bitvec::vec::BitVec<::core::primitive::u16, root::bitvec::order::Msb0>,
+                    pub lsb: ::subxt_path::utils::bits::DecodedBits<::core::primitive::u8, ::subxt_path::utils::bits::Lsb0>,
+                    pub msb: ::subxt_path::utils::bits::DecodedBits<::core::primitive::u16, ::subxt_path::utils::bits::Msb0>,
                 }
             }
         }

--- a/codegen/src/types/type_path.rs
+++ b/codegen/src/types/type_path.rs
@@ -246,7 +246,7 @@ impl TypePathType {
                 bit_store_type,
                 crate_path,
             } => {
-                let type_path = parse_quote! { #crate_path::ext::bitvec::vec::BitVec<#bit_store_type, #bit_order_type> };
+                let type_path = parse_quote! { #crate_path::utils::bits::DecodedBits<#bit_store_type, #bit_order_type> };
                 syn::Type::Path(type_path)
             }
         }

--- a/subxt/Cargo.toml
+++ b/subxt/Cargo.toml
@@ -26,10 +26,10 @@ jsonrpsee-ws = ["jsonrpsee/async-client", "jsonrpsee/client-ws-transport"]
 jsonrpsee-web = ["jsonrpsee/async-wasm-client", "jsonrpsee/client-web-transport"]
 
 [dependencies]
-bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full", "bit-vec"] }
-scale-info = { version = "2.0.0", features = ["bit-vec"] }
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full"] }
+scale-info = "2.0.0"
 scale-value = "0.6.0"
+scale-bits = "0.3"
 scale-decode = "0.4.0"
 futures = { version = "0.3.13", default-features = false }
 hex = "0.4.3"

--- a/subxt/src/lib.rs
+++ b/subxt/src/lib.rs
@@ -178,7 +178,6 @@ pub use crate::{
 
 /// Re-export external crates that are made use of in the subxt API.
 pub mod ext {
-    pub use bitvec;
     pub use codec;
     pub use frame_metadata;
     pub use scale_value;

--- a/subxt/src/utils.rs
+++ b/subxt/src/utils.rs
@@ -96,3 +96,124 @@ unsafe impl<T> Sync for PhantomDataSendSync<T> {}
 /// with collections like BTreeMap. This has the same type params
 /// as `BTreeMap` which allows us to easily swap the two during codegen.
 pub type KeyedVec<K, V> = Vec<(K, V)>;
+
+/// Generic `scale_bits` over `bitvec`-like `BitOrder` and `BitFormat` types.
+pub mod bits {
+    use codec::{Compact, Input};
+    use scale_bits::{
+        scale::format::{Format, OrderFormat, StoreFormat},
+        Bits,
+    };
+    use std::marker::PhantomData;
+
+    macro_rules! store {
+        ($ident: ident; $(($ty: ident, $wrapped: ty)),*) => {
+            /// Associates `bitvec::store::BitStore` trait with corresponding, type-erased `scale_bits::StoreFormat` enum.
+            ///
+            /// Used to decode bit sequences in runtime by providing `scale_bits::StoreFormat` using
+            /// `bitvec`-like type type parameters.
+            pub trait $ident {
+                /// Corresponding `scale_bits::StoreFormat` value.
+                const FORMAT: StoreFormat;
+                /// Number of bits that the backing store types holds.
+                const BITS: u32;
+            }
+
+            $(
+                impl $ident for $wrapped {
+                    const FORMAT: StoreFormat = StoreFormat::$ty;
+                    const BITS: u32 = <$wrapped>::BITS;
+                }
+            )*
+        };
+    }
+
+    macro_rules! order {
+        ($ident: ident; $($ty: ident),*) => {
+            /// Associates `bitvec::order::BitOrder` trait with corresponding, type-erased `scale_bits::OrderFormat` enum.
+            ///
+            /// Used to decode bit sequences in runtime by providing `scale_bits::OrderFormat` using
+            /// `bitvec`-like type type parameters.
+            pub trait $ident {
+                /// Corresponding `scale_bits::OrderFormat` value.
+                const FORMAT: OrderFormat;
+            }
+
+            $(
+                #[doc = concat!("Type-level value that corresponds to `scale_bits::OrderFormat::", stringify!($ty), "` at run-time")]
+                #[doc = concat!(" and `bitvec::order::BitOrder::", stringify!($ty), "` at the type level.")]
+                #[derive(Clone, Debug, PartialEq, Eq)]
+                pub enum $ty {}
+                impl $ident for $ty {
+                    const FORMAT: OrderFormat = OrderFormat::$ty;
+                }
+            )*
+        };
+    }
+
+    store!(BitStore; (U8, u8), (U16, u16), (U32, u32), (U64, u64));
+    order!(BitOrder; Lsb0, Msb0);
+
+    /// Constructs a run-time format parameters based on the corresponding type-level parameters.
+    pub fn bit_format<Store: BitStore, Order: BitOrder>() -> Format {
+        Format {
+            order: Order::FORMAT,
+            store: Store::FORMAT,
+        }
+    }
+
+    /// `scale_bits::Bits` generic over the bit store (`u8`/`u16`/`u32`/`u64`) and bit order (LSB, MSB) types.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub struct DecodedBits<Store: BitStore, Order: BitOrder>(
+        pub Bits,
+        pub PhantomData<Store>,
+        pub PhantomData<Order>,
+    );
+
+    impl<Store: BitStore, Order: BitOrder> codec::Decode for DecodedBits<Store, Order> {
+        fn decode<I: Input>(input: &mut I) -> Result<Self, codec::Error> {
+            /// Equivalent of `BitSlice::MAX_BITS` on 32bit machine.
+            const ARCH32BIT_BITSLICE_MAX_BITS: usize = 0x1fff_ffff;
+
+            let Compact(bits) = <Compact<u32>>::decode(input)?;
+            // Otherwise it is impossible to store it on 32bit machine.
+            if bits as usize > ARCH32BIT_BITSLICE_MAX_BITS {
+                return Err("Attempt to decode a BitVec with too many bits".into());
+            }
+            // NOTE: Replace with `bits.div_ceil(Store::BITS)` if `int_roundings` is stabilised
+            let bytes_needed =
+                (bits / Store::BITS) as usize + (bits % Store::BITS != 0) as usize;
+
+            // NOTE: We could reduce allocations if it would be possible to directly
+            // decode from an `Input` type using a custom format (rather than default <u8, Lsb0>)
+            // for the `Bits` type.
+            let mut storage = Vec::with_capacity(bytes_needed);
+            input.read(&mut storage)?;
+
+            let decoder = scale_bits::decode_using_format_from(
+                &storage,
+                bit_format::<Store, Order>(),
+            )?;
+            let bits = decoder.collect::<Result<Vec<_>, _>>()?;
+            let bits = Bits::from_iter(bits);
+
+            Ok(DecodedBits(bits, PhantomData, PhantomData))
+        }
+    }
+
+    impl<Store: BitStore, Order: BitOrder> codec::Encode for DecodedBits<Store, Order> {
+        fn size_hint(&self) -> usize {
+            self.0.size_hint()
+        }
+
+        fn encoded_size(&self) -> usize {
+            self.0.encoded_size()
+        }
+
+        fn encode(&self) -> Vec<u8> {
+            scale_bits::encode_using_format(self.0.iter(), bit_format::<Store, Order>())
+        }
+    }
+}
+
+pub use bits::{BitOrder, BitStore, DecodedBits, Lsb0, Msb0};

--- a/testing/integration-tests/src/codegen/polkadot.rs
+++ b/testing/integration-tests/src/codegen/polkadot.rs
@@ -38145,9 +38145,9 @@ pub mod api {
                     Debug,
                 )]
                 pub struct AvailabilityBitfield(
-                    pub  ::subxt::ext::bitvec::vec::BitVec<
+                    pub  ::subxt::utils::bits::DecodedBits<
                         ::core::primitive::u8,
-                        ::subxt::ext::bitvec::order::Lsb0,
+                        ::subxt::utils::bits::Lsb0,
                     >,
                 );
                 #[derive(
@@ -38163,9 +38163,9 @@ pub mod api {
                     pub validity_votes: ::std::vec::Vec<
                         runtime_types::polkadot_primitives::v2::ValidityAttestation,
                     >,
-                    pub validator_indices: ::subxt::ext::bitvec::vec::BitVec<
+                    pub validator_indices: ::subxt::utils::bits::DecodedBits<
                         ::core::primitive::u8,
-                        ::subxt::ext::bitvec::order::Lsb0,
+                        ::subxt::utils::bits::Lsb0,
                     >,
                 }
                 #[derive(
@@ -38255,13 +38255,13 @@ pub mod api {
                     Debug,
                 )]
                 pub struct DisputeState<_0> {
-                    pub validators_for: ::subxt::ext::bitvec::vec::BitVec<
+                    pub validators_for: ::subxt::utils::bits::DecodedBits<
                         ::core::primitive::u8,
-                        ::subxt::ext::bitvec::order::Lsb0,
+                        ::subxt::utils::bits::Lsb0,
                     >,
-                    pub validators_against: ::subxt::ext::bitvec::vec::BitVec<
+                    pub validators_against: ::subxt::utils::bits::DecodedBits<
                         ::core::primitive::u8,
-                        ::subxt::ext::bitvec::order::Lsb0,
+                        ::subxt::utils::bits::Lsb0,
                     >,
                     pub start: _0,
                     pub concluded_at: ::core::option::Option<_0>,
@@ -40088,13 +40088,13 @@ pub mod api {
                     pub hash: runtime_types::polkadot_core_primitives::CandidateHash,
                     pub descriptor:
                         runtime_types::polkadot_primitives::v2::CandidateDescriptor<_0>,
-                    pub availability_votes: ::subxt::ext::bitvec::vec::BitVec<
+                    pub availability_votes: ::subxt::utils::bits::DecodedBits<
                         ::core::primitive::u8,
-                        ::subxt::ext::bitvec::order::Lsb0,
+                        ::subxt::utils::bits::Lsb0,
                     >,
-                    pub backers: ::subxt::ext::bitvec::vec::BitVec<
+                    pub backers: ::subxt::utils::bits::DecodedBits<
                         ::core::primitive::u8,
-                        ::subxt::ext::bitvec::order::Lsb0,
+                        ::subxt::utils::bits::Lsb0,
                     >,
                     pub relay_parent_number: _1,
                     pub backed_in_number: _1,
@@ -40263,13 +40263,13 @@ pub mod api {
                     Debug,
                 )]
                 pub struct PvfCheckActiveVoteState<_0> {
-                    pub votes_accept: ::subxt::ext::bitvec::vec::BitVec<
+                    pub votes_accept: ::subxt::utils::bits::DecodedBits<
                         ::core::primitive::u8,
-                        ::subxt::ext::bitvec::order::Lsb0,
+                        ::subxt::utils::bits::Lsb0,
                     >,
-                    pub votes_reject: ::subxt::ext::bitvec::vec::BitVec<
+                    pub votes_reject: ::subxt::utils::bits::DecodedBits<
                         ::core::primitive::u8,
-                        ::subxt::ext::bitvec::order::Lsb0,
+                        ::subxt::utils::bits::Lsb0,
                     >,
                     pub age: _0,
                     pub created_at: _0,


### PR DESCRIPTION
Fixes #693 

Hopefully this is in line with what was expected from #693 cc @jsdw 