### PR TITLE
use unit type in polkadot config

### DIFF
--- a/subxt/src/config/mod.rs
+++ b/subxt/src/config/mod.rs
@@ -95,14 +95,6 @@ pub trait Header: Sized + Encode {
 /// Take a type implementing [`Config`] (eg [`SubstrateConfig`]), and some type which describes the
 /// additional and extra parameters to pass to an extrinsic (see [`ExtrinsicParams`]),
 /// and returns a type implementing [`Config`] with those new [`ExtrinsicParams`].
-///
-/// # Example
-///
-/// ```
-/// use subxt::config::{ SubstrateConfig, WithExtrinsicParams, polkadot::PolkadotExtrinsicParams };
-///
-/// // This is how PolkadotConfig is implemented:
-/// type PolkadotConfig = WithExtrinsicParams<SubstrateConfig, PolkadotExtrinsicParams<SubstrateConfig>>;
 /// ```
 pub struct WithExtrinsicParams<T: Config, E: extrinsic_params::ExtrinsicParams<T::Index, T::Hash>> {
     _marker: std::marker::PhantomData<(T, E)>,

--- a/subxt/src/config/polkadot.rs
+++ b/subxt/src/config/polkadot.rs
@@ -4,15 +4,29 @@
 
 //! Polkadot specific configuration
 
+use super::{
+    extrinsic_params::{BaseExtrinsicParams, BaseExtrinsicParamsBuilder},
+    Config,
+};
 use codec::Encode;
 
-use super::extrinsic_params::{BaseExtrinsicParams, BaseExtrinsicParamsBuilder};
+pub use crate::utils::{AccountId32, MultiAddress, MultiSignature};
+use crate::SubstrateConfig;
+pub use primitive_types::{H256, U256};
 
 /// Default set of commonly used types by Polkadot nodes.
-pub type PolkadotConfig = super::WithExtrinsicParams<
-    super::SubstrateConfig,
-    PolkadotExtrinsicParams<super::SubstrateConfig>,
->;
+pub enum PolkadotConfig {}
+
+impl Config for PolkadotConfig {
+    type Index = <SubstrateConfig as Config>::Index;
+    type Hash = <SubstrateConfig as Config>::Hash;
+    type AccountId = <SubstrateConfig as Config>::AccountId;
+    type Address = MultiAddress<Self::AccountId, ()>;
+    type Signature = <SubstrateConfig as Config>::Signature;
+    type Hasher = <SubstrateConfig as Config>::Hasher;
+    type Header = <SubstrateConfig as Config>::Header;
+    type ExtrinsicParams = PolkadotExtrinsicParams<Self>;
+}
 
 /// A struct representing the signed extra and additional parameters required
 /// to construct a transaction for a polkadot node.


### PR DESCRIPTION

I changed the second generic parameter in the polkadot config to `()`, but I am a bit confused still about the default for substrate.

There are the two directories `node` and `node-template` in `substate/bin`.

`node-template` seems to use `()`:

```rs
/// The address format for describing accounts.
pub type Address = sp_runtime::MultiAddress<AccountId, ()>;
```
in `substrate/bin/node-template/runtime/src/lib.rs`


while `node` seems to use u32:

```rs
/// The type for looking up accounts. We don't expect more than 4 billion of them.
pub type AccountIndex = u32;
```
in `substrate/bin/node/primitives/src/lib.rs` and
```rs
/// The address format for describing accounts.
pub type Address = sp_runtime::MultiAddress<AccountId, AccountIndex>;
```
in `substrate/bin/node/runtime/src/lib.rs`