### PR TITLE
tests: Ensure correct signing of extrinsics larger than 256 bytes

### DIFF
--- a/testing/integration-tests/src/client/mod.rs
+++ b/testing/integration-tests/src/client/mod.rs
@@ -235,6 +235,33 @@ async fn dry_run_fails() {
 }
 
 #[tokio::test]
+async fn submit_large_extrinsic() {
+    let ctx = test_context().await;
+    let api = ctx.client();
+
+    let alice = pair_signer(AccountKeyring::Alice.pair());
+
+    // 2 MiB blob of data.
+    let bytes: Vec<u8> = (0..2 * 1024 * 1024).map(|i: u32| i as u8).collect();
+    // The preimage pallet allows storing and managing large byte-blobs.
+    let tx = node_runtime::tx().preimage().note_preimage(bytes);
+
+    let signed_extrinsic = api
+        .tx()
+        .create_signed(&tx, &alice, Default::default())
+        .await
+        .unwrap();
+
+    signed_extrinsic
+        .submit_and_watch()
+        .await
+        .unwrap()
+        .wait_for_finalized_success()
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
 async fn unsigned_extrinsic_is_same_shape_as_polkadotjs() {
     let ctx = test_context().await;
     let api = ctx.client();

--- a/testing/integration-tests/src/client/mod.rs
+++ b/testing/integration-tests/src/client/mod.rs
@@ -242,7 +242,7 @@ async fn submit_large_extrinsic() {
     let alice = pair_signer(AccountKeyring::Alice.pair());
 
     // 2 MiB blob of data.
-    let bytes: Vec<u8> = (0..2 * 1024 * 1024).map(|i: u32| i as u8).collect();
+    let bytes = vec![0_u8; 2 * 1024 * 1024];
     // The preimage pallet allows storing and managing large byte-blobs.
     let tx = node_runtime::tx().preimage().note_preimage(bytes);
 


### PR DESCRIPTION
Test that subxt can submit properly extrinsics that are larger than 256 bytes.

This PR creates an extrinsic of 2MiB and submits it to a local node.

Specifically, there was a fix in #796 that ensures the signatures are created correctly for larger extrinsic payloads.

Without the fix from #796 results in `Transaction has a bad signature`.