### PR TITLE
added at_latest

### DIFF
--- a/examples/examples/concurrent_storage_requests.rs
+++ b/examples/examples/concurrent_storage_requests.rs
@@ -29,8 +29,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // For storage requests, we can join futures together to
     // await multiple futures concurrently:
-    let a_fut = api.storage().at(None).await?.fetch(&staking_bonded);
-    let b_fut = api.storage().at(None).await?.fetch(&staking_ledger);
+    let a_fut = api.storage().at_latest().await?.fetch(&staking_bonded);
+    let b_fut = api.storage().at_latest().await?.fetch(&staking_ledger);
     let (a, b) = join!(a_fut, b_fut);
 
     println!("{a:?}, {b:?}");

--- a/examples/examples/dynamic_queries.rs
+++ b/examples/examples/dynamic_queries.rs
@@ -61,7 +61,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
     let account = api
         .storage()
-        .at(None)
+        .at_latest()
         .await?
         .fetch_or_default(&storage_address)
         .await?
@@ -73,7 +73,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let storage_address = subxt::dynamic::storage_root("System", "Account");
     let mut iter = api
         .storage()
-        .at(None)
+        .at_latest()
         .await?
         .iter(storage_address, 10)
         .await?;

--- a/examples/examples/fetch_all_accounts.rs
+++ b/examples/examples/fetch_all_accounts.rs
@@ -23,7 +23,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let address = polkadot::storage().system().account_root();
 
-    let mut iter = api.storage().at(None).await?.iter(address, 10).await?;
+    let mut iter = api.storage().at_latest().await?.iter(address, 10).await?;
 
     while let Some((key, account)) = iter.next().await? {
         println!("{}: {}", hex::encode(key), account.data.free);

--- a/examples/examples/fetch_staking_details.rs
+++ b/examples/examples/fetch_staking_details.rs
@@ -27,7 +27,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let active_era_addr = polkadot::storage().staking().active_era();
     let era = api
         .storage()
-        .at(None)
+        .at_latest()
         .await?
         .fetch(&active_era_addr)
         .await?
@@ -51,7 +51,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let controller_acc_addr = polkadot::storage().staking().bonded(&alice_stash_id);
     let controller_acc = api
         .storage()
-        .at(None)
+        .at_latest()
         .await?
         .fetch(&controller_acc_addr)
         .await?
@@ -61,7 +61,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let era_reward_addr = polkadot::storage().staking().eras_reward_points(era.index);
     let era_result = api
         .storage()
-        .at(None)
+        .at_latest()
         .await?
         .fetch(&era_reward_addr)
         .await?;

--- a/examples/examples/storage_iterating.rs
+++ b/examples/examples/storage_iterating.rs
@@ -28,7 +28,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     {
         let key_addr = polkadot::storage().xcm_pallet().version_notifiers_root();
 
-        let mut iter = api.storage().at(None).await?.iter(key_addr, 10).await?;
+        let mut iter = api.storage().at_latest().await?.iter(key_addr, 10).await?;
 
         println!("\nExample 1. Obtained keys:");
         while let Some((key, value)) = iter.next().await? {
@@ -45,7 +45,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         // Fetch at most 10 keys from below the prefix XcmPallet' VersionNotifiers.
         let keys = api
             .storage()
-            .at(None)
+            .at_latest()
             .await?
             .fetch_keys(&key_addr.to_root_bytes(), 10, None)
             .await?;
@@ -54,7 +54,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         for key in keys.iter() {
             println!("Key: 0x{}", hex::encode(key));
 
-            if let Some(storage_data) = api.storage().at(None).await?.fetch_raw(&key.0).await? {
+            if let Some(storage_data) = api.storage().at_latest().await?.fetch_raw(&key.0).await? {
                 // We know the return value to be `QueryId` (`u64`) from inspecting either:
                 // - polkadot code
                 // - polkadot.rs generated file under `version_notifiers()` fn
@@ -85,7 +85,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         let keys = api
             .storage()
-            .at(None)
+            .at_latest()
             .await?
             .fetch_keys(&query_key, 10, None)
             .await?;
@@ -94,7 +94,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         for key in keys.iter() {
             println!("Key: 0x{}", hex::encode(key));
 
-            if let Some(storage_data) = api.storage().at(None).await?.fetch_raw(&key.0).await? {
+            if let Some(storage_data) = api.storage().at_latest().await?.fetch_raw(&key.0).await? {
                 // We know the return value to be `QueryId` (`u64`) from inspecting either:
                 // - polkadot code
                 // - polkadot.rs generated file under `version_notifiers()` fn

--- a/subxt/src/blocks/block_types.rs
+++ b/subxt/src/blocks/block_types.rs
@@ -287,7 +287,7 @@ where
         Some(events) => events.clone(),
         None => {
             events::EventsClient::new(client.clone())
-                .at(Some(block_hash))
+                .at(block_hash)
                 .await?
         }
     };

--- a/subxt/src/blocks/blocks_client.rs
+++ b/subxt/src/blocks/blocks_client.rs
@@ -49,6 +49,36 @@ where
     /// but may run into errors attempting to work with them.
     pub fn at(
         &self,
+        block_hash: T::Hash,
+    ) -> impl Future<Output = Result<Block<T, Client>, Error>> + Send + 'static {
+        self.at_optional_block_hash(Some(block_hash))
+    }
+
+    /// Obtain block details given the provided block hash, or the latest block if `None` is
+    /// provided.
+    ///
+    /// # Warning
+    ///
+    /// This call only supports blocks produced since the most recent
+    /// runtime upgrade. You can attempt to retrieve older blocks,
+    /// but may run into errors attempting to work with them.
+    pub fn at_latest(
+        &self,
+    ) -> impl Future<Output = Result<Block<T, Client>, Error>> + Send + 'static {
+        self.at_optional_block_hash(None)
+    }
+
+    /// Obtain block details given the provided block hash, or the latest block if `None` is
+    /// provided.
+    ///
+    /// # Warning
+    ///
+    /// This call only supports blocks produced since the most recent
+    /// runtime upgrade. You can attempt to retrieve older blocks,
+    /// but may run into errors attempting to work with them.
+    #[inline]
+    fn at_optional_block_hash(
+        &self,
         block_hash: Option<T::Hash>,
     ) -> impl Future<Output = Result<Block<T, Client>, Error>> + Send + 'static {
         let client = self.client.clone();

--- a/subxt/src/blocks/blocks_client.rs
+++ b/subxt/src/blocks/blocks_client.rs
@@ -39,8 +39,7 @@ where
     T: Config,
     Client: OnlineClientT<T>,
 {
-    /// Obtain block details given the provided block hash, or the latest block if `None` is
-    /// provided.
+    /// Obtain block details given the provided block hash.
     ///
     /// # Warning
     ///
@@ -54,14 +53,7 @@ where
         self.at_optional_block_hash(Some(block_hash))
     }
 
-    /// Obtain block details given the provided block hash, or the latest block if `None` is
-    /// provided.
-    ///
-    /// # Warning
-    ///
-    /// This call only supports blocks produced since the most recent
-    /// runtime upgrade. You can attempt to retrieve older blocks,
-    /// but may run into errors attempting to work with them.
+    /// Obtain block details of the latest block hash.
     pub fn at_latest(
         &self,
     ) -> impl Future<Output = Result<Block<T, Client>, Error>> + Send + 'static {
@@ -70,12 +62,6 @@ where
 
     /// Obtain block details given the provided block hash, or the latest block if `None` is
     /// provided.
-    ///
-    /// # Warning
-    ///
-    /// This call only supports blocks produced since the most recent
-    /// runtime upgrade. You can attempt to retrieve older blocks,
-    /// but may run into errors attempting to work with them.
     #[inline]
     fn at_optional_block_hash(
         &self,

--- a/subxt/src/blocks/blocks_client.rs
+++ b/subxt/src/blocks/blocks_client.rs
@@ -50,20 +50,19 @@ where
         &self,
         block_hash: T::Hash,
     ) -> impl Future<Output = Result<Block<T, Client>, Error>> + Send + 'static {
-        self.at_optional_block_hash(Some(block_hash))
+        self.at_or_latest(Some(block_hash))
     }
 
     /// Obtain block details of the latest block hash.
     pub fn at_latest(
         &self,
     ) -> impl Future<Output = Result<Block<T, Client>, Error>> + Send + 'static {
-        self.at_optional_block_hash(None)
+        self.at_or_latest(None)
     }
 
     /// Obtain block details given the provided block hash, or the latest block if `None` is
     /// provided.
-    #[inline]
-    fn at_optional_block_hash(
+    fn at_or_latest(
         &self,
         block_hash: Option<T::Hash>,
     ) -> impl Future<Output = Result<Block<T, Client>, Error>> + Send + 'static {

--- a/subxt/src/events/events_client.rs
+++ b/subxt/src/events/events_client.rs
@@ -38,6 +38,32 @@ where
     /// but may run into errors attempting to work with them.
     pub fn at(
         &self,
+        block_hash: T::Hash,
+    ) -> impl Future<Output = Result<Events<T>, Error>> + Send + 'static {
+        self.at_optional_block_hash(Some(block_hash))
+    }
+
+    /// Obtain events at the latest block hash.
+    ///
+    /// # Warning
+    ///
+    /// This call only supports blocks produced since the most recent
+    /// runtime upgrade. You can attempt to retrieve events from older blocks,
+    /// but may run into errors attempting to work with them.
+    pub fn at_latest(&self) -> impl Future<Output = Result<Events<T>, Error>> + Send + 'static {
+        self.at_optional_block_hash(None)
+    }
+
+    /// Obtain events at some block hash.
+    ///
+    /// # Warning
+    ///
+    /// This call only supports blocks produced since the most recent
+    /// runtime upgrade. You can attempt to retrieve events from older blocks,
+    /// but may run into errors attempting to work with them.
+    #[inline]
+    fn at_optional_block_hash(
+        &self,
         block_hash: Option<T::Hash>,
     ) -> impl Future<Output = Result<Events<T>, Error>> + Send + 'static {
         // Clone and pass the client in like this so that we can explicitly

--- a/subxt/src/events/events_client.rs
+++ b/subxt/src/events/events_client.rs
@@ -40,29 +40,16 @@ where
         &self,
         block_hash: T::Hash,
     ) -> impl Future<Output = Result<Events<T>, Error>> + Send + 'static {
-        self.at_optional_block_hash(Some(block_hash))
+        self.at_or_latest(Some(block_hash))
     }
 
     /// Obtain events at the latest block hash.
-    ///
-    /// # Warning
-    ///
-    /// This call only supports blocks produced since the most recent
-    /// runtime upgrade. You can attempt to retrieve events from older blocks,
-    /// but may run into errors attempting to work with them.
     pub fn at_latest(&self) -> impl Future<Output = Result<Events<T>, Error>> + Send + 'static {
-        self.at_optional_block_hash(None)
+        self.at_or_latest(None)
     }
 
     /// Obtain events at some block hash.
-    ///
-    /// # Warning
-    ///
-    /// This call only supports blocks produced since the most recent
-    /// runtime upgrade. You can attempt to retrieve events from older blocks,
-    /// but may run into errors attempting to work with them.
-    #[inline]
-    fn at_optional_block_hash(
+    fn at_or_latest(
         &self,
         block_hash: Option<T::Hash>,
     ) -> impl Future<Output = Result<Events<T>, Error>> + Send + 'static {

--- a/subxt/src/storage/storage_client.rs
+++ b/subxt/src/storage/storage_client.rs
@@ -71,24 +71,24 @@ where
     Client: OnlineClientT<T>,
 {
     /// Obtain storage at some block hash.
-    pub fn at(
+    pub fn at(&self, block_hash: T::Hash) -> Storage<T, Client> {
+        Storage::new(self.client.clone(), block_hash)
+    }
+
+    /// Obtain storage at the latest block hash.
+    pub fn at_latest(
         &self,
-        block_hash: Option<T::Hash>,
     ) -> impl Future<Output = Result<Storage<T, Client>, Error>> + Send + 'static {
         // Clone and pass the client in like this so that we can explicitly
         // return a Future that's Send + 'static, rather than tied to &self.
         let client = self.client.clone();
         async move {
-            // If block hash is not provided, get the hash
-            // for the latest block and use that.
-            let block_hash = match block_hash {
-                Some(hash) => hash,
-                None => client
-                    .rpc()
-                    .block_hash(None)
-                    .await?
-                    .expect("didn't pass a block number; qed"),
-            };
+            // get the hash for the latest block and use that.
+            let block_hash = client
+                .rpc()
+                .block_hash(None)
+                .await?
+                .expect("didn't pass a block number; qed");
 
             Ok(Storage::new(client, block_hash))
         }

--- a/subxt/src/storage/storage_type.rs
+++ b/subxt/src/storage/storage_type.rs
@@ -75,7 +75,7 @@ where
     /// // Fetch just the keys, returning up to 10 keys.
     /// let value = api
     ///     .storage()
-    ///     .at(None)
+    ///     .at_latest()
     ///     .await
     ///     .unwrap()
     ///     .fetch(&address)
@@ -185,7 +185,7 @@ where
     /// // Iterate over keys and values at that address.
     /// let mut iter = api
     ///     .storage()
-    ///     .at(None)
+    ///     .at_latest()
     ///     .await
     ///     .unwrap()
     ///     .iter(address, 10)

--- a/subxt/src/tx/tx_progress.rs
+++ b/subxt/src/tx/tx_progress.rs
@@ -397,7 +397,7 @@ impl<T: Config, C: OnlineClientT<T>> TxInBlock<T, C> {
             .ok_or(Error::Transaction(TransactionError::BlockNotFound))?;
 
         let events = EventsClient::new(self.client.clone())
-            .at(Some(self.block_hash))
+            .at(self.block_hash)
             .await?;
 
         Ok(crate::blocks::ExtrinsicEvents::new(

--- a/testing/integration-tests/src/client/mod.rs
+++ b/testing/integration-tests/src/client/mod.rs
@@ -111,7 +111,7 @@ async fn fetch_keys() {
     let addr = node_runtime::storage().system().account_root();
     let keys = api
         .storage()
-        .at(None)
+        .at_latest()
         .await
         .unwrap()
         .fetch_keys(&addr.to_root_bytes(), 4, None)
@@ -128,7 +128,7 @@ async fn test_iter() {
     let addr = node_runtime::storage().system().account_root();
     let mut iter = api
         .storage()
-        .at(None)
+        .at_latest()
         .await
         .unwrap()
         .iter(addr, 10)

--- a/testing/integration-tests/src/frame/balances.rs
+++ b/testing/integration-tests/src/frame/balances.rs
@@ -27,13 +27,13 @@ async fn tx_basic_transfer() -> Result<(), subxt::Error> {
 
     let alice_pre = api
         .storage()
-        .at(None)
+        .at_latest()
         .await?
         .fetch_or_default(&alice_account_addr)
         .await?;
     let bob_pre = api
         .storage()
-        .at(None)
+        .at_latest()
         .await?
         .fetch_or_default(&bob_account_addr)
         .await?;
@@ -64,13 +64,13 @@ async fn tx_basic_transfer() -> Result<(), subxt::Error> {
 
     let alice_post = api
         .storage()
-        .at(None)
+        .at_latest()
         .await?
         .fetch_or_default(&alice_account_addr)
         .await?;
     let bob_post = api
         .storage()
-        .at(None)
+        .at_latest()
         .await?
         .fetch_or_default(&bob_account_addr)
         .await?;
@@ -102,13 +102,13 @@ async fn tx_dynamic_transfer() -> Result<(), subxt::Error> {
 
     let alice_pre = api
         .storage()
-        .at(None)
+        .at_latest()
         .await?
         .fetch_or_default(&alice_account_addr)
         .await?;
     let bob_pre = api
         .storage()
-        .at(None)
+        .at_latest()
         .await?
         .fetch_or_default(&bob_account_addr)
         .await?;
@@ -152,13 +152,13 @@ async fn tx_dynamic_transfer() -> Result<(), subxt::Error> {
 
     let alice_post = api
         .storage()
-        .at(None)
+        .at_latest()
         .await?
         .fetch_or_default(&alice_account_addr)
         .await?;
     let bob_post = api
         .storage()
-        .at(None)
+        .at_latest()
         .await?
         .fetch_or_default(&bob_account_addr)
         .await?;
@@ -211,7 +211,7 @@ async fn multiple_transfers_work_nonce_incremented() -> Result<(), subxt::Error>
 
     let bob_pre = api
         .storage()
-        .at(None)
+        .at_latest()
         .await?
         .fetch_or_default(&bob_account_addr)
         .await?;
@@ -231,7 +231,7 @@ async fn multiple_transfers_work_nonce_incremented() -> Result<(), subxt::Error>
 
     let bob_post = api
         .storage()
-        .at(None)
+        .at_latest()
         .await?
         .fetch_or_default(&bob_account_addr)
         .await?;
@@ -248,7 +248,7 @@ async fn storage_total_issuance() {
     let addr = node_runtime::storage().balances().total_issuance();
     let total_issuance = api
         .storage()
-        .at(None)
+        .at_latest()
         .await
         .unwrap()
         .fetch_or_default(&addr)
@@ -283,7 +283,7 @@ async fn storage_balance_lock() -> Result<(), subxt::Error> {
 
     let locks = api
         .storage()
-        .at(None)
+        .at_latest()
         .await?
         .fetch_or_default(&locks_addr)
         .await?;

--- a/testing/integration-tests/src/frame/contracts.rs
+++ b/testing/integration-tests/src/frame/contracts.rs
@@ -212,7 +212,7 @@ async fn tx_call() {
     let contract_info = cxt
         .client()
         .storage()
-        .at(None)
+        .at_latest()
         .await
         .unwrap()
         .fetch(&info_addr)
@@ -222,7 +222,7 @@ async fn tx_call() {
     let keys = cxt
         .client()
         .storage()
-        .at(None)
+        .at_latest()
         .await
         .unwrap()
         .fetch_keys(&info_addr_bytes, 10, None)

--- a/testing/integration-tests/src/frame/staking.rs
+++ b/testing/integration-tests/src/frame/staking.rs
@@ -146,7 +146,7 @@ async fn chill_works_for_controller_only() -> Result<(), Error> {
     let ledger_addr = node_runtime::storage().staking().ledger(alice.account_id());
     let ledger = api
         .storage()
-        .at(None)
+        .at_latest()
         .await?
         .fetch(&ledger_addr)
         .await?
@@ -234,7 +234,7 @@ async fn storage_current_era() -> Result<(), Error> {
     let current_era_addr = node_runtime::storage().staking().current_era();
     let _current_era = api
         .storage()
-        .at(None)
+        .at_latest()
         .await?
         .fetch(&current_era_addr)
         .await?
@@ -249,7 +249,7 @@ async fn storage_era_reward_points() -> Result<(), Error> {
     let reward_points_addr = node_runtime::storage().staking().eras_reward_points(0);
     let current_era_result = api
         .storage()
-        .at(None)
+        .at_latest()
         .await?
         .fetch(&reward_points_addr)
         .await;

--- a/testing/integration-tests/src/frame/system.rs
+++ b/testing/integration-tests/src/frame/system.rs
@@ -20,7 +20,7 @@ async fn storage_account() -> Result<(), subxt::Error> {
 
     let account_info = api
         .storage()
-        .at(None)
+        .at_latest()
         .await?
         .fetch_or_default(&account_info_addr)
         .await;

--- a/testing/integration-tests/src/frame/timestamp.rs
+++ b/testing/integration-tests/src/frame/timestamp.rs
@@ -11,7 +11,7 @@ async fn storage_get_current_timestamp() {
 
     let timestamp = api
         .storage()
-        .at(None)
+        .at_latest()
         .await
         .unwrap()
         .fetch(&node_runtime::storage().timestamp().now())

--- a/testing/integration-tests/src/storage/mod.rs
+++ b/testing/integration-tests/src/storage/mod.rs
@@ -18,7 +18,7 @@ async fn storage_plain_lookup() -> Result<(), subxt::Error> {
     let addr = node_runtime::storage().timestamp().now();
     let entry = api
         .storage()
-        .at(None)
+        .at_latest()
         .await?
         .fetch_or_default(&addr)
         .await?;
@@ -47,7 +47,7 @@ async fn storage_map_lookup() -> Result<(), subxt::Error> {
     let nonce_addr = node_runtime::storage().system().account(alice);
     let entry = api
         .storage()
-        .at(None)
+        .at_latest()
         .await?
         .fetch_or_default(&nonce_addr)
         .await?;
@@ -121,7 +121,7 @@ async fn storage_n_map_storage_lookup() -> Result<(), subxt::Error> {
 
     // The actual test; look up this approval in storage:
     let addr = node_runtime::storage().assets().approvals(99, alice, bob);
-    let entry = api.storage().at(None).await?.fetch(&addr).await?;
+    let entry = api.storage().at_latest().await?.fetch(&addr).await?;
     assert_eq!(entry.map(|a| a.amount), Some(123));
     Ok(())
 }


### PR DESCRIPTION
resolves #899 by providing a simplified API for `.at(Option<Hash>)` by specialization into `.at_latest()` and `.at(Hash)`  in various places:
- storage_client: the at() version does not require async + Result anymore
- blocks_client: both versions still require async + Result
- events_client: both versions still require async + Result