### PR TITLE
Add topics to `EventDetails`

### DIFF
--- a/subxt/src/blocks/extrinsic_types.rs
+++ b/subxt/src/blocks/extrinsic_types.rs
@@ -560,7 +560,7 @@ impl<T: Config> ExtrinsicEvents<T> {
     ///
     /// This works in the same way that [`events::Events::iter()`] does, with the
     /// exception that it filters out events not related to the submitted extrinsic.
-    pub fn iter(&self) -> impl Iterator<Item = Result<events::EventDetails, Error>> + '_ {
+    pub fn iter(&self) -> impl Iterator<Item = Result<events::EventDetails<T>, Error>> + '_ {
         self.events.iter().filter(|ev| {
             ev.as_ref()
                 .map(|ev| ev.phase() == events::Phase::ApplyExtrinsic(self.idx))

--- a/subxt/src/events/events_type.rs
+++ b/subxt/src/events/events_type.rs
@@ -253,8 +253,7 @@ impl<T: Config> EventDetails<T> {
         // the end of the field bytes.
         let event_fields_end_idx = all_bytes.len() - input.len();
 
-        // topics come after the event data in EventRecord. They aren't used for
-        // anything at the moment, so just decode and throw them away.
+        // topics come after the event data in EventRecord.
         let topics = Vec::<T::Hash>::decode(input)?;
 
         // what bytes did we skip over in total, including topics.

--- a/subxt/src/events/events_type.rs
+++ b/subxt/src/events/events_type.rs
@@ -979,7 +979,7 @@ mod tests {
             metadata,
             vec![EventRecord::new(
                 Phase::ApplyExtrinsic(123),
-                event.clone(),
+                event,
                 topics.clone(),
             )],
         );

--- a/subxt/src/events/events_type.rs
+++ b/subxt/src/events/events_type.rs
@@ -121,7 +121,7 @@ impl<T: Config> Events<T> {
     // use of it with our `FilterEvents` stuff.
     pub fn iter(
         &self,
-    ) -> impl Iterator<Item = Result<EventDetails, Error>> + Send + Sync + 'static {
+    ) -> impl Iterator<Item = Result<EventDetails<T>, Error>> + Send + Sync + 'static {
         // The event bytes ignoring the compact encoded length on the front:
         let event_bytes = self.event_bytes.clone();
         let metadata = self.metadata.clone();
@@ -133,7 +133,7 @@ impl<T: Config> Events<T> {
             if event_bytes.len() <= pos || num_events == index {
                 None
             } else {
-                match EventDetails::decode_from::<T>(
+                match EventDetails::decode_from(
                     metadata.clone(),
                     event_bytes.clone(),
                     pos,
@@ -189,7 +189,7 @@ impl<T: Config> Events<T> {
 
 /// The event details.
 #[derive(Debug, Clone)]
-pub struct EventDetails {
+pub struct EventDetails<T: Config> {
     phase: Phase,
     /// The index of the event in the list of events in a given block.
     index: u32,
@@ -205,16 +205,17 @@ pub struct EventDetails {
     // end of everything (fields + topics)
     end_idx: usize,
     metadata: Metadata,
+    topics: Vec<T::Hash>,
 }
 
-impl EventDetails {
+impl<T: Config> EventDetails<T> {
     // Attempt to dynamically decode a single event from our events input.
-    fn decode_from<T: Config>(
+    fn decode_from(
         metadata: Metadata,
         all_bytes: Arc<[u8]>,
         start_idx: usize,
         index: u32,
-    ) -> Result<EventDetails, Error> {
+    ) -> Result<EventDetails<T>, Error> {
         let input = &mut &all_bytes[start_idx..];
 
         let phase = Phase::decode(input)?;
@@ -254,7 +255,7 @@ impl EventDetails {
 
         // topics come after the event data in EventRecord. They aren't used for
         // anything at the moment, so just decode and throw them away.
-        let _topics = Vec::<T::Hash>::decode(input)?;
+        let topics = Vec::<T::Hash>::decode(input)?;
 
         // what bytes did we skip over in total, including topics.
         let end_idx = all_bytes.len() - input.len();
@@ -269,6 +270,7 @@ impl EventDetails {
             end_idx,
             all_bytes,
             metadata,
+            topics,
         })
     }
 
@@ -385,6 +387,11 @@ impl EventDetails {
             &self.metadata,
         )
     }
+
+    /// Return the topics associated with this event.
+    pub fn topics(&self) -> &[T::Hash] {
+        &self.topics
+    }
 }
 
 /// Details for the given event plucked from the metadata.
@@ -467,14 +474,17 @@ pub(crate) mod test_utils {
         topics: Vec<<SubstrateConfig as Config>::Hash>,
     }
 
+    impl<E: Encode> EventRecord<E> {
+        /// Create a new event record with the given phase, event, and topics.
+        pub fn new(phase: Phase, event: E, topics: Vec<<SubstrateConfig as Config>::Hash>) -> Self {
+            Self { phase, event: AllEvents::Test(event), topics }
+        }
+    }
+
     /// Build an EventRecord, which encoded events in the format expected
     /// to be handed back from storage queries to System.Events.
     pub fn event_record<E: Encode>(phase: Phase, event: E) -> EventRecord<E> {
-        EventRecord {
-            phase,
-            event: AllEvents::Test(event),
-            topics: vec![],
-        }
+        EventRecord::new(phase, event, vec![])
     }
 
     /// Build fake metadata consisting of a single pallet that knows
@@ -564,10 +574,12 @@ pub(crate) mod test_utils {
 #[cfg(test)]
 mod tests {
     use super::{
-        test_utils::{event_record, events, events_raw, AllEvents},
+        test_utils::{event_record, events, events_raw, AllEvents, EventRecord},
         *,
     };
+    use crate::SubstrateConfig;
     use codec::Encode;
+    use primitive_types::H256;
     use scale_info::TypeInfo;
     use scale_value::Value;
 
@@ -596,7 +608,7 @@ mod tests {
         // Just for convenience, pass in the metadata type constructed
         // by the `metadata` function above to simplify caller code.
         metadata: &Metadata,
-        actual: EventDetails,
+        actual: EventDetails<SubstrateConfig>,
         expected: TestRawEventDetails,
     ) {
         let types = &metadata.types();
@@ -949,5 +961,36 @@ mod tests {
             },
         );
         assert!(event_details.next().is_none());
+    }
+
+    #[test]
+    fn topics() {
+        #[derive(Clone, Debug, PartialEq, Decode, Encode, TypeInfo, scale_decode::DecodeAsType)]
+        enum Event {
+            A(u8, bool, Vec<String>),
+        }
+
+        // Create fake metadata that knows about our single event, above:
+        let metadata = metadata::<Event>();
+
+        // Encode our events in the format we expect back from a node, and
+        // construct an Events object to iterate them:
+        let event = Event::A(1, true, vec!["Hi".into()]);
+        let topics = vec![
+            H256::from_low_u64_le(123),
+            H256::from_low_u64_le(456),
+        ];
+        let events = events::<Event>(
+            metadata,
+            vec![EventRecord::new(Phase::ApplyExtrinsic(123), event.clone(), topics.clone())],
+        );
+
+        let ev = events
+            .iter()
+            .next()
+            .expect("one event expected")
+            .expect("event should be extracted OK");
+
+        assert_eq!(topics, ev.topics());
     }
 }

--- a/subxt/src/events/events_type.rs
+++ b/subxt/src/events/events_type.rs
@@ -133,12 +133,7 @@ impl<T: Config> Events<T> {
             if event_bytes.len() <= pos || num_events == index {
                 None
             } else {
-                match EventDetails::decode_from(
-                    metadata.clone(),
-                    event_bytes.clone(),
-                    pos,
-                    index,
-                ) {
+                match EventDetails::decode_from(metadata.clone(), event_bytes.clone(), pos, index) {
                     Ok(event_details) => {
                         // Skip over decoded bytes in next iteration:
                         pos += event_details.bytes().len();
@@ -476,7 +471,11 @@ pub(crate) mod test_utils {
     impl<E: Encode> EventRecord<E> {
         /// Create a new event record with the given phase, event, and topics.
         pub fn new(phase: Phase, event: E, topics: Vec<<SubstrateConfig as Config>::Hash>) -> Self {
-            Self { phase, event: AllEvents::Test(event), topics }
+            Self {
+                phase,
+                event: AllEvents::Test(event),
+                topics,
+            }
         }
     }
 
@@ -975,13 +974,14 @@ mod tests {
         // Encode our events in the format we expect back from a node, and
         // construct an Events object to iterate them:
         let event = Event::A(1, true, vec!["Hi".into()]);
-        let topics = vec![
-            H256::from_low_u64_le(123),
-            H256::from_low_u64_le(456),
-        ];
+        let topics = vec![H256::from_low_u64_le(123), H256::from_low_u64_le(456)];
         let events = events::<Event>(
             metadata,
-            vec![EventRecord::new(Phase::ApplyExtrinsic(123), event.clone(), topics.clone())],
+            vec![EventRecord::new(
+                Phase::ApplyExtrinsic(123),
+                event.clone(),
+                topics.clone(),
+            )],
         );
 
         let ev = events


### PR DESCRIPTION
Topics are actually used in `pallet-contracts`, and we will need access to them for upcoming changes to `ink!` events.