### PR TITLE
Expose signer payload to allow external signing

### DIFF
--- a/subxt/src/tx/tx_client.rs
+++ b/subxt/src/tx/tx_client.rs
@@ -182,7 +182,7 @@ impl<T: Config, C: OfflineClientT<T>> TxClient<T, C> {
         let partial_signed = self.create_partial_signed_with_nonce(call, account_nonce, other_params)?;
 
         // 3. Sign and construct an extrinsic from these details.
-        partial_signed.sign(signer)
+        Ok(partial_signed.sign(signer))
     }
 }
 
@@ -361,7 +361,7 @@ where
     /// Convert this [`PartialExtrinsic`] into a [`SubmittableExtrinsic`], ready to submit.
     /// The provided `signer` is responsible for providing the "from" address for the transaction,
     /// as well as providing a signature to attach to it.
-    pub fn sign<Signer>(&self, signer: &Signer) -> Result<SubmittableExtrinsic<T, C>, Error>
+    pub fn sign<Signer>(&self, signer: &Signer) -> SubmittableExtrinsic<T, C>
     where
         Signer: SignerT<T>,
     {
@@ -393,10 +393,10 @@ where
         };
 
         // Return an extrinsic ready to be submitted.
-        Ok(SubmittableExtrinsic::from_bytes(
+        SubmittableExtrinsic::from_bytes(
             self.client.clone(),
             extrinsic,
-        ))
+        )
     }
 }
 

--- a/subxt/src/tx/tx_client.rs
+++ b/subxt/src/tx/tx_client.rs
@@ -369,7 +369,7 @@ where
         Signer: SignerT<T>,
     {
         // Given our signer, we can sign the payload representing this extrinsic.
-        let signature = self.with_signer_payload(|bytes| signer.sign(&*bytes));
+        let signature = self.with_signer_payload(|bytes| signer.sign(&bytes));
         // Now, use the signature and "from" address to build the extrinsic.
         self.sign_with_address_and_signature(&signer.address(), &signature)
     }


### PR DESCRIPTION
This PR adds a few methods to `client.tx()`; `create_partial_signed_with_nonce` and `create_partial_signed` (to mirror `create_signed_with_nonce` and `create_signed`). These return a `PartialExtrinsic`, which just needs a signature to be turned into a "proper" extrinsic, and exposes a `signer_payload()` method to get back the signer payload that needs to be signed.

The added test is currently the best example of this flow. I'll do a documentation pass quite soon to add a bunch of examples and document some common flows and such.

Closes #836 