### PR TITLE
Support deserializing block number in header from hex or number

### DIFF
--- a/subxt/src/config/substrate.rs
+++ b/subxt/src/config/substrate.rs
@@ -310,7 +310,8 @@ mod test {
             }
         "#;
 
-        let header: SubstrateHeader<u32, BlakeTwo256> = serde_json::from_str(numeric_block_number_json).expect("valid block header");
+        let header: SubstrateHeader<u32, BlakeTwo256> =
+            serde_json::from_str(numeric_block_number_json).expect("valid block header");
         assert_eq!(header.number(), 4);
     }
 
@@ -329,8 +330,8 @@ mod test {
             }
         "#;
 
-        let header: SubstrateHeader<u32, BlakeTwo256> = serde_json::from_str(numeric_block_number_json).expect("valid block header");
+        let header: SubstrateHeader<u32, BlakeTwo256> =
+            serde_json::from_str(numeric_block_number_json).expect("valid block header");
         assert_eq!(header.number(), 4);
     }
-
 }


### PR DESCRIPTION
Substrate returns hex based block numbers, but Smoldot returns plain old numbers. Make sure we can deserialize both.