### PR TITLE
export missing config

### DIFF
--- a/subxt/src/config/mod.rs
+++ b/subxt/src/config/mod.rs
@@ -22,9 +22,18 @@ use serde::{
     Serialize,
 };
 
-pub use extrinsic_params::ExtrinsicParams;
-pub use polkadot::PolkadotConfig;
-pub use substrate::SubstrateConfig;
+pub use extrinsic_params::{
+    BaseExtrinsicParams,
+    ExtrinsicParams,
+};
+pub use polkadot::{
+    PolkadotConfig,
+    PolkadotExtrinsicParams,
+};
+pub use substrate::{
+    SubstrateConfig,
+    SubstrateExtrinsicParams,
+};
 
 /// Runtime types.
 // Note: the 'static bound isn't strictly required, but currently deriving TypeInfo

--- a/subxt/src/config/mod.rs
+++ b/subxt/src/config/mod.rs
@@ -27,10 +27,12 @@ pub use extrinsic_params::{
     ExtrinsicParams,
 };
 pub use polkadot::{
+    PlainTip,
     PolkadotConfig,
     PolkadotExtrinsicParams,
 };
 pub use substrate::{
+    AssetTip,
     SubstrateConfig,
     SubstrateExtrinsicParams,
 };


### PR DESCRIPTION
At least should export `BaseExtrinsicParams` and `Tip` type.