### PR TITLE
Codegen: Preserve attrs and add #[allow(clippy::all)]

### DIFF
--- a/codegen/src/api/mod.rs
+++ b/codegen/src/api/mod.rs
@@ -328,7 +328,7 @@ impl RuntimeGenerator {
         quote! {
             #( #item_mod_attrs )*
             #[allow(dead_code, unused_imports, non_camel_case_types)]
-            #[allow(clippy::*)]
+            #[allow(clippy::all)]
             pub mod #mod_ident {
                 // Preserve any Rust items that were previously defined in the adorned module
                 #( #rust_items ) *

--- a/codegen/src/api/mod.rs
+++ b/codegen/src/api/mod.rs
@@ -154,6 +154,7 @@ impl RuntimeGenerator {
         derives: DerivesRegistry,
         crate_path: CratePath,
     ) -> TokenStream2 {
+        let item_mod_attrs = item_mod.attrs.clone();
         let item_mod_ir = ir::ItemMod::from(item_mod);
         let default_derives = derives.default_derives();
 
@@ -325,7 +326,9 @@ impl RuntimeGenerator {
         let rust_items = item_mod_ir.rust_items();
 
         quote! {
+            #( #item_mod_attrs )*
             #[allow(dead_code, unused_imports, non_camel_case_types)]
+            #[allow(clippy::*)]
             pub mod #mod_ident {
                 // Preserve any Rust items that were previously defined in the adorned module
                 #( #rust_items ) *

--- a/testing/integration-tests/src/codegen/codegen_documentation.rs
+++ b/testing/integration-tests/src/codegen/codegen_documentation.rs
@@ -9,11 +9,14 @@ use subxt_codegen::{
     RuntimeGenerator,
 };
 
+fn load_test_metadata() -> frame_metadata::RuntimeMetadataPrefixed {
+    let bytes = test_runtime::METADATA;
+    codec::Decode::decode(&mut &*bytes).expect("Cannot decode scale metadata")
+}
+
 fn metadata_docs() -> Vec<String> {
     // Load the runtime metadata downloaded from a node via `test-runtime`.
-    let bytes = test_runtime::METADATA;
-    let meta: frame_metadata::RuntimeMetadataPrefixed =
-        codec::Decode::decode(&mut &*bytes).expect("Cannot decode scale metadata");
+    let meta = load_test_metadata();
     let metadata = match meta.1 {
         frame_metadata::RuntimeMetadata::V14(v14) => v14,
         _ => panic!("Unsupported metadata version {:?}", meta.1),
@@ -45,9 +48,7 @@ fn metadata_docs() -> Vec<String> {
 
 fn generate_runtime_interface(crate_path: CratePath) -> String {
     // Load the runtime metadata downloaded from a node via `test-runtime`.
-    let bytes = test_runtime::METADATA;
-    let metadata: frame_metadata::RuntimeMetadataPrefixed =
-        codec::Decode::decode(&mut &*bytes).expect("Cannot decode scale metadata");
+    let metadata = load_test_metadata();
 
     // Generate a runtime interface from the provided metadata.
     let generator = RuntimeGenerator::new(metadata);
@@ -107,4 +108,36 @@ fn check_documentation() {
             raw
         );
     }
+}
+
+#[test]
+fn check_root_attrs_preserved() {
+    let metadata = load_test_metadata();
+
+    // Test that the root docs/attr are preserved.
+    let item_mod = syn::parse_quote!(
+        /// Some root level documentation
+        #[some_root_attribute]
+        pub mod api {}
+    );
+
+    // Generate a runtime interface from the provided metadata.
+    let generator = RuntimeGenerator::new(metadata);
+    let derives = DerivesRegistry::new(&CratePath::default());
+    let generated_code = generator
+        .generate_runtime(item_mod, derives, CratePath::default())
+        .to_string();
+
+    let doc_str_loc = generated_code
+        .find("Some root level documentation")
+        .expect("root docs should be preserved");
+    let attr_loc = generated_code.find("some_root_attribute") // '#' is space separated in generated output.
+        .expect("root attr should be preserved");
+    let mod_start = generated_code
+        .find("pub mod api")
+        .expect("'pub mod api' expected");
+
+    // These things should be before the mod start
+    assert!(doc_str_loc < mod_start);
+    assert!(attr_loc < mod_start);
 }


### PR DESCRIPTION
Closes #775 and allows arbitrary attributes to be kept as needed on codegen module.