### PR TITLE
rpc: Expose the `subscription ID` for `RpcClientT`

### DIFF
--- a/examples/examples/custom_rpc_client.rs
+++ b/examples/examples/custom_rpc_client.rs
@@ -16,7 +16,6 @@ use subxt::{
         RpcClientT,
         RpcFuture,
         RpcSubscription,
-        RpcSubscriptionId,
     },
     OnlineClient,
     PolkadotConfig,
@@ -55,7 +54,7 @@ impl RpcClientT for MyLoggingClient {
         sub: &'a str,
         params: Option<Box<RawValue>>,
         unsub: &'a str,
-    ) -> RpcFuture<'a, (RpcSubscription, Option<RpcSubscriptionId>)> {
+    ) -> RpcFuture<'a, RpcSubscription> {
         writeln!(
             self.log.lock().unwrap(),
             "{sub}({}) (unsub: {unsub})",
@@ -70,7 +69,7 @@ impl RpcClientT for MyLoggingClient {
         let stream = futures::stream::once(async move { Ok(res) });
         let stream: Pin<Box<dyn futures::Stream<Item = _> + Send>> = Box::pin(stream);
         // This subscription does not provide an ID.
-        Box::pin(std::future::ready(Ok((stream, None))))
+        Box::pin(std::future::ready(Ok(RpcSubscription { stream, id: None })))
     }
 }
 

--- a/examples/examples/custom_rpc_client.rs
+++ b/examples/examples/custom_rpc_client.rs
@@ -16,6 +16,7 @@ use subxt::{
         RpcClientT,
         RpcFuture,
         RpcSubscription,
+        RpcSubscriptionId,
     },
     OnlineClient,
     PolkadotConfig,
@@ -54,7 +55,7 @@ impl RpcClientT for MyLoggingClient {
         sub: &'a str,
         params: Option<Box<RawValue>>,
         unsub: &'a str,
-    ) -> RpcFuture<'a, RpcSubscription> {
+    ) -> RpcFuture<'a, (RpcSubscription, Option<RpcSubscriptionId>)> {
         writeln!(
             self.log.lock().unwrap(),
             "{sub}({}) (unsub: {unsub})",
@@ -68,7 +69,8 @@ impl RpcClientT for MyLoggingClient {
         let res = RawValue::from_string("[]".to_string()).unwrap();
         let stream = futures::stream::once(async move { Ok(res) });
         let stream: Pin<Box<dyn futures::Stream<Item = _> + Send>> = Box::pin(stream);
-        Box::pin(std::future::ready(Ok(stream)))
+        // This subscription does not provide an ID.
+        Box::pin(std::future::ready(Ok((stream, None))))
     }
 }
 

--- a/subxt/src/rpc/mod.rs
+++ b/subxt/src/rpc/mod.rs
@@ -67,6 +67,7 @@ pub use rpc_client_t::{
     RpcClientT,
     RpcFuture,
     RpcSubscription,
+    RpcSubscriptionId,
 };
 
 pub use rpc_client::{

--- a/subxt/src/rpc/mod.rs
+++ b/subxt/src/rpc/mod.rs
@@ -68,6 +68,7 @@ pub use rpc_client_t::{
     RpcFuture,
     RpcSubscription,
     RpcSubscriptionId,
+    RpcSubscriptionStream,
 };
 
 pub use rpc_client::{

--- a/subxt/src/rpc/rpc_client.rs
+++ b/subxt/src/rpc/rpc_client.rs
@@ -5,6 +5,7 @@
 use super::{
     RpcClientT,
     RpcSubscription,
+    RpcSubscriptionId,
 };
 use crate::error::Error;
 use futures::{
@@ -60,8 +61,8 @@ impl RpcClient {
         params: RpcParams,
         unsub: &str,
     ) -> Result<Subscription<Res>, Error> {
-        let sub = self.0.subscribe_raw(sub, params.build(), unsub).await?;
-        Ok(Subscription::new(sub))
+        let (sub, sub_id) = self.0.subscribe_raw(sub, params.build(), unsub).await?;
+        Ok(Subscription::new(sub, sub_id))
     }
 }
 
@@ -166,6 +167,7 @@ impl RpcParams {
 /// [`StreamExt`] extension trait.
 pub struct Subscription<Res> {
     inner: RpcSubscription,
+    sub_id: Option<RpcSubscriptionId>,
     _marker: std::marker::PhantomData<Res>,
 }
 
@@ -179,11 +181,17 @@ impl<Res> std::fmt::Debug for Subscription<Res> {
 }
 
 impl<Res> Subscription<Res> {
-    fn new(inner: RpcSubscription) -> Self {
+    fn new(inner: RpcSubscription, sub_id: Option<RpcSubscriptionId>) -> Self {
         Self {
             inner,
+            sub_id,
             _marker: std::marker::PhantomData,
         }
+    }
+
+    /// Obtain the ID associated with this subscription.
+    pub fn subscription_id(&self) -> Option<&RpcSubscriptionId> {
+        self.sub_id.as_ref()
     }
 }
 

--- a/subxt/src/rpc/rpc_client_t.rs
+++ b/subxt/src/rpc/rpc_client_t.rs
@@ -52,15 +52,23 @@ pub trait RpcClientT: Send + Sync + 'static {
         sub: &'a str,
         params: Option<Box<RawValue>>,
         unsub: &'a str,
-    ) -> RpcFuture<'a, (RpcSubscription, Option<RpcSubscriptionId>)>;
+    ) -> RpcFuture<'a, RpcSubscription>;
 }
 
 /// A boxed future that is returned from the [`RpcClientT`] methods.
 pub type RpcFuture<'a, T> =
     Pin<Box<dyn Future<Output = Result<T, RpcError>> + Send + 'a>>;
 
+/// The RPC subscription returned from [`RpcClientT`]'s `subscription` method.
+pub struct RpcSubscription {
+    /// The subscription stream.
+    pub stream: RpcSubscriptionStream,
+    /// The ID associated with the subscription.
+    pub id: Option<RpcSubscriptionId>,
+}
+
 /// The inner subscription stream returned from our [`RpcClientT`]'s `subscription` method.
-pub type RpcSubscription =
+pub type RpcSubscriptionStream =
     Pin<Box<dyn Stream<Item = Result<Box<RawValue>, RpcError>> + Send + 'static>>;
 
 /// The ID associated with the [`RpcClientT`]'s `subscription`.

--- a/subxt/src/rpc/rpc_client_t.rs
+++ b/subxt/src/rpc/rpc_client_t.rs
@@ -52,7 +52,7 @@ pub trait RpcClientT: Send + Sync + 'static {
         sub: &'a str,
         params: Option<Box<RawValue>>,
         unsub: &'a str,
-    ) -> RpcFuture<'a, RpcSubscription>;
+    ) -> RpcFuture<'a, (RpcSubscription, Option<RpcSubscriptionId>)>;
 }
 
 /// A boxed future that is returned from the [`RpcClientT`] methods.
@@ -62,3 +62,6 @@ pub type RpcFuture<'a, T> =
 /// The inner subscription stream returned from our [`RpcClientT`]'s `subscription` method.
 pub type RpcSubscription =
     Pin<Box<dyn Stream<Item = Result<Box<RawValue>, RpcError>> + Send + 'static>>;
+
+/// The ID associated with the [`RpcClientT`]'s `subscription`.
+pub type RpcSubscriptionId = String;


### PR DESCRIPTION
Extent the `RpcClientT` to obtain the ID associated with subscriptions.

To ensure that this extension is not impacting users that do not want to
implement/return it, the subscription ID is optional.

The subscription ID needs to be exposed for implementing https://github.com/paritytech/subxt/issues/732.
