### PR TITLE
events: Fetch metadata at arbitrary blocks

### DIFF
--- a/subxt/src/client/online_client.rs
+++ b/subxt/src/client/online_client.rs
@@ -93,7 +93,7 @@ impl<T: Config> OnlineClient<T> {
         let (genesis_hash, runtime_version, metadata) = future::join3(
             rpc.genesis_hash(),
             rpc.runtime_version(None),
-            rpc.metadata(),
+            rpc.metadata(None),
         )
         .await;
 
@@ -310,7 +310,7 @@ impl<T: Config> RuntimeUpdaterStream<T> {
             Err(err) => return Some(Err(err)),
         };
 
-        let metadata = match self.client.rpc().metadata().await {
+        let metadata = match self.client.rpc().metadata(None).await {
             Ok(metadata) => metadata,
             Err(err) => return Some(Err(err)),
         };

--- a/subxt/src/events/events_client.rs
+++ b/subxt/src/events/events_client.rs
@@ -66,13 +66,7 @@ where
                 }
             };
 
-            let event_bytes = client
-                .rpc()
-                .storage(&system_events_key().0, Some(block_hash))
-                .await?
-                .map(|e| e.0)
-                .unwrap_or_else(Vec::new);
-
+            let event_bytes = get_event_bytes(&client, Some(block_hash)).await?;
             Ok(Events::new(client.metadata(), block_hash, event_bytes))
         }
     }
@@ -83,4 +77,21 @@ fn system_events_key() -> StorageKey {
     let mut storage_key = twox_128(b"System").to_vec();
     storage_key.extend(twox_128(b"Events").to_vec());
     StorageKey(storage_key)
+}
+
+// Get the event bytes from the provided client, at the provided block hash.
+pub(crate) async fn get_event_bytes<T, Client>(
+    client: &Client,
+    block_hash: Option<T::Hash>,
+) -> Result<Vec<u8>, Error>
+where
+    T: Config,
+    Client: OnlineClientT<T>,
+{
+    Ok(client
+        .rpc()
+        .storage(&system_events_key().0, block_hash)
+        .await?
+        .map(|e| e.0)
+        .unwrap_or_else(Vec::new))
 }

--- a/subxt/src/events/events_client.rs
+++ b/subxt/src/events/events_client.rs
@@ -55,26 +55,14 @@ where
         async move {
             // If block hash is not provided, get the hash
             // for the latest block and use that.
-            let (block_hash, metadata) = match block_hash {
-                Some(hash) => {
-                    // If the block hash is provided, the hash can be of an older
-                    // block where the metadata was different. Fetch the metadata
-                    // at the specific block to ensure proper dynamic decoding of
-                    // events.
-                    (hash, client.rpc().metadata(Some(hash)).await?)
-                }
+            let block_hash = match block_hash {
+                Some(hash) => hash,
                 None => {
-                    // If the block hash was not provided, the metadata is
-                    // extracted from the client and is presumed to be up to
-                    // date (ie client should subscribe to the runtime upgrades).
-                    (
-                        client
-                            .rpc()
-                            .block_hash(None)
-                            .await?
-                            .expect("didn't pass a block number; qed"),
-                        client.metadata(),
-                    )
+                    client
+                        .rpc()
+                        .block_hash(None)
+                        .await?
+                        .expect("didn't pass a block number; qed")
                 }
             };
 
@@ -85,7 +73,7 @@ where
                 .map(|e| e.0)
                 .unwrap_or_else(Vec::new);
 
-            Ok(Events::new(metadata, block_hash, event_bytes))
+            Ok(Events::new(client.metadata(), block_hash, event_bytes))
         }
     }
 }

--- a/subxt/src/events/events_type.rs
+++ b/subxt/src/events/events_type.rs
@@ -66,7 +66,7 @@ impl<T: Config> Events<T> {
         }
     }
 
-    /// Obtain the events from a block hash, custom metadata and provided client.
+    /// Obtain the events from a block hash given custom metadata and a client.
     ///
     /// This method gives users the ability to inspect the events of older blocks,
     /// where the metadata changed. For those cases, the user is responsible for

--- a/subxt/src/rpc/rpc.rs
+++ b/subxt/src/rpc/rpc.rs
@@ -443,10 +443,10 @@ impl<T: Config> Rpc<T> {
     }
 
     /// Fetch the metadata
-    pub async fn metadata(&self) -> Result<Metadata, Error> {
+    pub async fn metadata(&self, at: Option<T::Hash>) -> Result<Metadata, Error> {
         let bytes: Bytes = self
             .client
-            .request("state_getMetadata", rpc_params![])
+            .request("state_getMetadata", rpc_params![at])
             .await?;
         let meta: RuntimeMetadataPrefixed = Decode::decode(&mut &bytes[..])?;
         let metadata: Metadata = meta.try_into()?;


### PR DESCRIPTION
The events are using the client metadata for dynamic decoding.
However, the users are allowed to inspect the events at an arbitrary block.
If the arbitrary block is a block where a runtime upgrade happened that
changed the metadata content, the dynamic decoding of the events
would fail.

To mitigate this scenario, expose the ability to query the metadata at
an arbitrary block, and fetch the metadata of a block when fetching the
block events.

This ensures that dynamic decoding of events will succeed if an arbitrary
block hash is provided.

The client is encouraged to keep the metadata in sync via subscriptions
to the runtime upgrade.

Closes: https://github.com/paritytech/subxt/issues/725