### PR TITLE
Add Runtime API to execute runtime calls

### DIFF
--- a/subxt/src/blocks/block_types.rs
+++ b/subxt/src/blocks/block_types.rs
@@ -91,7 +91,7 @@ where
         ))
     }
 
-    /// Execute a runtime API calls at this block.
+    /// Execute a runtime API call at this block.
     pub async fn runtime_api(&self) -> Result<RuntimeApi<T, C>, Error> {
         Ok(RuntimeApi::new(self.client.clone(), self.hash()))
     }

--- a/subxt/src/blocks/block_types.rs
+++ b/subxt/src/blocks/block_types.rs
@@ -18,6 +18,7 @@ use crate::{
     },
     events,
     rpc::types::ChainBlockResponse,
+    runtime_api::RuntimeApi,
 };
 use derivative::Derivative;
 use futures::lock::Mutex as AsyncMutex;
@@ -88,6 +89,11 @@ where
             block_details,
             self.cached_events.clone(),
         ))
+    }
+
+    /// Execute a runtime API calls at this block.
+    pub async fn runtime_api(&self) -> Result<RuntimeApi<T, C>, Error> {
+        Ok(RuntimeApi::new(self.client.clone(), self.hash()))
     }
 }
 

--- a/subxt/src/client/offline_client.rs
+++ b/subxt/src/client/offline_client.rs
@@ -7,6 +7,7 @@ use crate::{
     constants::ConstantsClient,
     events::EventsClient,
     rpc::types::RuntimeVersion,
+    runtime_api::RuntimeApiClient,
     storage::StorageClient,
     tx::TxClient,
     Config,
@@ -48,6 +49,11 @@ pub trait OfflineClientT<T: Config>: Clone + Send + Sync + 'static {
     /// Work with blocks.
     fn blocks(&self) -> BlocksClient<T, Self> {
         BlocksClient::new(self.clone())
+    }
+
+    /// Work with runtime API.
+    fn runtime_api(&self) -> RuntimeApiClient<T, Self> {
+        RuntimeApiClient::new(self.clone())
     }
 }
 

--- a/subxt/src/client/online_client.rs
+++ b/subxt/src/client/online_client.rs
@@ -117,9 +117,7 @@ impl<T: Config> OnlineClient<T> {
 
     /// Fetch the metadata from substrate using the runtime API.
     async fn fetch_metadata(rpc: &Rpc<T>) -> Result<Metadata, Error> {
-        let bytes = rpc
-            .state_call("Metadata_metadata".into(), None, None)
-            .await?;
+        let bytes = rpc.state_call("Metadata_metadata", None, None).await?;
         let cursor = &mut &*bytes;
         let _ = <Compact<u32>>::decode(cursor)?;
         let meta: RuntimeMetadataPrefixed = Decode::decode(cursor)?;

--- a/subxt/src/client/online_client.rs
+++ b/subxt/src/client/online_client.rs
@@ -19,6 +19,7 @@ use crate::{
         Rpc,
         RpcClientT,
     },
+    runtime_api::RuntimeApiClient,
     storage::StorageClient,
     tx::TxClient,
     Config,
@@ -213,6 +214,11 @@ impl<T: Config> OnlineClient<T> {
     /// Work with blocks.
     pub fn blocks(&self) -> BlocksClient<T, Self> {
         <Self as OfflineClientT<T>>::blocks(self)
+    }
+
+    /// Work with runtime API.
+    pub fn runtime_api(&self) -> RuntimeApiClient<T, Self> {
+        <Self as OfflineClientT<T>>::runtime_api(self)
     }
 }
 

--- a/subxt/src/client/online_client.rs
+++ b/subxt/src/client/online_client.rs
@@ -25,7 +25,12 @@ use crate::{
     Config,
     Metadata,
 };
+use codec::{
+    Compact,
+    Decode,
+};
 use derivative::Derivative;
+use frame_metadata::RuntimeMetadataPrefixed;
 use futures::future;
 use parking_lot::RwLock;
 use std::sync::Arc;
@@ -96,7 +101,7 @@ impl<T: Config> OnlineClient<T> {
         let (genesis_hash, runtime_version, metadata) = future::join3(
             rpc.genesis_hash(),
             rpc.runtime_version(None),
-            rpc.metadata(None),
+            OnlineClient::fetch_metadata(&rpc),
         )
         .await;
 
@@ -108,6 +113,17 @@ impl<T: Config> OnlineClient<T> {
             })),
             rpc,
         })
+    }
+
+    /// Fetch the metadata from substrate using the runtime API.
+    async fn fetch_metadata(rpc: &Rpc<T>) -> Result<Metadata, Error> {
+        let bytes = rpc
+            .state_call("Metadata_metadata".into(), None, None)
+            .await?;
+        let cursor = &mut &*bytes;
+        let _ = <Compact<u32>>::decode(cursor)?;
+        let meta: RuntimeMetadataPrefixed = Decode::decode(cursor)?;
+        Ok(meta.try_into()?)
     }
 
     /// Create an object which can be used to keep the runtime up to date

--- a/subxt/src/lib.rs
+++ b/subxt/src/lib.rs
@@ -155,6 +155,7 @@ pub mod error;
 pub mod events;
 pub mod metadata;
 pub mod rpc;
+pub mod runtime_api;
 pub mod storage;
 pub mod tx;
 pub mod utils;

--- a/subxt/src/rpc/rpc.rs
+++ b/subxt/src/rpc/rpc.rs
@@ -374,7 +374,7 @@ impl<T: Config> Rpc<T> {
     /// Execute a runtime API call.
     pub async fn state_call(
         &self,
-        function: String,
+        function: &str,
         call_parameters: Option<&[u8]>,
         at: Option<T::Hash>,
     ) -> Result<types::Bytes, Error> {

--- a/subxt/src/rpc/rpc.rs
+++ b/subxt/src/rpc/rpc.rs
@@ -371,6 +371,25 @@ impl<T: Config> Rpc<T> {
         Ok(xt_hash)
     }
 
+    /// Execute a runtime API call.
+    pub async fn state_call(
+        &self,
+        function: String,
+        call_parameters: Option<&[u8]>,
+        at: Option<T::Hash>,
+    ) -> Result<types::Bytes, Error> {
+        let call_parameters = call_parameters.unwrap_or_default();
+
+        let bytes: types::Bytes = self
+            .client
+            .request(
+                "state_call",
+                rpc_params![function, to_hex(call_parameters), at],
+            )
+            .await?;
+        Ok(bytes)
+    }
+
     /// Create and submit an extrinsic and return a subscription to the events triggered.
     pub async fn watch_extrinsic<X: Encode>(
         &self,

--- a/subxt/src/runtime_api/mod.rs
+++ b/subxt/src/runtime_api/mod.rs
@@ -1,0 +1,11 @@
+// Copyright 2019-2022 Parity Technologies (UK) Ltd.
+// This file is dual-licensed as Apache-2.0 or GPL-3.0.
+// see LICENSE for license details.
+
+//! Types associated with executing runtime API calls.
+
+mod runtime_client;
+mod runtime_types;
+
+pub use runtime_client::RuntimeApiClient;
+pub use runtime_types::RuntimeApi;

--- a/subxt/src/runtime_api/runtime_client.rs
+++ b/subxt/src/runtime_api/runtime_client.rs
@@ -1,0 +1,66 @@
+// Copyright 2019-2022 Parity Technologies (UK) Ltd.
+// This file is dual-licensed as Apache-2.0 or GPL-3.0.
+// see LICENSE for license details.
+
+use super::runtime_types::RuntimeApi;
+
+use crate::{
+    client::OnlineClientT,
+    error::Error,
+    Config,
+};
+use derivative::Derivative;
+use std::{
+    future::Future,
+    marker::PhantomData,
+};
+
+/// Execute runtime API calls.
+#[derive(Derivative)]
+#[derivative(Clone(bound = "Client: Clone"))]
+pub struct RuntimeApiClient<T, Client> {
+    client: Client,
+    _marker: PhantomData<T>,
+}
+
+impl<T, Client> RuntimeApiClient<T, Client> {
+    /// Create a new [`RuntimeApiClient`]
+    pub fn new(client: Client) -> Self {
+        Self {
+            client,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<T, Client> RuntimeApiClient<T, Client>
+where
+    T: Config,
+    Client: OnlineClientT<T>,
+{
+    /// Obtain a runtime API at some block hash.
+    pub fn at(
+        &self,
+        block_hash: Option<T::Hash>,
+    ) -> impl Future<Output = Result<RuntimeApi<T, Client>, Error>> + Send + 'static {
+        // Clone and pass the client in like this so that we can explicitly
+        // return a Future that's Send + 'static, rather than tied to &self.
+        let client = self.client.clone();
+        async move {
+            // If block hash is not provided, get the hash
+            // for the latest block and use that.
+            let block_hash = match block_hash {
+                Some(hash) => hash,
+                None => {
+                    client
+                        .rpc()
+                        .block_hash(None)
+                        .await?
+                        .expect("didn't pass a block number; qed")
+                }
+            };
+
+            Ok(RuntimeApi::new(client, block_hash))
+        }
+    }
+}

--- a/subxt/src/runtime_api/runtime_client.rs
+++ b/subxt/src/runtime_api/runtime_client.rs
@@ -56,7 +56,7 @@ where
                         .rpc()
                         .block_hash(None)
                         .await?
-                        .expect("didn't pass a block number; qed")
+                        .expect("substrate RPC returns the best block when no block number is provided; qed")
                 }
             };
 

--- a/subxt/src/runtime_api/runtime_types.rs
+++ b/subxt/src/runtime_api/runtime_types.rs
@@ -41,7 +41,7 @@ where
     /// Execute a raw runtime API call.
     pub fn call_raw<'a>(
         &self,
-        function: String,
+        function: &'a str,
         call_parameters: Option<&'a [u8]>,
     ) -> impl Future<Output = Result<Vec<u8>, Error>> + 'a {
         let client = self.client.clone();

--- a/subxt/src/runtime_api/runtime_types.rs
+++ b/subxt/src/runtime_api/runtime_types.rs
@@ -1,0 +1,59 @@
+// Copyright 2019-2022 Parity Technologies (UK) Ltd.
+// This file is dual-licensed as Apache-2.0 or GPL-3.0.
+// see LICENSE for license details.
+
+use crate::{
+    client::OnlineClientT,
+    error::Error,
+    Config,
+};
+use derivative::Derivative;
+use std::{
+    future::Future,
+    marker::PhantomData,
+};
+
+/// Execute runtime API calls.
+#[derive(Derivative)]
+#[derivative(Clone(bound = "Client: Clone"))]
+pub struct RuntimeApi<T: Config, Client> {
+    client: Client,
+    block_hash: T::Hash,
+    _marker: PhantomData<T>,
+}
+
+impl<T: Config, Client> RuntimeApi<T, Client> {
+    /// Create a new [`RuntimeApi`]
+    pub(crate) fn new(client: Client, block_hash: T::Hash) -> Self {
+        Self {
+            client,
+            block_hash,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<T, Client> RuntimeApi<T, Client>
+where
+    T: Config,
+    Client: OnlineClientT<T>,
+{
+    /// Execute a raw runtime API call.
+    pub fn call_raw<'a>(
+        &self,
+        function: String,
+        call_parameters: Option<&'a [u8]>,
+    ) -> impl Future<Output = Result<Vec<u8>, Error>> + 'a {
+        let client = self.client.clone();
+        let block_hash = self.block_hash;
+        // Ensure that the returned future doesn't have a lifetime tied to api.runtime_api(),
+        // which is a temporary thing we'll be throwing away quickly:
+        async move {
+            let data = client
+                .rpc()
+                .state_call(function, call_parameters, Some(block_hash))
+                .await?;
+            Ok(data.0)
+        }
+    }
+}

--- a/testing/integration-tests/src/blocks/mod.rs
+++ b/testing/integration-tests/src/blocks/mod.rs
@@ -104,7 +104,7 @@ async fn runtime_api_call() -> Result<(), subxt::Error> {
     let block = sub.next().await.unwrap()?;
     let rt = block.runtime_api().await?;
 
-    let bytes = rt.call_raw("Metadata_metadata".into(), None).await?;
+    let bytes = rt.call_raw("Metadata_metadata", None).await?;
     let cursor = &mut &*bytes;
     let _ = <Compact<u32>>::decode(cursor)?;
     let meta: RuntimeMetadataPrefixed = Decode::decode(cursor)?;

--- a/testing/integration-tests/src/client/mod.rs
+++ b/testing/integration-tests/src/client/mod.rs
@@ -264,7 +264,7 @@ async fn rpc_state_call() {
     // Call into the runtime of the chain to get the Metadata.
     let metadata_bytes = api
         .rpc()
-        .state_call("Metadata_metadata".into(), None, None)
+        .state_call("Metadata_metadata", None, None)
         .await
         .unwrap();
 

--- a/testing/integration-tests/src/client/mod.rs
+++ b/testing/integration-tests/src/client/mod.rs
@@ -11,6 +11,11 @@ use crate::{
         wait_for_blocks,
     },
 };
+use codec::{
+    Compact,
+    Decode,
+};
+use frame_metadata::RuntimeMetadataPrefixed;
 use sp_core::{
     sr25519::Pair as Sr25519Pair,
     storage::well_known_keys,
@@ -249,4 +254,30 @@ async fn unsigned_extrinsic_is_same_shape_as_polkadotjs() {
 
     // Make sure our encoding is the same as the encoding polkadot UI created.
     assert_eq!(actual_tx_bytes, expected_tx_bytes);
+}
+
+#[tokio::test]
+async fn rpc_state_call() {
+    let ctx = test_context().await;
+    let api = ctx.client();
+
+    // Call into the runtime of the chain to get the Metadata.
+    let metadata_bytes = api
+        .rpc()
+        .state_call("Metadata_metadata".into(), None, None)
+        .await
+        .unwrap();
+
+    let cursor = &mut &*metadata_bytes;
+    let _ = <Compact<u32>>::decode(cursor).unwrap();
+    let meta: RuntimeMetadataPrefixed = Decode::decode(cursor).unwrap();
+    let metadata_call = match meta.1 {
+        frame_metadata::RuntimeMetadata::V14(metadata) => metadata,
+        _ => panic!("Metadata V14 unavailable"),
+    };
+
+    // Compare the runtime API call against the `state_getMetadata`.
+    let metadata = api.rpc().metadata(None).await.unwrap();
+    let metadata = metadata.runtime_metadata();
+    assert_eq!(&metadata_call, metadata);
 }


### PR DESCRIPTION
This PR adds the ability to call into the runtime API of the subxt.

At this moment, the subxt utilises the `state_call` method.
This work lays the ground for transitioning to the `chainHead` and `archive` methods of the RPC SpecV2.

The API is exposed both at the root level via, as well at the blocks level (block-centric approach).

Part of #732 .