### PR TITLE
impl Header and Hasher for some substrate types behind the "substrate-compat" feature flag

### DIFF
--- a/subxt/src/config/mod.rs
+++ b/subxt/src/config/mod.rs
@@ -124,10 +124,8 @@ impl<T: Config, E: extrinsic_params::ExtrinsicParams<T::Index, T::Hash>> Config
 /// implement subxt's Hasher and Header traits for some substrate structs
 #[cfg(feature = "substrate-compat")]
 mod substrate_impls {
-    use primitive_types::{H256, U256};
-    use sp_core::Hasher as SpHasher;
-
     use super::*;
+    use primitive_types::{H256, U256};
 
     impl<N, H> Header for sp_runtime::generic::Header<N, H>
     where
@@ -147,7 +145,7 @@ mod substrate_impls {
         type Output = H256;
 
         fn hash(s: &[u8]) -> Self::Output {
-            <Self as SpHasher>::hash(s)
+            <Self as sp_core::Hasher>::hash(s)
         }
     }
 
@@ -155,7 +153,7 @@ mod substrate_impls {
         type Output = H256;
 
         fn hash(s: &[u8]) -> Self::Output {
-            <Self as SpHasher>::hash(s)
+            <Self as sp_core::Hasher>::hash(s)
         }
     }
 }

--- a/subxt/src/config/mod.rs
+++ b/subxt/src/config/mod.rs
@@ -120,3 +120,42 @@ impl<T: Config, E: extrinsic_params::ExtrinsicParams<T::Index, T::Hash>> Config
     type Header = T::Header;
     type ExtrinsicParams = E;
 }
+
+/// implement subxt's Hasher and Header traits for some substrate structs
+#[cfg(feature = "substrate-compat")]
+mod substrate_impls {
+    use primitive_types::{H256, U256};
+    use sp_core::Hasher as SpHasher;
+
+    use super::*;
+
+    impl<N, H> Header for sp_runtime::generic::Header<N, H>
+    where
+        Self: Encode,
+        N: Copy + Into<U256> + Into<u64> + TryFrom<U256>,
+        H: sp_runtime::traits::Hash + Hasher,
+    {
+        type Number = N;
+        type Hasher = H;
+
+        fn number(&self) -> Self::Number {
+            self.number
+        }
+    }
+
+    impl Hasher for sp_core::Blake2Hasher {
+        type Output = H256;
+
+        fn hash(s: &[u8]) -> Self::Output {
+            <Self as SpHasher>::hash(s)
+        }
+    }
+
+    impl Hasher for sp_core::KeccakHasher {
+        type Output = H256;
+
+        fn hash(s: &[u8]) -> Self::Output {
+            <Self as SpHasher>::hash(s)
+        }
+    }
+}


### PR DESCRIPTION
fixes #835.

This PR I implements subxts `Hasher` trait for:
- `sp_core::Blake2Hasher`
- `sp_core::KeccakHasher`

and subxts `Header` trait for:
- `sp_runtime::generic::Header`

I don't know if there are other types for which I should implement the traits as well, please let me know.