### PR TITLE
ci: Print substrate version

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,11 +23,9 @@ jobs:
         run: |
             curl $SUBSTRATE_URL --output substrate --location
             chmod +x substrate
+            ./substrate --version
             mkdir -p ~/.local/bin
             mv substrate ~/.local/bin
-
-      - name: Substrate Version
-        run: ~/.local/bin/substrate --version
 
       - name: Install Rust stable toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,9 +23,11 @@ jobs:
         run: |
             curl $SUBSTRATE_URL --output substrate --location
             chmod +x substrate
-            ./substrate --version
             mkdir -p ~/.local/bin
             mv substrate ~/.local/bin
+
+      - name: Substrate Version
+        run: ~/.local/bin/substrate --version
 
       - name: Install Rust stable toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,6 +23,7 @@ jobs:
         run: |
             curl $SUBSTRATE_URL --output substrate --location
             chmod +x substrate
+            ./substrate --version
             mkdir -p ~/.local/bin
             mv substrate ~/.local/bin
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,9 +29,11 @@ jobs:
         run: |
             curl $SUBSTRATE_URL --output substrate --location
             chmod +x substrate
-            ./substrate --version
             mkdir -p ~/.local/bin
             mv substrate ~/.local/bin
+
+      - name: Substrate Version
+        run: ~/.local/bin/substrate --version
 
       - name: Install Rust stable toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,11 +29,9 @@ jobs:
         run: |
             curl $SUBSTRATE_URL --output substrate --location
             chmod +x substrate
+            ./substrate --version
             mkdir -p ~/.local/bin
             mv substrate ~/.local/bin
-
-      - name: Substrate Version
-        run: ~/.local/bin/substrate --version
 
       - name: Install Rust stable toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,6 +29,7 @@ jobs:
         run: |
             curl $SUBSTRATE_URL --output substrate --location
             chmod +x substrate
+            ./substrate --version
             mkdir -p ~/.local/bin
             mv substrate ~/.local/bin
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -87,6 +87,7 @@ jobs:
         run: |
             curl $SUBSTRATE_URL --output substrate --location
             chmod +x substrate
+            ./substrate --version
             mkdir -p ~/.local/bin
             mv substrate ~/.local/bin
 
@@ -120,6 +121,7 @@ jobs:
         run: |
             curl $SUBSTRATE_URL --output substrate --location
             chmod +x substrate
+            ./substrate --version
             mkdir -p ~/.local/bin
             mv substrate ~/.local/bin
 
@@ -150,6 +152,7 @@ jobs:
         run: |
             curl $SUBSTRATE_URL --output substrate --location
             chmod +x substrate
+            ./substrate --version
             mkdir -p ~/.local/bin
             mv substrate ~/.local/bin
 
@@ -193,6 +196,7 @@ jobs:
       run: |
         curl $SUBSTRATE_URL --output substrate --location
         chmod +x substrate
+        ./substrate --version
         mkdir -p ~/.local/bin
         mv substrate ~/.local/bin
 


### PR DESCRIPTION
The nightly CI has detected a failure in a subxt UI test (https://github.com/paritytech/subxt/issues/779).

In order to gain better knowledge into what version of substrate we are using, this PR outputs the `substrate --version`.