### PR TITLE
Add `find_last` for events_types

### DIFF
--- a/subxt/src/events/events_type.rs
+++ b/subxt/src/events/events_type.rs
@@ -187,6 +187,12 @@ impl<T: Config> Events<T> {
         self.find::<Ev>().next().transpose()
     }
 
+    /// Iterate through the events using metadata to dynamically decode and skip
+    /// them, and return the last event found which decodes to the provided `Ev` type.
+    pub fn find_last<Ev: StaticEvent>(&self) -> Result<Option<Ev>, Error> {
+        self.find::<Ev>().last().transpose()
+    }
+
     /// Find an event that decodes to the type provided. Returns true if it was found.
     pub fn has<Ev: StaticEvent>(&self) -> Result<bool, Error> {
         Ok(self.find::<Ev>().next().transpose()?.is_some())


### PR DESCRIPTION
In order to optimise the code present in this [PR](https://github.com/paritytech/cargo-contract/pull/965), used for this [issue](https://github.com/paritytech/cargo-contract/issues/777) fixing the wrong return of contract account id with `cargo contract instantiate`

At the moment, only the method was added, yet more integration tests should be. 

As @ascjones suggests, finding 'a pallet where we know that two of the same type of event will be raised by the same extrinsic' should be more relevant than just adding the same integration tests where `find_first` is used,

What do you think would be the best @jsdw ?  