### PR TITLE
ci: Try running `cargo test` flag with `--release`

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,6 +7,7 @@ on:
 
 
 env:
+  CARGO_INCREMENTAL: 0
   CARGO_TERM_COLOR: always
   # Use latest substrate for nightly runs:
   SUBSTRATE_URL: https://releases.parity.io/substrate/x86_64-debian:stretch/latest/substrate/substrate

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -136,7 +136,7 @@ jobs:
         uses: actions-rs/cargo@v1.0.3
         with:
           command: test
-          args: --all-targets --workspace
+          args: --release --all-targets --workspace
 
   clippy:
     name: Cargo clippy

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -137,7 +137,7 @@ jobs:
         uses: actions-rs/cargo@v1.0.3
         with:
           command: test
-          args: --release --all-targets --workspace
+          args: --all-targets --workspace
 
   clippy:
     name: Cargo clippy

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,6 +13,7 @@ on:
       - master
 
 env:
+  CARGO_INCREMENTAL: 0
   CARGO_TERM_COLOR: always
   # TODO: Currently pointing at latest substrate; is there a suitable binary we can pin to here?
   SUBSTRATE_URL: https://releases.parity.io/substrate/x86_64-debian:stretch/latest/substrate/substrate


### PR DESCRIPTION
Trying to improve the run time of the `cargo test` job.