### PR TITLE
Remove a soon-to-be-removed `const_err` lint

### DIFF
--- a/subxt/src/lib.rs
+++ b/subxt/src/lib.rs
@@ -111,7 +111,6 @@
 
 #![deny(
     bad_style,
-    const_err,
     improper_ctypes,
     missing_docs,
     non_shorthand_field_patterns,


### PR DESCRIPTION
Removed in Rust 1.66:
```
warning: lint `const_err` has been removed: converted into hard error, see issue #71800 <https://github.com/rust-lang/rust/issues/71800> for more information
   --> subxt/src/lib.rs:114:5
    |
114 |     const_err,
    |     ^^^^^^^^^
    |
    = note: `#[warn(renamed_and_removed_lints)]` on by default
```