### PR TITLE
Runtime APIs; don't ask for validation hash anywhere except new_static

### DIFF
--- a/examples/examples/runtime_calls.rs
+++ b/examples/examples/runtime_calls.rs
@@ -68,10 +68,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("AccountNonceApi_account_nonce for Alice: {:?}", nonce);
 
     // Dynamic calls.
-    let runtime_api_call = subxt::dynamic::runtime_api_call(
-        "Metadata_metadata_versions",
-        Vec::<Value<()>>::new()
-    );
+    let runtime_api_call =
+        subxt::dynamic::runtime_api_call("Metadata_metadata_versions", Vec::<Value<()>>::new());
     let versions = api
         .runtime_api()
         .at_latest()

--- a/examples/examples/runtime_calls.rs
+++ b/examples/examples/runtime_calls.rs
@@ -70,8 +70,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Dynamic calls.
     let runtime_api_call = subxt::dynamic::runtime_api_call(
         "Metadata_metadata_versions",
-        Vec::<Value<()>>::new(),
-        None,
+        Vec::<Value<()>>::new()
     );
     let versions = api
         .runtime_api()

--- a/subxt/src/runtime_api/runtime_payload.rs
+++ b/subxt/src/runtime_api/runtime_payload.rs
@@ -97,15 +97,11 @@ pub type DynamicRuntimeApiPayload = Payload<Composite<()>, DecodedValueThunk>;
 
 impl<ReturnTy, ArgsData> Payload<ArgsData, ReturnTy> {
     /// Create a new [`Payload`].
-    pub fn new(
-        fn_name: impl Into<String>,
-        args_data: ArgsData,
-        validation_hash: Option<[u8; 32]>,
-    ) -> Self {
+    pub fn new(fn_name: impl Into<String>, args_data: ArgsData) -> Self {
         Payload {
             fn_name: Cow::Owned(fn_name.into()),
             args_data,
-            validation_hash,
+            validation_hash: None,
             _marker: PhantomData,
         }
     }
@@ -151,12 +147,6 @@ impl<ReturnTy, ArgsData> Payload<ArgsData, ReturnTy> {
 pub fn dynamic(
     fn_name: impl Into<String>,
     args_data: impl Into<Composite<()>>,
-    hash: Option<[u8; 32]>,
 ) -> DynamicRuntimeApiPayload {
-    DynamicRuntimeApiPayload {
-        fn_name: Cow::Owned(fn_name.into()),
-        args_data: args_data.into(),
-        validation_hash: hash,
-        _marker: std::marker::PhantomData,
-    }
+    Payload::new(fn_name, args_data)
 }

--- a/subxt/src/runtime_api/runtime_payload.rs
+++ b/subxt/src/runtime_api/runtime_payload.rs
@@ -148,5 +148,5 @@ pub fn dynamic(
     fn_name: impl Into<String>,
     args_data: impl Into<Composite<()>>,
 ) -> DynamicRuntimeApiPayload {
-    Payload::new(fn_name, args_data)
+    Payload::new(fn_name, args_data.into())
 }


### PR DESCRIPTION
It doesn't make any sense to expect people to provide it outside of `new_static` for our codegen; just a tiny tweak as I missed this in review :)