### PR TITLE
Add `find_last` for block types 

### DIFF
--- a/subxt/src/blocks/block_types.rs
+++ b/subxt/src/blocks/block_types.rs
@@ -269,7 +269,7 @@ impl<T: Config> ExtrinsicEvents<T> {
     /// Iterate through the transaction events using metadata to dynamically decode and skip
     /// them, and return the last event found which decodes to the provided `Ev` type.
     ///
-    /// This works in the same way that [`events::Events::find_first()`] does, with the
+    /// This works in the same way that [`events::Events::find_last()`] does, with the
     /// exception that it ignores events not related to the submitted extrinsic.
     pub fn find_last<Ev: events::StaticEvent>(&self) -> Result<Option<Ev>, Error> {
         self.find::<Ev>().last().transpose()

--- a/subxt/src/blocks/block_types.rs
+++ b/subxt/src/blocks/block_types.rs
@@ -266,6 +266,15 @@ impl<T: Config> ExtrinsicEvents<T> {
         self.find::<Ev>().next().transpose()
     }
 
+    /// Iterate through the transaction events using metadata to dynamically decode and skip
+    /// them, and return the last event found which decodes to the provided `Ev` type.
+    ///
+    /// This works in the same way that [`events::Events::find_first()`] does, with the
+    /// exception that it ignores events not related to the submitted extrinsic.
+    pub fn find_last<Ev: events::StaticEvent>(&self) -> Result<Option<Ev>, Error> {
+        self.find::<Ev>().last().transpose()
+    }
+
     /// Find an event in those associated with this transaction. Returns true if it was found.
     ///
     /// This works in the same way that [`events::Events::has()`] does, with the


### PR DESCRIPTION
Still to fix the [issue](https://github.com/paritytech/cargo-contract/issues/777) and complete this [PR](https://github.com/paritytech/subxt/pull/821), `find_last` was added for block types events. 

This time, it was tested for this [fix](https://github.com/paritytech/cargo-contract/pull/965) 