### PR TITLE
scripts: Fix `generate_changelog.sh` with empty printf

### DIFF
--- a/scripts/generate_changelog.sh
+++ b/scripts/generate_changelog.sh
@@ -55,8 +55,10 @@ function generate_changelog() {
         pr_link="$REMOTE_LINK$pr_number"
         # Generate the link as markdown.
         pr_md_link=" ([#$pr_number]($pr_link))"
-        # Print the changelog line as `- commit-title pr-link`.
-        echo "$line" | awk -v var="$pr_md_link" '{NF--; printf "- "; printf; print var}'
+        # Print every word from the commit title, except the last word.
+        # The last word is the PR id that is already included by the pr-link.
+        # The changelog line is `- commit-title pr-link`.
+        echo "$line" | awk -v link="$pr_md_link" '{ printf "- "; for(i=1;i<=NF-1;i++) { printf $i" "} print link}'
     done <<< "$prs"
 }
 


### PR DESCRIPTION
The error was generated by the following line
```
$        echo "$line" | awk -v var="$pr_md_link" '{NF--; printf "- "; printf; print var}'

- awk: cmd. line:1: (FILENAME=- FNR=1) fatal: printf: no arguments
```

To mitigate this issue, ensure AWK iterates over the correct words
from the commit title, skipping the last one.

For example, in the following commit title, the last word is `(#835)`.
```
[Bug Fix] - Incorrect trace caused by use of `Span::enter` in asynchronous code  (#835)
```
This is skipped from the output because will be replaced by

```
([#835](https://github.com/paritytech/jsonrpsee/pull/835))
```

The script worked prior only on MacOS, now it is compatible with Linux as well

Signed-off-by: Alexandru Vasile <alexandru.vasile@parity.io>