### PR TITLE
cli: Use WS by default instead of HTTP

### DIFF
--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -62,7 +62,7 @@ impl FileOrUrl {
             .await?),
             // Default if neither is provided; fetch from local url
             (None, None, version) => {
-                let uri = Uri::from_static("http://localhost:9933");
+                let uri = Uri::from_static("ws://localhost:9944");
                 Ok(
                     subxt_codegen::utils::fetch_metadata_bytes(&uri, version.unwrap_or_default())
                         .await?,


### PR DESCRIPTION
After the substrate patch to remove the RPC HTTP port, trying to fetch the metadata directly from the runtime will fail.

This is because on the HTTP port asking for Metadata_versions will return 

```bash
Err(Transport(HTTP error: error trying to connect: tcp connect error: Connection refused (os error 111)))
```

### Reproduce 

1. Start substrate from the latest master
2. Fetch the unstable metadata via CLI

```bash
cargo run --release -p subxt-cli -- metadata  --version unstable --format json

Error:
   0: Other error: The node can only return version 14 metadata but you've asked for something else

Location:
   cli/src/utils.rs:67
```

However, the Substrate node has access and exposes the V15 under the u32::max.

