### PR TITLE
Bump Substrate dependencies

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -15,10 +15,10 @@ description = "Subxt example usage"
 [dev-dependencies]
 subxt = { path = "../subxt" }
 tokio = { version = "1.25", features = ["rt-multi-thread", "macros", "time"] }
-sp-keyring = "18.0.0"
+sp-keyring = "20.0.0"
 futures = "0.3.26"
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full", "bit-vec"] }
 hex = "0.4.3"
 tracing-subscriber = "0.3.11"
-sp-core = { version = "16.0.0", default-features = false }
-sp-runtime = "18.0.0"
+sp-core = { version = "18.0.0", default-features = false }
+sp-runtime = "20.0.0"

--- a/metadata/Cargo.toml
+++ b/metadata/Cargo.toml
@@ -17,7 +17,7 @@ description = "Command line utilities for checking metadata compatibility betwee
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full"] }
 frame-metadata = "15.0.0"
 scale-info = "2.0.0"
-sp-core-hashing = "6.0.0"
+sp-core-hashing = "7.0.0"
 
 [dev-dependencies]
 bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }

--- a/subxt/Cargo.toml
+++ b/subxt/Cargo.toml
@@ -57,15 +57,15 @@ subxt-metadata = { version = "0.27.1", path = "../metadata" }
 # Provides some deserialization, types like U256/H256 and hashing impls like twox/blake256:
 impl-serde = { version = "0.4.0" }
 primitive-types = { version = "0.12.0", default-features = false, features = ["codec", "scale-info", "serde"] }
-sp-core-hashing = "6.0.0"
+sp-core-hashing = "7.0.0"
 
 # For ss58 encoding AccountId32 to serialize them properly:
 base58 = { version = "0.2.0" }
 blake2 = { version = "0.10.4", default-features = false }
 
 # These are only included is "substrate-compat" is enabled.
-sp-core = { version = "16.0.0", default-features = false, optional = true }
-sp-runtime = { version = "18.0.0", optional = true }
+sp-core = { version = "18.0.0", default-features = false, optional = true }
+sp-runtime = { version = "20.0.0", optional = true }
 
 [target.wasm32-unknown-unknown.dependencies]
 getrandom = { version = "0.2", features = ["js"] }
@@ -75,7 +75,7 @@ bitvec = "1"
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full", "bit-vec"] }
 scale-info = { version = "2.0.0", features = ["bit-vec"] }
 tokio = { version = "1.25", features = ["macros", "time", "rt-multi-thread"] }
-sp-core = { version = "16.0.0", default-features = false }
-sp-runtime = "18.0.0"
-sp-keyring = "18.0.0"
-sp-version = "16.0.0"
+sp-core = { version = "18.0.0", default-features = false }
+sp-runtime = "20.0.0"
+sp-keyring = "20.0.0"
+sp-version = "18.0.0"

--- a/testing/integration-tests/Cargo.toml
+++ b/testing/integration-tests/Cargo.toml
@@ -23,9 +23,9 @@ futures = "0.3.26"
 hex = "0.4.3"
 regex = "1.5.0"
 scale-info = { version = "2.0.0", features = ["bit-vec"] }
-sp-core = { version = "16.0.0", default-features = false }
-sp-keyring = "18.0.0"
-sp-runtime = "18.0.0"
+sp-core = { version = "18.0.0", default-features = false }
+sp-keyring = "20.0.0"
+sp-runtime = "20.0.0"
 syn = "1.0.109"
 subxt = { version = "0.27.1", path = "../../subxt" }
 subxt-codegen = { version = "0.27.1", path = "../../codegen" }

--- a/testing/test-runtime/Cargo.toml
+++ b/testing/test-runtime/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 subxt = { path = "../../subxt" }
-sp-runtime = "18.0.0"
+sp-runtime = "20.0.0"
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full", "bit-vec"] }
 
 [build-dependencies]


### PR DESCRIPTION
Bumping all `sp-*` dependencies to the newest versions. Helps with linking issue in `wasmtime` (https://github.com/bytecodealliance/wasmtime/issues/5768)