### PR TITLE
Retain specific runtime APIs

### DIFF
--- a/metadata/src/lib.rs
+++ b/metadata/src/lib.rs
@@ -7,7 +7,7 @@ mod validation;
 
 use frame_metadata::{v14::RuntimeMetadataV14, v15::RuntimeMetadataV15};
 
-pub use retain::retain_metadata_pallets;
+pub use retain::retain_metadata;
 pub use validation::{
     get_call_hash, get_constant_hash, get_pallet_hash, get_runtime_api_hash, get_storage_hash,
     MetadataHasher, NotFound,

--- a/testing/ui-tests/src/utils/pallet_metadata_test_runner.rs
+++ b/testing/ui-tests/src/utils/pallet_metadata_test_runner.rs
@@ -5,7 +5,7 @@
 use codec::{Decode, Encode};
 use frame_metadata::{v15::RuntimeMetadataV15, RuntimeMetadataPrefixed};
 use std::io::Read;
-use subxt_metadata::{metadata_v14_to_latest, retain_metadata_pallets};
+use subxt_metadata::{metadata_v14_to_latest, retain_metadata};
 
 static TEST_DIR_PREFIX: &str = "subxt_generated_pallets_ui_tests_";
 static METADATA_FILE: &str = "../../artifacts/polkadot_metadata_full.scale";
@@ -59,7 +59,11 @@ impl PalletMetadataTestRunner {
 
         // Build custom metadata containing only this pallet.
         let mut metadata = self.metadata.clone();
-        retain_metadata_pallets(&mut metadata, |pallet_filter| pallet_filter == pallet.name);
+        retain_metadata(
+            &mut metadata,
+            |pallet_filter| pallet_filter == pallet.name,
+            |_| true,
+        );
 
         let mut tmp_dir = std::env::temp_dir();
         tmp_dir.push(format!("{TEST_DIR_PREFIX}{index}"));


### PR DESCRIPTION
fixes #933 

I integrated the retaining of specific runtime APIs into the existing `retain_metadata_pallets` functionality, because it is more efficient to join the two operations in one place. As for the typing: I tried usind `Option<FnMut(&str) -> bool>` as a sensiple argument type for both `pallets_filter` and `runtime_apis_filter` but spent way too much time on lifetime issues and could not get it going well. So now I settled for just passing `|_| true` closures, when all elements should be retained. Not so nice, I know, but should work.