### PR TITLE
use blake2 for extrinsic hashing

### DIFF
--- a/subxt/src/tx/tx_client.rs
+++ b/subxt/src/tx/tx_client.rs
@@ -6,6 +6,7 @@ use std::borrow::Cow;
 
 use codec::{Compact, Encode};
 use derivative::Derivative;
+use sp_core_hashing::blake2_256;
 
 use crate::{
     client::{OfflineClientT, OnlineClientT},
@@ -320,7 +321,7 @@ where
         self.additional_and_extra_params
             .encode_additional_to(&mut bytes);
         if bytes.len() > 256 {
-            f(Cow::Borrowed(T::Hasher::hash_of(&Encoded(bytes)).as_ref()))
+            f(Cow::Borrowed(blake2_256(&bytes).as_ref()))
         } else {
             f(Cow::Owned(bytes))
         }


### PR DESCRIPTION
Substrate uses `blake2_256` for extrinsic hashing regardless of the configured hasher for the runtime

https://github.com/paritytech/substrate/blob/c7d26dcf3d6c19fa7dcbd1f2633e337e5a5cbc40/primitives/runtime/src/generic/unchecked_extrinsic.rs#L211-L228