### PR TITLE
doc: first item is current version comment

### DIFF
--- a/subxt/src/rpc/rpc.rs
+++ b/subxt/src/rpc/rpc.rs
@@ -366,6 +366,7 @@ impl<T: Config> Rpc<T> {
     }
 
     /// Subscribe to runtime version updates that produce changes in the metadata.
+    /// The first item emitted by the stream is the current runtime version.
     pub async fn subscribe_runtime_version(
         &self,
     ) -> Result<Subscription<types::RuntimeVersion>, Error> {


### PR DESCRIPTION
This is helpful info, I was going to create a wrapper stream to add this functionality then realised it's already included OOTB :). 