### PR TITLE
Do not use std imports

### DIFF
--- a/codegen/src/api/calls.rs
+++ b/codegen/src/api/calls.rs
@@ -52,7 +52,7 @@ pub fn generate_calls(
                     .map(|(name, field)| {
                         let fn_arg_type = &field.type_path;
                         let call_arg = if field.is_boxed() {
-                            quote! { #name: ::std::boxed::Box::new(#name) }
+                            quote! { #name: ::alloc::boxed::Box::new(#name) }
                         } else {
                             quote! { #name }
                         };

--- a/codegen/src/api/mod.rs
+++ b/codegen/src/api/mod.rs
@@ -218,6 +218,7 @@ impl RuntimeGenerator {
         let types_mod = type_gen.generate_types_mod()?;
 
         Ok(quote! {
+            extern crate alloc;
             #( #item_mod_attrs )*
             #[allow(dead_code, unused_imports, non_camel_case_types)]
             #[allow(clippy::all)]
@@ -453,6 +454,7 @@ impl RuntimeGenerator {
         )?;
 
         Ok(quote! {
+            extern crate alloc;
             #( #item_mod_attrs )*
             #[allow(dead_code, unused_imports, non_camel_case_types)]
             #[allow(clippy::all)]

--- a/codegen/src/api/storage.rs
+++ b/codegen/src/api/storage.rs
@@ -142,7 +142,7 @@ fn generate_storage_entry_fns(
             Some(ty) => quote!([#ty]),
             _ => quote!(#field_type),
         };
-        quote!( #field_name: impl ::std::borrow::Borrow<#field_ty> )
+        quote!( #field_name: impl ::core::borrow::Borrow<#field_ty> )
     });
 
     let is_map_type = matches!(storage_entry.ty, StorageEntryType::Map { .. });

--- a/codegen/src/types/composite_def.rs
+++ b/codegen/src/types/composite_def.rs
@@ -320,7 +320,7 @@ impl quote::ToTokens for CompositeDefFieldType {
         let ty_path = &self.type_path;
 
         if self.is_boxed() {
-            tokens.extend(quote! { ::std::boxed::Box<#ty_path> })
+            tokens.extend(quote! { ::alloc::boxed::Box<#ty_path> })
         } else {
             tokens.extend(quote! { #ty_path })
         };

--- a/codegen/src/types/substitutes.rs
+++ b/codegen/src/types/substitutes.rs
@@ -98,7 +98,7 @@ impl TypeSubstitutes {
                 path_segments!(BTreeMap),
                 parse_quote!(#crate_path::utils::KeyedVec),
             ),
-            (path_segments!(BTreeSet), parse_quote!(::std::vec::Vec)),
+            (path_segments!(BTreeSet), parse_quote!(::alloc::vec::Vec)),
         ];
 
         let default_substitutes = defaults

--- a/codegen/src/types/tests.rs
+++ b/codegen/src/types/tests.rs
@@ -485,7 +485,7 @@ fn compact_generic_parameter() {
                 pub struct S {
                     pub a: ::core::option::Option<::subxt_path::ext::codec::Compact<::core::primitive::u128> >,
                     pub nested: ::core::option::Option<::core::result::Result<::subxt_path::ext::codec::Compact<::core::primitive::u128>, ::core::primitive::u8 > >,
-                    pub vector: ::std::vec::Vec<::subxt_path::ext::codec::Compact<::core::primitive::u16> >,
+                    pub vector: ::alloc::vec::Vec<::subxt_path::ext::codec::Compact<::core::primitive::u16> >,
                     pub array: [::subxt_path::ext::codec::Compact<::core::primitive::u8>; 32usize],
                     pub tuple: (::subxt_path::ext::codec::Compact<::core::primitive::u8>, ::subxt_path::ext::codec::Compact<::core::primitive::u16>,),
                 }
@@ -618,8 +618,8 @@ fn box_fields_struct() {
                 #[decode_as_type(crate_path = ":: subxt_path :: ext :: scale_decode")]
                 #[encode_as_type(crate_path = ":: subxt_path :: ext :: scale_encode")]
                 pub struct S {
-                    pub a: ::std::boxed::Box<::core::primitive::bool>,
-                    pub b: ::std::boxed::Box<::core::primitive::u32>,
+                    pub a: ::alloc::boxed::Box<::core::primitive::bool>,
+                    pub b: ::alloc::boxed::Box<::core::primitive::u32>,
                 }
             }
         }
@@ -665,9 +665,9 @@ fn box_fields_enum() {
                 #[encode_as_type(crate_path = ":: subxt_path :: ext :: scale_encode")]
                 pub enum E {
                     # [codec (index = 0)]
-                    A(::std::boxed::Box<::core::primitive::bool>,),
+                    A(::alloc::boxed::Box<::core::primitive::bool>,),
                     # [codec (index = 1)]
-                    B { a: ::std::boxed::Box<::core::primitive::u32>, },
+                    B { a: ::alloc::boxed::Box<::core::primitive::u32>, },
                 }
             }
         }
@@ -1315,7 +1315,7 @@ fn opt_out_from_default_substitutes() {
                 #[decode_as_type(crate_path = ":: subxt_path :: ext :: scale_decode")]
                 #[encode_as_type(crate_path = ":: subxt_path :: ext :: scale_encode")]
                 pub struct S {
-                    pub map: ::std::collections::BTreeMap<:: core :: primitive :: u8,:: core :: primitive :: u8>,
+                    pub map: ::alloc::collections::BTreeMap<:: core :: primitive :: u8,:: core :: primitive :: u8>,
                 }
             }
         }.to_string()

--- a/codegen/src/types/type_path.rs
+++ b/codegen/src/types/type_path.rs
@@ -141,9 +141,9 @@ impl TypePathType {
                 match ident.as_str() {
                     "Option" => parse_quote!(::core::option::Option),
                     "Result" => parse_quote!(::core::result::Result),
-                    "Cow" => parse_quote!(::std::borrow::Cow),
-                    "BTreeMap" => parse_quote!(::std::collections::BTreeMap),
-                    "BTreeSet" => parse_quote!(::std::collections::BTreeSet),
+                    "Cow" => parse_quote!(::core::borrow::Cow),
+                    "BTreeMap" => parse_quote!(::alloc::collections::BTreeMap),
+                    "BTreeSet" => parse_quote!(::alloc::collections::BTreeSet),
                     "Range" => parse_quote!(::core::ops::Range),
                     "RangeInclusive" => parse_quote!(::core::ops::RangeInclusive),
                     ident => panic!("Unknown prelude type '{ident}'"),
@@ -213,7 +213,7 @@ impl TypePathType {
                 syn::Type::Path(path)
             }
             TypePathType::Vec { of } => {
-                let type_path = parse_quote! { ::std::vec::Vec<#of> };
+                let type_path = parse_quote! { ::alloc::vec::Vec<#of> };
                 syn::Type::Path(type_path)
             }
             TypePathType::Array { len, of } => {
@@ -227,7 +227,7 @@ impl TypePathType {
             TypePathType::Primitive { def } => syn::Type::Path(match def {
                 TypeDefPrimitive::Bool => parse_quote!(::core::primitive::bool),
                 TypeDefPrimitive::Char => parse_quote!(::core::primitive::char),
-                TypeDefPrimitive::Str => parse_quote!(::std::string::String),
+                TypeDefPrimitive::Str => parse_quote!(::alloc::string::String),
                 TypeDefPrimitive::U8 => parse_quote!(::core::primitive::u8),
                 TypeDefPrimitive::U16 => parse_quote!(::core::primitive::u16),
                 TypeDefPrimitive::U32 => parse_quote!(::core::primitive::u32),


### PR DESCRIPTION
Substitute `std::` imports in the generated code with `core::` or `alloc::` to enable using macro within no-std context.