### PR TITLE
Add ability to set custom metadata etc on OnlineClient

### DIFF
--- a/subxt/src/client/mod.rs
+++ b/subxt/src/client/mod.rs
@@ -23,3 +23,9 @@ pub use online_client::{
     Update,
     UpgradeError,
 };
+
+#[cfg(any(
+    feature = "jsonrpsee-ws",
+    all(feature = "jsonrpsee-web", target_arch = "wasm32")
+))]
+pub use online_client::default_rpc_client;

--- a/subxt/src/client/online_client.rs
+++ b/subxt/src/client/online_client.rs
@@ -145,9 +145,6 @@ impl<T: Config> OnlineClient<T> {
         let rpc = Rpc::<T>::new(rpc_client.clone());
         let (genesis_hash, runtime_version, metadata) = future::join3(
             rpc.genesis_hash(),
-            // This _could_ always be the latest runtime version, but offhand it makes sense to keep
-            // it consistent with the block hash provided, so that if we were to ask for it, we'd see
-            // it at that point.
             rpc.runtime_version(block_hash),
             rpc.metadata(block_hash),
         )

--- a/subxt/src/client/online_client.rs
+++ b/subxt/src/client/online_client.rs
@@ -79,9 +79,12 @@ impl<T: Config> OnlineClient<T> {
     ///
     /// # Warning
     ///
-    /// If you use this function, you take responsibility for knowing which blocks this
-    /// client will be capable of interacting with successfully. For example, subscriptions
-    /// to recent blocks and submitting transactions may fail.
+    /// - If you use this function, subxt will be unable to work with blocks that aren't
+    ///   compatible with the metadata at the provided block hash, and if the block hash is
+    ///   not recent, things like subscribing to the head of the chain and submitting
+    ///   transactions will likely fail or encounter errors.
+    /// - Subxt does not support blocks using pre-V14 metadata and will error if you attempt
+    ///   to instantiate a client at such a block.
     pub async fn new_at(block_hash: Option<T::Hash>) -> Result<OnlineClient<T>, Error> {
         let url = "ws://127.0.0.1:9944";
         OnlineClient::from_url_at(url, block_hash).await
@@ -97,9 +100,12 @@ impl<T: Config> OnlineClient<T> {
     ///
     /// # Warning
     ///
-    /// If you use this function, you take responsibility for knowing which blocks this
-    /// client will be capable of interacting with successfully. For example, subscriptions
-    /// to recent blocks and submitting transactions may fail.
+    /// - If you use this function, subxt will be unable to work with blocks that aren't
+    ///   compatible with the metadata at the provided block hash, and if the block hash is
+    ///   not recent, things like subscribing to the head of the chain and submitting
+    ///   transactions will likely fail or encounter errors.
+    /// - Subxt does not support blocks using pre-V14 metadata and will error if you attempt
+    ///   to instantiate a client at such a block.
     pub async fn from_url_at(
         url: impl AsRef<str>,
         block_hash: Option<T::Hash>,
@@ -126,9 +132,12 @@ impl<T: Config> OnlineClient<T> {
     ///
     /// # Warning
     ///
-    /// If you use this function, you take responsibility for knowing which blocks this
-    /// client will be capable of interacting with successfully. For example, subscriptions
-    /// to recent blocks and submitting transactions may fail.
+    /// - If you use this function, subxt will be unable to work with blocks that aren't
+    ///   compatible with the metadata at the provided block hash, and if the block hash is
+    ///   not recent, things like subscribing to the head of the chain and submitting
+    ///   transactions will likely fail or encounter errors.
+    /// - Subxt does not support blocks using pre-V14 metadata and will error if you attempt
+    ///   to instantiate a client at such a block.
     pub async fn from_rpc_client_at<R: RpcClientT>(
         rpc_client: Arc<R>,
         block_hash: Option<T::Hash>,


### PR DESCRIPTION
This allows one to instantiate clients capable of decoding older (as long as still V14) blocks and such, with suitable warnings that such clients may not be able to interact with the head of the chain and such.

Hopefully this closes #793