### PR TITLE
Release 0.27.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.27.1] - 2022-02-15
+
+## Added
+
+- Add `find_last` for block types ([#825](https://github.com/paritytech/subxt/pull/825))
+
 ## [0.27.0] - 2022-02-13
 
 This is a fairly small release, primarily to bump substrate dependencies to their latest versions.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1559,7 +1559,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "assert_matches",
  "frame-metadata",
@@ -3387,7 +3387,7 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "subxt"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "base58",
  "bitvec",
@@ -3422,7 +3422,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-cli"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "clap 4.1.4",
  "color-eyre",
@@ -3440,7 +3440,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-codegen"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "bitvec",
  "darling",
@@ -3461,7 +3461,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-examples"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "futures",
  "hex",
@@ -3476,7 +3476,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "darling",
  "proc-macro-error",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-metadata"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "bitvec",
  "criterion",
@@ -3542,7 +3542,7 @@ dependencies = [
 
 [[package]]
 name = "test-runtime"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -3873,7 +3873,7 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "ui-tests"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subxt-cli"
-version = "0.27.0"
+version = "0.27.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = true
@@ -17,9 +17,9 @@ path = "src/main.rs"
 
 [dependencies]
 # perform subxt codegen
-subxt-codegen = { version = "0.27.0", path = "../codegen" }
+subxt-codegen = { version = "0.27.1", path = "../codegen" }
 # perform node compatibility
-subxt-metadata = { version = "0.27.0", path = "../metadata" }
+subxt-metadata = { version = "0.27.1", path = "../metadata" }
 # parse command line args
 clap = { version = "4.1.4", features = ["derive", "cargo"] }
 # colourful error reports

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subxt-codegen"
-version = "0.27.0"
+version = "0.27.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = true
@@ -21,7 +21,7 @@ proc-macro-error = "1.0.4"
 quote = "1.0.8"
 syn = "1.0.58"
 scale-info = "2.0.0"
-subxt-metadata = { version = "0.27.0", path = "../metadata" }
+subxt-metadata = { version = "0.27.1", path = "../metadata" }
 jsonrpsee = { version = "0.16.0", features = ["async-client", "client-ws-transport", "http-client"] }
 hex = "0.4.3"
 tokio = { version = "1.25", features = ["macros", "rt-multi-thread"] }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subxt-examples"
-version = "0.27.0"
+version = "0.27.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subxt-macro"
-version = "0.27.0"
+version = "0.27.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = true
@@ -20,4 +20,4 @@ darling = "0.14.3"
 proc-macro-error = "1.0.4"
 syn = "1.0.58"
 
-subxt-codegen = { path = "../codegen", version = "0.27.0" }
+subxt-codegen = { path = "../codegen", version = "0.27.1" }

--- a/metadata/Cargo.toml
+++ b/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subxt-metadata"
-version = "0.27.0"
+version = "0.27.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = true

--- a/subxt/Cargo.toml
+++ b/subxt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subxt"
-version = "0.27.0"
+version = "0.27.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = true
@@ -50,8 +50,8 @@ parking_lot = "0.12.0"
 frame-metadata = "15.0.0"
 derivative = "2.2.0"
 
-subxt-macro = { version = "0.27.0", path = "../macro" }
-subxt-metadata = { version = "0.27.0", path = "../metadata" }
+subxt-macro = { version = "0.27.1", path = "../macro" }
+subxt-metadata = { version = "0.27.1", path = "../metadata" }
 
 # Provides some deserialization, types like U256/H256 and hashing impls like twox/blake256:
 impl-serde = { version = "0.4.0" }

--- a/testing/integration-tests/Cargo.toml
+++ b/testing/integration-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "integration-tests"
-version = "0.27.0"
+version = "0.27.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false
@@ -27,8 +27,8 @@ sp-core = { version = "16.0.0", default-features = false }
 sp-keyring = "18.0.0"
 sp-runtime = "18.0.0"
 syn = "1.0.0"
-subxt = { version = "0.27.0", path = "../../subxt" }
-subxt-codegen = { version = "0.27.0", path = "../../codegen" }
+subxt = { version = "0.27.1", path = "../../subxt" }
+subxt-codegen = { version = "0.27.1", path = "../../codegen" }
 test-runtime = { path = "../test-runtime" }
 tokio = { version = "1.25", features = ["macros", "time"] }
 tracing = "0.1.34"

--- a/testing/test-runtime/Cargo.toml
+++ b/testing/test-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test-runtime"
-version = "0.27.0"
+version = "0.27.1"
 edition = "2021"
 publish = false
 

--- a/testing/ui-tests/Cargo.toml
+++ b/testing/ui-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ui-tests"
-version = "0.27.0"
+version = "0.27.1"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
Release 0.27.1 for the change 
- Add `find_last` for block types ([#825](https://github.com/paritytech/subxt/pull/825))
 
For this (PR)[https://github.com/paritytech/cargo-contract/pull/965]