### PR TITLE
CI: Concurrency group

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,6 +12,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   # TODO: Currently pointing at latest substrate; is there a suitable binary we can pin to here?


### PR DESCRIPTION
Currently, CI workflow will continue to run even if a new commit has been pushed to a PR branch / master. For simple Rust checks and tests this usually is just wasting resources. By introducing:
```yaml
concurrency:
  group: ${{ github.ref }}-${{ github.workflow }}
  cancel-in-progress: true
```

(see: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency) we ensure that for every branch (`github.ref`) the Rust workflow (`github.workflow`) will be run only for the newest change - the previous launches will be canceled.