### PR TITLE
cargo: Update `sp-*` crates from v7.0.0 to v9.0.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -185,8 +185,8 @@ jobs:
     - name: Install chrome
       uses: browser-actions/setup-chrome@latest
 
-    # - name: Rust Cache
-    #   uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6 # v2.2.0
+    - name: Rust Cache
+      uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6 # v2.2.0
 
     - name: Download Substrate
       run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -185,8 +185,8 @@ jobs:
     - name: Install chrome
       uses: browser-actions/setup-chrome@latest
 
-    - name: Rust Cache
-      uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6 # v2.2.0
+    # - name: Rust Cache
+    #   uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6 # v2.2.0
 
     - name: Download Substrate
       run: |

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -14,7 +14,7 @@ description = "Subxt example usage"
 [dev-dependencies]
 subxt = { path = "../subxt" }
 tokio = { version = "1.8", features = ["rt-multi-thread", "macros", "time"] }
-sp-keyring = "9.0.0"
+sp-keyring = "11.0.0"
 futures = "0.3.13"
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full", "bit-vec"] }
 hex = "0.4.3"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -14,7 +14,7 @@ description = "Subxt example usage"
 [dev-dependencies]
 subxt = { path = "../subxt" }
 tokio = { version = "1.8", features = ["rt-multi-thread", "macros", "time"] }
-sp-keyring = "8.0.0"
+sp-keyring = "9.0.0"
 futures = "0.3.13"
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full", "bit-vec"] }
 hex = "0.4.3"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -14,7 +14,7 @@ description = "Subxt example usage"
 [dev-dependencies]
 subxt = { path = "../subxt" }
 tokio = { version = "1.8", features = ["rt-multi-thread", "macros", "time"] }
-sp-keyring = "11.0.0"
+sp-keyring = { version = "11.0.0", default-features = false }
 futures = "0.3.13"
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full", "bit-vec"] }
 hex = "0.4.3"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -14,7 +14,7 @@ description = "Subxt example usage"
 [dev-dependencies]
 subxt = { path = "../subxt" }
 tokio = { version = "1.8", features = ["rt-multi-thread", "macros", "time"] }
-sp-keyring = "7.0.0"
+sp-keyring = "8.0.0"
 futures = "0.3.13"
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full", "bit-vec"] }
 hex = "0.4.3"

--- a/metadata/Cargo.toml
+++ b/metadata/Cargo.toml
@@ -16,7 +16,7 @@ description = "Command line utilities for checking metadata compatibility betwee
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full"] }
 frame-metadata = "15.0.0"
 scale-info = "2.0.0"
-sp-core = "7.0.0"
+sp-core = "8.0.0"
 
 [dev-dependencies]
 bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }

--- a/metadata/Cargo.toml
+++ b/metadata/Cargo.toml
@@ -16,7 +16,7 @@ description = "Command line utilities for checking metadata compatibility betwee
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full"] }
 frame-metadata = "15.0.0"
 scale-info = "2.0.0"
-sp-core = "8.0.0"
+sp-core = "9.0.0"
 
 [dev-dependencies]
 bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }

--- a/metadata/Cargo.toml
+++ b/metadata/Cargo.toml
@@ -16,7 +16,7 @@ description = "Command line utilities for checking metadata compatibility betwee
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full"] }
 frame-metadata = "15.0.0"
 scale-info = "2.0.0"
-sp-core = "9.0.0"
+sp-core = { version = "10.0.0", default-features = false }
 
 [dev-dependencies]
 bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }

--- a/subxt/Cargo.toml
+++ b/subxt/Cargo.toml
@@ -45,7 +45,7 @@ subxt-macro = { version = "0.25.0", path = "../macro" }
 subxt-metadata = { version = "0.25.0", path = "../metadata" }
 
 sp-core = { version = "10.0.0", default-features = false }
-sp-runtime = "11.0.0"
+sp-runtime = { version = "11.0.0", default-features = false }
 
 frame-metadata = "15.0.0"
 derivative = "2.2.0"

--- a/subxt/Cargo.toml
+++ b/subxt/Cargo.toml
@@ -44,8 +44,8 @@ parking_lot = "0.12.0"
 subxt-macro = { version = "0.25.0", path = "../macro" }
 subxt-metadata = { version = "0.25.0", path = "../metadata" }
 
-sp-core = { version = "8.0.0", default-features = false  }
-sp-runtime = "8.0.0"
+sp-core = { version = "9.0.0", default-features = false  }
+sp-runtime = "9.0.0"
 
 frame-metadata = "15.0.0"
 derivative = "2.2.0"

--- a/subxt/Cargo.toml
+++ b/subxt/Cargo.toml
@@ -44,8 +44,8 @@ parking_lot = "0.12.0"
 subxt-macro = { version = "0.25.0", path = "../macro" }
 subxt-metadata = { version = "0.25.0", path = "../metadata" }
 
-sp-core = { version = "9.0.0", default-features = false  }
-sp-runtime = "9.0.0"
+sp-core = { version = "10.0.0", default-features = false }
+sp-runtime = "11.0.0"
 
 frame-metadata = "15.0.0"
 derivative = "2.2.0"

--- a/subxt/Cargo.toml
+++ b/subxt/Cargo.toml
@@ -44,8 +44,8 @@ parking_lot = "0.12.0"
 subxt-macro = { version = "0.25.0", path = "../macro" }
 subxt-metadata = { version = "0.25.0", path = "../metadata" }
 
-sp-core = { version = "7.0.0", default-features = false  }
-sp-runtime = "7.0.0"
+sp-core = { version = "8.0.0", default-features = false  }
+sp-runtime = "8.0.0"
 
 frame-metadata = "15.0.0"
 derivative = "2.2.0"

--- a/testing/integration-tests/Cargo.toml
+++ b/testing/integration-tests/Cargo.toml
@@ -23,9 +23,9 @@ futures = "0.3.13"
 hex = "0.4.3"
 regex = "1.5.0"
 scale-info = { version = "2.0.0", features = ["bit-vec"] }
-sp-core = { version = "7.0.0", default-features = false }
-sp-keyring = "7.0.0"
-sp-runtime = "7.0.0"
+sp-core = { version = "8.0.0", default-features = false }
+sp-keyring = "8.0.0"
+sp-runtime = "8.0.0"
 syn = "1.0.0"
 subxt = { version = "0.25.0", path = "../../subxt" }
 subxt-codegen = { version = "0.25.0", path = "../../codegen" }

--- a/testing/integration-tests/Cargo.toml
+++ b/testing/integration-tests/Cargo.toml
@@ -25,7 +25,7 @@ regex = "1.5.0"
 scale-info = { version = "2.0.0", features = ["bit-vec"] }
 sp-core = { version = "10.0.0", default-features = false }
 sp-keyring = "11.0.0"
-sp-runtime = "11.0.0"
+sp-runtime = { version = "11.0.0", default-features = false }
 syn = "1.0.0"
 subxt = { version = "0.25.0", path = "../../subxt" }
 subxt-codegen = { version = "0.25.0", path = "../../codegen" }

--- a/testing/integration-tests/Cargo.toml
+++ b/testing/integration-tests/Cargo.toml
@@ -24,7 +24,7 @@ hex = "0.4.3"
 regex = "1.5.0"
 scale-info = { version = "2.0.0", features = ["bit-vec"] }
 sp-core = { version = "10.0.0", default-features = false }
-sp-keyring = "11.0.0"
+sp-keyring = { version = "11.0.0", default-features = false }
 sp-runtime = { version = "11.0.0", default-features = false }
 syn = "1.0.0"
 subxt = { version = "0.25.0", path = "../../subxt" }

--- a/testing/integration-tests/Cargo.toml
+++ b/testing/integration-tests/Cargo.toml
@@ -23,9 +23,9 @@ futures = "0.3.13"
 hex = "0.4.3"
 regex = "1.5.0"
 scale-info = { version = "2.0.0", features = ["bit-vec"] }
-sp-core = { version = "9.0.0", default-features = false }
-sp-keyring = "9.0.0"
-sp-runtime = "9.0.0"
+sp-core = { version = "10.0.0", default-features = false }
+sp-keyring = "11.0.0"
+sp-runtime = "11.0.0"
 syn = "1.0.0"
 subxt = { version = "0.25.0", path = "../../subxt" }
 subxt-codegen = { version = "0.25.0", path = "../../codegen" }

--- a/testing/integration-tests/Cargo.toml
+++ b/testing/integration-tests/Cargo.toml
@@ -23,9 +23,9 @@ futures = "0.3.13"
 hex = "0.4.3"
 regex = "1.5.0"
 scale-info = { version = "2.0.0", features = ["bit-vec"] }
-sp-core = { version = "8.0.0", default-features = false }
-sp-keyring = "8.0.0"
-sp-runtime = "8.0.0"
+sp-core = { version = "9.0.0", default-features = false }
+sp-keyring = "9.0.0"
+sp-runtime = "9.0.0"
 syn = "1.0.0"
 subxt = { version = "0.25.0", path = "../../subxt" }
 subxt-codegen = { version = "0.25.0", path = "../../codegen" }

--- a/testing/test-runtime/Cargo.toml
+++ b/testing/test-runtime/Cargo.toml
@@ -6,12 +6,12 @@ publish = false
 
 [dependencies]
 subxt = { path = "../../subxt" }
-sp-runtime = "7.0.0"
+sp-runtime = "8.0.0"
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full", "bit-vec"] }
 
 [build-dependencies]
 subxt = { path = "../../subxt" }
-sp-core = { version = "7.0.0", default-features = false  }
+sp-core = { version = "8.0.0", default-features = false  }
 tokio = { version = "1.8", features = ["macros", "rt-multi-thread"] }
 which = "4.2.2"
 jsonrpsee = { version = "0.16.0", features = ["async-client", "client-ws-transport"] }

--- a/testing/test-runtime/Cargo.toml
+++ b/testing/test-runtime/Cargo.toml
@@ -6,12 +6,12 @@ publish = false
 
 [dependencies]
 subxt = { path = "../../subxt" }
-sp-runtime = "8.0.0"
+sp-runtime = "9.0.0"
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full", "bit-vec"] }
 
 [build-dependencies]
 subxt = { path = "../../subxt" }
-sp-core = { version = "8.0.0", default-features = false  }
+sp-core = { version = "9.0.0", default-features = false  }
 tokio = { version = "1.8", features = ["macros", "rt-multi-thread"] }
 which = "4.2.2"
 jsonrpsee = { version = "0.16.0", features = ["async-client", "client-ws-transport"] }

--- a/testing/test-runtime/Cargo.toml
+++ b/testing/test-runtime/Cargo.toml
@@ -6,12 +6,12 @@ publish = false
 
 [dependencies]
 subxt = { path = "../../subxt" }
-sp-runtime = "9.0.0"
+sp-runtime = "11.0.0"
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full", "bit-vec"] }
 
 [build-dependencies]
 subxt = { path = "../../subxt" }
-sp-core = { version = "9.0.0", default-features = false  }
+sp-core = { version = "10.0.0", default-features = false }
 tokio = { version = "1.8", features = ["macros", "rt-multi-thread"] }
 which = "4.2.2"
 jsonrpsee = { version = "0.16.0", features = ["async-client", "client-ws-transport"] }

--- a/testing/test-runtime/Cargo.toml
+++ b/testing/test-runtime/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 subxt = { path = "../../subxt" }
-sp-runtime = "11.0.0"
+sp-runtime = { version = "11.0.0", default-features = false }
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full", "bit-vec"] }
 
 [build-dependencies]


### PR DESCRIPTION
Update the `sp-core`, `sp-keyring` and `sp-runtime` crates to the latest v8.0.0 version.

The crates need a manual update to properly sync all dependencies, as noted by
dependabot in https://github.com/paritytech/subxt/pull/747, https://github.com/paritytech/subxt/pull/746 and https://github.com/paritytech/subxt/pull/745.
