### PR TITLE
fix: re-export `sp-core` and `sp-runtime`

### DIFF
--- a/subxt/src/lib.rs
+++ b/subxt/src/lib.rs
@@ -182,4 +182,8 @@ pub mod ext {
     pub use frame_metadata;
     pub use scale_bits;
     pub use scale_value;
+    #[cfg(feature = "substrate-compat")]
+    pub use sp_core;
+    #[cfg(feature = "substrate-compat")]
+    pub use sp_runtime;
 }


### PR DESCRIPTION
When the `substrate-compat` is enabled let's re-export `sp-core` and `sp-runtime` again for compatibility reasons.

Further, it easy to pick the wrong version of `sp-core` and `sp-runtime` so let's make the usage a bit smoother.

Close https://github.com/paritytech/subxt/issues/844