### PR TITLE
Tidy up some metadata accessing

### DIFF
--- a/subxt/src/blocks/extrinsic_types.rs
+++ b/subxt/src/blocks/extrinsic_types.rs
@@ -366,10 +366,7 @@ where
 
     /// Fetch the metadata for this extrinsic.
     pub fn extrinsic_metadata(&self) -> Result<ExtrinsicMetadataDetails, Error> {
-        let pallet = self
-            .metadata
-            .pallet_by_index(self.pallet_index())
-            .ok_or_else(|| MetadataError::PalletIndexNotFound(self.pallet_index()))?;
+        let pallet = self.metadata.pallet_by_index_err(self.pallet_index())?;
         let variant = pallet
             .call_variant_by_index(self.variant_index())
             .ok_or_else(|| MetadataError::VariantIndexNotFound(self.variant_index()))?;

--- a/subxt/src/constants/constants_client.rs
+++ b/subxt/src/constants/constants_client.rs
@@ -39,8 +39,7 @@ impl<T: Config, Client: OfflineClientT<T>> ConstantsClient<T, Client> {
             let expected_hash = self
                 .client
                 .metadata()
-                .pallet_by_name(address.pallet_name())
-                .ok_or_else(|| MetadataError::PalletNameNotFound(address.pallet_name().to_owned()))?
+                .pallet_by_name_err(address.pallet_name())?
                 .constant_hash(address.constant_name())
                 .ok_or_else(|| {
                     MetadataError::ConstantNameNotFound(address.constant_name().to_owned())
@@ -65,10 +64,8 @@ impl<T: Config, Client: OfflineClientT<T>> ConstantsClient<T, Client> {
         self.validate(address)?;
 
         // 2. Attempt to decode the constant into the type given:
-        let pallet = metadata
-            .pallet_by_name(address.pallet_name())
-            .ok_or_else(|| MetadataError::PalletNameNotFound(address.pallet_name().to_owned()))?;
-        let constant = pallet
+        let constant = metadata
+            .pallet_by_name_err(address.pallet_name())?
             .constant_by_name(address.constant_name())
             .ok_or_else(|| {
                 MetadataError::ConstantNameNotFound(address.constant_name().to_owned())

--- a/subxt/src/error/dispatch_error.rs
+++ b/subxt/src/error/dispatch_error.rs
@@ -154,11 +154,7 @@ impl std::fmt::Display for ModuleError {
 impl ModuleError {
     /// Return more details about this error.
     pub fn details(&self) -> Result<ModuleErrorDetails, MetadataError> {
-        let pallet = self
-            .metadata
-            .pallet_by_index(self.raw.pallet_index)
-            .ok_or(MetadataError::PalletIndexNotFound(self.raw.pallet_index))?;
-
+        let pallet = self.metadata.pallet_by_index_err(self.raw.pallet_index)?;
         let variant = pallet
             .error_variant_by_index(self.raw.error[0])
             .ok_or_else(|| MetadataError::VariantIndexNotFound(self.raw.error[0]))?;

--- a/subxt/src/events/events_type.rs
+++ b/subxt/src/events/events_type.rs
@@ -227,9 +227,7 @@ impl EventDetails {
         let event_fields_start_idx = all_bytes.len() - input.len();
 
         // Get metadata for the event:
-        let event_pallet = metadata
-            .pallet_by_index(pallet_index)
-            .ok_or(MetadataError::PalletIndexNotFound(pallet_index))?;
+        let event_pallet = metadata.pallet_by_index_err(pallet_index)?;
         let event_variant = event_pallet
             .event_variant_by_index(variant_index)
             .ok_or(MetadataError::VariantIndexNotFound(variant_index))?;

--- a/subxt/src/metadata/metadata_type.rs
+++ b/subxt/src/metadata/metadata_type.rs
@@ -25,7 +25,8 @@ impl Metadata {
         }
     }
 
-    pub(crate) fn pallet_by_name_err(
+    /// Identical to [`Metadata::pallet_by_name`], but returns an error if the pallet is not found.
+    pub fn pallet_by_name_err(
         &self,
         name: &str,
     ) -> Result<subxt_metadata::PalletMetadata, MetadataError> {
@@ -33,7 +34,8 @@ impl Metadata {
             .ok_or_else(|| MetadataError::PalletNameNotFound(name.to_owned()))
     }
 
-    pub(crate) fn pallet_by_index_err(
+    /// Identical to [`Metadata::pallet_by_index`], but returns an error if the pallet is not found.
+    pub fn pallet_by_index_err(
         &self,
         index: u8,
     ) -> Result<subxt_metadata::PalletMetadata, MetadataError> {
@@ -41,7 +43,8 @@ impl Metadata {
             .ok_or_else(|| MetadataError::PalletIndexNotFound(index))
     }
 
-    pub(crate) fn runtime_api_trait_by_name_err(
+    /// Identical to [`Metadata::runtime_api_trait_by_name`], but returns an error if the trait is not found.
+    pub fn runtime_api_trait_by_name_err(
         &self,
         name: &str,
     ) -> Result<subxt_metadata::RuntimeApiMetadata, MetadataError> {

--- a/subxt/src/metadata/metadata_type.rs
+++ b/subxt/src/metadata/metadata_type.rs
@@ -25,7 +25,7 @@ impl Metadata {
         }
     }
 
-    /// Identical to [`Metadata::pallet_by_name`], but returns an error if the pallet is not found.
+    /// Identical to `metadata.pallet_by_name()`, but returns an error if the pallet is not found.
     pub fn pallet_by_name_err(
         &self,
         name: &str,
@@ -34,16 +34,16 @@ impl Metadata {
             .ok_or_else(|| MetadataError::PalletNameNotFound(name.to_owned()))
     }
 
-    /// Identical to [`Metadata::pallet_by_index`], but returns an error if the pallet is not found.
+    /// Identical to `metadata.pallet_by_index()`, but returns an error if the pallet is not found.
     pub fn pallet_by_index_err(
         &self,
         index: u8,
     ) -> Result<subxt_metadata::PalletMetadata, MetadataError> {
         self.pallet_by_index(index)
-            .ok_or_else(|| MetadataError::PalletIndexNotFound(index))
+            .ok_or(MetadataError::PalletIndexNotFound(index))
     }
 
-    /// Identical to [`Metadata::runtime_api_trait_by_name`], but returns an error if the trait is not found.
+    /// Identical to `metadata.runtime_api_trait_by_name()`, but returns an error if the trait is not found.
     pub fn runtime_api_trait_by_name_err(
         &self,
         name: &str,

--- a/subxt/src/metadata/metadata_type.rs
+++ b/subxt/src/metadata/metadata_type.rs
@@ -2,6 +2,7 @@
 // This file is dual-licensed as Apache-2.0 or GPL-3.0.
 // see LICENSE for license details.
 
+use crate::error::MetadataError;
 use std::sync::Arc;
 
 /// A cheaply clone-able representation of the runtime metadata received from a node.
@@ -22,6 +23,30 @@ impl Metadata {
         Metadata {
             inner: Arc::new(md),
         }
+    }
+
+    pub(crate) fn pallet_by_name_err(
+        &self,
+        name: &str,
+    ) -> Result<subxt_metadata::PalletMetadata, MetadataError> {
+        self.pallet_by_name(name)
+            .ok_or_else(|| MetadataError::PalletNameNotFound(name.to_owned()))
+    }
+
+    pub(crate) fn pallet_by_index_err(
+        &self,
+        index: u8,
+    ) -> Result<subxt_metadata::PalletMetadata, MetadataError> {
+        self.pallet_by_index(index)
+            .ok_or_else(|| MetadataError::PalletIndexNotFound(index))
+    }
+
+    pub(crate) fn runtime_api_trait_by_name_err(
+        &self,
+        name: &str,
+    ) -> Result<subxt_metadata::RuntimeApiMetadata, MetadataError> {
+        self.runtime_api_trait_by_name(name)
+            .ok_or_else(|| MetadataError::RuntimeTraitNotFound(name.to_owned()))
     }
 }
 

--- a/subxt/src/runtime_api/runtime_payload.rs
+++ b/subxt/src/runtime_api/runtime_payload.rs
@@ -88,10 +88,8 @@ impl<ArgsData: EncodeAsFields, ReturnTy: DecodeWithMetadata> RuntimeApiPayload
     }
 
     fn encode_args_to(&self, metadata: &Metadata, out: &mut Vec<u8>) -> Result<(), Error> {
-        let api_trait = metadata
-            .runtime_api_trait_by_name(&self.trait_name)
-            .ok_or_else(|| MetadataError::RuntimeTraitNotFound((*self.trait_name).to_owned()))?;
-        let api_method = api_trait
+        let api_method = metadata
+            .runtime_api_trait_by_name_err(&self.trait_name)?
             .method_by_name(&self.method_name)
             .ok_or_else(|| MetadataError::RuntimeMethodNotFound((*self.method_name).to_owned()))?;
 

--- a/subxt/src/runtime_api/runtime_types.rs
+++ b/subxt/src/runtime_api/runtime_types.rs
@@ -70,11 +70,7 @@ where
         async move {
             let metadata = client.metadata();
 
-            let api_trait = metadata
-                .runtime_api_trait_by_name(payload.trait_name())
-                .ok_or_else(|| {
-                    MetadataError::RuntimeTraitNotFound(payload.trait_name().to_owned())
-                })?;
+            let api_trait = metadata.runtime_api_trait_by_name_err(payload.trait_name())?;
             let api_method = api_trait
                 .method_by_name(payload.method_name())
                 .ok_or_else(|| {

--- a/subxt/src/storage/storage_address.rs
+++ b/subxt/src/storage/storage_address.rs
@@ -138,9 +138,7 @@ where
     }
 
     fn append_entry_bytes(&self, metadata: &Metadata, bytes: &mut Vec<u8>) -> Result<(), Error> {
-        let pallet = metadata
-            .pallet_by_name(self.pallet_name())
-            .ok_or_else(|| MetadataError::PalletNameNotFound(self.pallet_name().to_owned()))?;
+        let pallet = metadata.pallet_by_name_err(self.pallet_name())?;
         let storage = pallet
             .storage()
             .ok_or_else(|| MetadataError::StorageNotFoundInPallet(self.pallet_name().to_owned()))?;

--- a/subxt/src/storage/storage_client.rs
+++ b/subxt/src/storage/storage_client.rs
@@ -9,7 +9,7 @@ use super::{
 
 use crate::{
     client::{OfflineClientT, OnlineClientT},
-    error::{Error, MetadataError},
+    error::Error,
     Config,
 };
 use derivative::Derivative;
@@ -44,9 +44,7 @@ where
     /// the pallet or storage entry in question do not exist at all).
     pub fn validate<Address: StorageAddress>(&self, address: &Address) -> Result<(), Error> {
         let metadata = self.client.metadata();
-        let pallet_metadata = metadata
-            .pallet_by_name(address.pallet_name())
-            .ok_or_else(|| MetadataError::PalletNameNotFound(address.pallet_name().to_owned()))?;
+        let pallet_metadata = metadata.pallet_by_name_err(address.pallet_name())?;
         validate_storage_address(address, pallet_metadata)
     }
 

--- a/subxt/src/storage/storage_type.rs
+++ b/subxt/src/storage/storage_type.rs
@@ -321,9 +321,7 @@ fn lookup_entry_details<'a>(
     entry_name: &str,
     metadata: &'a Metadata,
 ) -> Result<(PalletMetadata<'a>, &'a StorageEntryMetadata), Error> {
-    let pallet_metadata = metadata
-        .pallet_by_name(pallet_name)
-        .ok_or_else(|| MetadataError::PalletNameNotFound(pallet_name.to_owned()))?;
+    let pallet_metadata = metadata.pallet_by_name_err(pallet_name)?;
     let storage_metadata = pallet_metadata
         .storage()
         .ok_or_else(|| MetadataError::StorageNotFoundInPallet(pallet_name.to_owned()))?;

--- a/subxt/src/tx/tx_client.rs
+++ b/subxt/src/tx/tx_client.rs
@@ -50,8 +50,7 @@ impl<T: Config, C: OfflineClientT<T>> TxClient<T, C> {
             let expected_hash = self
                 .client
                 .metadata()
-                .pallet_by_name(details.pallet_name)
-                .ok_or_else(|| MetadataError::PalletNameNotFound(details.pallet_name.to_owned()))?
+                .pallet_by_name_err(details.pallet_name)?
                 .call_hash(details.call_name)
                 .ok_or_else(|| MetadataError::CallNameNotFound(details.call_name.to_owned()))?;
 

--- a/subxt/src/tx/tx_payload.rs
+++ b/subxt/src/tx/tx_payload.rs
@@ -141,9 +141,7 @@ impl Payload<Composite<()>> {
 
 impl<CallData: EncodeAsFields> TxPayload for Payload<CallData> {
     fn encode_call_data_to(&self, metadata: &Metadata, out: &mut Vec<u8>) -> Result<(), Error> {
-        let pallet = metadata
-            .pallet_by_name(&self.pallet_name)
-            .ok_or_else(|| MetadataError::PalletNameNotFound((*self.pallet_name).to_owned()))?;
+        let pallet = metadata.pallet_by_name_err(&self.pallet_name)?;
         let call = pallet
             .call_variant_by_name(&self.call_name)
             .ok_or_else(|| MetadataError::CallNameNotFound((*self.call_name).to_owned()))?;


### PR DESCRIPTION
Just a small PR to reduce some duplication across the codebase when fetching pallets and runtime traits from metadata