### PR TITLE
Fix bad signature when the extrinsic size is over 256 bytes

### DIFF
--- a/subxt/src/tx/tx_client.rs
+++ b/subxt/src/tx/tx_client.rs
@@ -169,7 +169,7 @@ impl<T: Config, C: OfflineClientT<T>> TxClient<T, C> {
             additional_and_extra_params.encode_extra_to(&mut bytes);
             additional_and_extra_params.encode_additional_to(&mut bytes);
             if bytes.len() > 256 {
-                signer.sign(T::Hasher::hash_of(&bytes).as_ref())
+                signer.sign(T::Hasher::hash_of(&Encoded(bytes)).as_ref())
             } else {
                 signer.sign(&bytes)
             }


### PR DESCRIPTION
This is a bug introduced in [#760](https://github.com/paritytech/subxt/pull/760/files#diff-2fb361b08d8543a8a513a3f16b7d44ed1d1105716427e00006c44e763cef8290R172).