### PR TITLE
add `#[allow(rustdoc::broken_intra_doc_links)]` to subxt-codegen

### DIFF
--- a/codegen/src/api/mod.rs
+++ b/codegen/src/api/mod.rs
@@ -527,6 +527,7 @@ impl RuntimeGenerator {
             #( #item_mod_attrs )*
             #[allow(dead_code, unused_imports, non_camel_case_types)]
             #[allow(clippy::all)]
+            #[allow(rustdoc::broken_intra_doc_links)]
             pub mod #mod_ident {
                 // Preserve any Rust items that were previously defined in the adorned module.
                 #( #rust_items ) *

--- a/codegen/src/api/mod.rs
+++ b/codegen/src/api/mod.rs
@@ -253,6 +253,7 @@ impl RuntimeGenerator {
             #( #item_mod_attrs )*
             #[allow(dead_code, unused_imports, non_camel_case_types)]
             #[allow(clippy::all)]
+            #[allow(rustdoc::broken_intra_doc_links)]
             pub mod #mod_ident {
                 // Preserve any Rust items that were previously defined in the adorned module
                 #( #rust_items ) *


### PR DESCRIPTION
We are developing [gear protocol](https://github.com/gear-tech/gear) and have decided to enable flag that will convert all warnings to errors when the link in a document comment does not exist.

I think it makes sense to add this attribute in order not to get warnings when building documentation.
The `cargo doc` warning looks like this and it comes from the code generated by subxt-codegen
```
warning: unresolved link to `IdentityInfo`
    --> gsdk/src/metadata/generated.rs:2590:21
     |
2590 | /                     #[doc = "Provide a judgement for an account's identity."]
2591 | |                     #[doc = ""]
2592 | |                     #[doc = "The dispatch origin for this call must be _Signed_ and the sender must be the account"]
2593 | |                     #[doc = "of the registrar whose index is `reg_index`."]
...    |
2605 | |                     #[doc = "  - where `R` registrar-count (governance-bounded)."]
2606 | |                     #[doc = "  - where `X` additional-field-count (deposit-bounded and code-bounded)."]
     | |_______________________________________________________________________________________________________^
     |
     = note: the link appears in this line:
             
             - `identity`: The hash of the [`IdentityInfo`] for that the judgement is provided.
                                            ^^^^^^^^^^^^^^
     = note: no item named `IdentityInfo` in scope
     = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
     = note: `#[warn(rustdoc::broken_intra_doc_links)]` on by default
```