### PR TITLE
Retain Rust code items from `mod` decorated with `subxt` attribute

### DIFF
--- a/codegen/src/api/mod.rs
+++ b/codegen/src/api/mod.rs
@@ -204,9 +204,7 @@ impl RuntimeGenerator {
         })
         .collect::<HashMap<_, _>>();
 
-        for (path, substitute) in item_mod_ir.type_substitutes().iter() {
-            type_substitutes.insert(path.to_string(), substitute.clone());
-        }
+        type_substitutes.extend(item_mod_ir.type_substitutes().into_iter());
 
         let type_gen = TypeGenerator::new(
             &self.metadata.types,

--- a/codegen/src/api/mod.rs
+++ b/codegen/src/api/mod.rs
@@ -300,7 +300,7 @@ impl RuntimeGenerator {
             }
         };
 
-        let mod_ident = item_mod_ir.ident;
+        let mod_ident = &item_mod_ir.ident;
         let pallets_with_constants: Vec<_> = pallets_with_mod_names
             .iter()
             .filter_map(|(pallet, pallet_mod_name)| {
@@ -322,9 +322,14 @@ impl RuntimeGenerator {
             })
             .collect();
 
+        let rust_items: Vec<_> = item_mod_ir.rust_items().collect();
+
         quote! {
             #[allow(dead_code, unused_imports, non_camel_case_types)]
             pub mod #mod_ident {
+                // Preserve any Rust items that were previously defined in the adorned module
+                #( #rust_items ) *
+
                 // Make it easy to access the root via `root_mod` at different levels:
                 use super::#mod_ident as root_mod;
                 // Identify the pallets composing the static metadata by name.

--- a/codegen/src/api/mod.rs
+++ b/codegen/src/api/mod.rs
@@ -322,7 +322,7 @@ impl RuntimeGenerator {
             })
             .collect();
 
-        let rust_items: Vec<_> = item_mod_ir.rust_items().collect();
+        let rust_items = item_mod_ir.rust_items();
 
         quote! {
             #[allow(dead_code, unused_imports, non_camel_case_types)]

--- a/codegen/src/ir.rs
+++ b/codegen/src/ir.rs
@@ -26,16 +26,13 @@ impl From<syn::ItemMod> for ItemMod {
                 abort!(module, "out-of-line subxt modules are not supported",)
             }
         };
-        let items = items
-            .into_iter()
-            .map(<Item as From<syn::Item>>::from)
-            .collect::<Vec<_>>();
+
         Self {
             vis: module.vis,
             mod_token: module.mod_token,
             ident: module.ident,
             brace,
-            items,
+            items: items.into_iter().map(From::from).collect(),
         }
     }
 }

--- a/codegen/src/ir.rs
+++ b/codegen/src/ir.rs
@@ -55,7 +55,7 @@ impl ItemMod {
             .collect()
     }
 
-    pub fn rust_items<'a>(&'a self) -> impl Iterator<Item = &'a syn::Item> {
+    pub fn rust_items(&self) -> impl Iterator<Item = &syn::Item> {
         self.items.iter().filter_map(Item::as_rust)
     }
 }

--- a/codegen/src/ir.rs
+++ b/codegen/src/ir.rs
@@ -54,6 +54,10 @@ impl ItemMod {
             })
             .collect()
     }
+
+    pub fn rust_items<'a>(&'a self) -> impl Iterator<Item = &'a syn::Item> {
+        self.items.iter().filter_map(Item::as_rust)
+    }
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -61,6 +65,15 @@ impl ItemMod {
 pub enum Item {
     Rust(syn::Item),
     Subxt(SubxtItem),
+}
+
+impl Item {
+    pub fn as_rust(&self) -> Option<&syn::Item> {
+        match self {
+            Item::Rust(item) => Some(item),
+            _ => None,
+        }
+    }
 }
 
 impl From<syn::Item> for Item {

--- a/testing/ui-tests/src/correct/rust-items-preserved.rs
+++ b/testing/ui-tests/src/correct/rust-items-preserved.rs
@@ -1,0 +1,30 @@
+#[subxt::subxt(runtime_metadata_path = "../../../artifacts/polkadot_metadata.scale")]
+pub mod node_runtime {
+    pub struct SomeStruct;
+    pub enum SomeEnum {
+        A,
+        B,
+    }
+    pub trait SomeTrait {
+        fn some_func(&self) -> u32;
+    }
+    impl SomeTrait for SomeStruct {
+        fn some_func(&self) -> u32 {
+            1
+        }
+    }
+    impl SomeTrait for SomeEnum {
+        fn some_func(&self) -> u32 {
+            2
+        }
+    }
+}
+
+fn main() {
+    use node_runtime::SomeTrait;
+
+    let unit = node_runtime::SomeStruct;
+    assert_eq!(unit.some_func(), 1);
+    let enumeration = node_runtime::SomeEnum::A;
+    assert_eq!(enumeration.some_func(), 2);
+}

--- a/testing/ui-tests/src/lib.rs
+++ b/testing/ui-tests/src/lib.rs
@@ -25,6 +25,8 @@ fn ui_tests() {
     let mut m = MetadataTestRunner::default();
     let t = trybuild::TestCases::new();
 
+    t.pass("src/correct/*.rs");
+
     // Check that storage maps with no keys are handled properly.
     t.pass(&m.path_to_ui_test_for_metadata(
         "storage_map_no_keys",
@@ -50,5 +52,4 @@ fn ui_tests() {
 fn ui_fail() {
     let t = trybuild::TestCases::new();
     t.compile_fail("src/incorrect/*.rs");
-    t.pass("src/correct/*.rs");
 }

--- a/testing/ui-tests/src/lib.rs
+++ b/testing/ui-tests/src/lib.rs
@@ -50,4 +50,5 @@ fn ui_tests() {
 fn ui_fail() {
     let t = trybuild::TestCases::new();
     t.compile_fail("src/incorrect/*.rs");
+    t.pass("src/correct/*.rs");
 }


### PR DESCRIPTION
Closes #346 