### PR TITLE
Expose version info in CLI tool with build-time obtained git hash

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -21,7 +21,7 @@ subxt-codegen = { version = "0.25.0", path = "../codegen" }
 # perform node compatibility
 subxt-metadata = { version = "0.25.0", path = "../metadata" }
 # parse command line args
-clap = { version = "4.0.8", features = ["derive"] }
+clap = { version = "4.0.8", features = ["derive", "cargo"] }
 # colourful error reports
 color-eyre = "0.6.1"
 # serialize the metadata

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -1,0 +1,20 @@
+use std::process::Command;
+
+fn main() {
+    // Make git hash available via GIT_HASH build-time env var:
+    output_git_short_hash();
+}
+
+fn output_git_short_hash() {
+    let output = Command::new("git")
+        .args(&["rev-parse", "--short=11", "HEAD"])
+        .output()
+        .expect("'git' command should exist and run successfully");
+
+    let git_hash =
+        String::from_utf8(output.stdout).expect("git hash should be valid UTF8");
+
+    println!("cargo:rustc-env=GIT_HASH={}", git_hash);
+    println!("cargo:rustc-rerun-if-changed=../.git/HEAD");
+    println!("cargo:rustc-rerun-if-changed=build.rs");
+}

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -1,4 +1,5 @@
 use std::process::Command;
+use std::borrow::Cow;
 
 fn main() {
     // Make git hash available via GIT_HASH build-time env var:
@@ -8,13 +9,25 @@ fn main() {
 fn output_git_short_hash() {
     let output = Command::new("git")
         .args(["rev-parse", "--short=11", "HEAD"])
-        .output()
-        .expect("'git' command should exist and run successfully");
+        .output();
 
-    let git_hash =
-        String::from_utf8(output.stdout).expect("git hash should be valid UTF8");
+    let git_hash = match output {
+        Ok(o) if o.status.success() => {
+            let sha = String::from_utf8_lossy(&o.stdout).trim().to_owned();
+            Cow::from(sha)
+        },
+        Ok(o) => {
+            println!("cargo:warning=Git command failed with status: {}", o.status);
+            Cow::from("unknown")
+        },
+        Err(err) => {
+            println!("cargo:warning=Failed to execute git command: {}", err);
+            Cow::from("unknown")
+        },
+    };
 
     println!("cargo:rustc-env=GIT_HASH={}", git_hash);
-    println!("cargo:rustc-rerun-if-changed=../.git/HEAD");
-    println!("cargo:rustc-rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=../.git/HEAD");
+    println!("cargo:rerun-if-changed=../.git/refs");
+    println!("cargo:rerun-if-changed=build.rs");
 }

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -1,5 +1,7 @@
-use std::process::Command;
-use std::borrow::Cow;
+use std::{
+    borrow::Cow,
+    process::Command,
+};
 
 fn main() {
     // Make git hash available via GIT_HASH build-time env var:
@@ -15,15 +17,15 @@ fn output_git_short_hash() {
         Ok(o) if o.status.success() => {
             let sha = String::from_utf8_lossy(&o.stdout).trim().to_owned();
             Cow::from(sha)
-        },
+        }
         Ok(o) => {
             println!("cargo:warning=Git command failed with status: {}", o.status);
             Cow::from("unknown")
-        },
+        }
         Err(err) => {
             println!("cargo:warning=Failed to execute git command: {}", err);
             Cow::from("unknown")
-        },
+        }
     };
 
     println!("cargo:rustc-env=GIT_HASH={}", git_hash);

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -7,7 +7,7 @@ fn main() {
 
 fn output_git_short_hash() {
     let output = Command::new("git")
-        .args(&["rev-parse", "--short=11", "HEAD"])
+        .args(["rev-parse", "--short=11", "HEAD"])
         .output()
         .expect("'git' command should exist and run successfully");
 

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -5,3 +5,4 @@
 pub mod codegen;
 pub mod compatibility;
 pub mod metadata;
+pub mod version;

--- a/cli/src/commands/version.rs
+++ b/cli/src/commands/version.rs
@@ -1,0 +1,16 @@
+use clap::Parser as ClapParser;
+
+/// Prints version information
+#[derive(Debug, ClapParser)]
+pub struct Opts {}
+
+pub fn run(_opts: Opts) -> color_eyre::Result<()> {
+    let git_hash = env!("GIT_HASH");
+    println!(
+        "{} {}-{}",
+        clap::crate_name!(),
+        clap::crate_version!(),
+        git_hash
+    );
+    Ok(())
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -13,6 +13,7 @@ enum Command {
     Metadata(commands::metadata::Opts),
     Codegen(commands::codegen::Opts),
     Compatibility(commands::compatibility::Opts),
+    Version(commands::version::Opts),
 }
 
 #[tokio::main]
@@ -24,5 +25,6 @@ async fn main() -> color_eyre::Result<()> {
         Command::Metadata(opts) => commands::metadata::run(opts).await,
         Command::Codegen(opts) => commands::codegen::run(opts).await,
         Command::Compatibility(opts) => commands::compatibility::run(opts).await,
+        Command::Version(opts) => commands::version::run(opts),
     }
 }


### PR DESCRIPTION
Builds off  @DaviRain-Su's work in #776 and provides version info in the subxt CLI command, making the git hash be a compile-time included string.

Closes #739 