### PR TITLE
Update `trybuild` to the latest version

### DIFF
--- a/testing/ui-tests/Cargo.toml
+++ b/testing/ui-tests/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 
 [dev-dependencies]
-trybuild = "=1.0.75"
+trybuild = "1.0.76"
 scale-info = { version = "2.3.0", features = ["bit-vec"] }
 frame-metadata = "15.0.0"
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full", "bit-vec"] }

--- a/testing/ui-tests/src/correct/rust-items-preserved.rs
+++ b/testing/ui-tests/src/correct/rust-items-preserved.rs
@@ -1,4 +1,4 @@
-#[subxt::subxt(runtime_metadata_path = "../../../artifacts/polkadot_metadata.scale")]
+#[subxt::subxt(runtime_metadata_path = "../../../../artifacts/polkadot_metadata.scale")]
 pub mod node_runtime {
     pub struct SomeStruct;
     pub enum SomeEnum {

--- a/testing/ui-tests/src/incorrect/substitute_path_not_absolute.rs
+++ b/testing/ui-tests/src/incorrect/substitute_path_not_absolute.rs
@@ -1,4 +1,4 @@
-#[subxt::subxt(runtime_metadata_path = "../../../artifacts/polkadot_metadata.scale")]
+#[subxt::subxt(runtime_metadata_path = "../../../../artifacts/polkadot_metadata.scale")]
 pub mod node_runtime {
     #[subxt::subxt(substitute_type = "sp_arithmetic::per_things::Perbill")]
     use sp_runtime::Perbill;

--- a/testing/ui-tests/src/incorrect/url_and_path_provided.rs
+++ b/testing/ui-tests/src/incorrect/url_and_path_provided.rs
@@ -1,5 +1,5 @@
 #[subxt::subxt(
-    runtime_metadata_path = "../../../artifacts/polkadot_metadata.scale",
+    runtime_metadata_path = "../../../../artifacts/polkadot_metadata.scale",
     runtime_metadata_url = "wss://rpc.polkadot.io:443"
 )]
 pub mod node_runtime {}

--- a/testing/ui-tests/src/incorrect/url_and_path_provided.stderr
+++ b/testing/ui-tests/src/incorrect/url_and_path_provided.stderr
@@ -2,7 +2,7 @@ error: Only one of 'runtime_metadata_path' or 'runtime_metadata_url' can be prov
  --> src/incorrect/url_and_path_provided.rs:1:1
   |
 1 | / #[subxt::subxt(
-2 | |     runtime_metadata_path = "../../../artifacts/polkadot_metadata.scale",
+2 | |     runtime_metadata_path = "../../../../artifacts/polkadot_metadata.scale",
 3 | |     runtime_metadata_url = "wss://rpc.polkadot.io:443"
 4 | | )]
   | |__^


### PR DESCRIPTION
Use the latest version of trybuild `1.0.76` and adjust the path to the scale metadata blob for UI testing.