### PR TITLE
Get account nonce via state_call; remove RPC method

### DIFF
--- a/subxt/src/config/mod.rs
+++ b/subxt/src/config/mod.rs
@@ -27,7 +27,7 @@ pub use substrate::SubstrateConfig;
 pub trait Config: 'static {
     /// Account index (aka nonce) type. This stores the number of previous
     /// transactions associated with a sender account.
-    type Index: Debug + Copy + DeserializeOwned + Into<u64>;
+    type Index: Debug + Copy + Decode + Into<u64>;
 
     /// The output of the `Hasher` function.
     type Hash: Debug
@@ -42,7 +42,7 @@ pub trait Config: 'static {
         + PartialEq;
 
     /// The account ID type.
-    type AccountId: Debug + Clone + Serialize;
+    type AccountId: Debug + Clone + Encode;
 
     /// The address type.
     type Address: Debug + Encode + From<Self::AccountId>;

--- a/subxt/src/rpc/rpc.rs
+++ b/subxt/src/rpc/rpc.rs
@@ -34,7 +34,6 @@
 use std::sync::Arc;
 
 use codec::{Decode, Encode};
-use serde::Serialize;
 
 use crate::{error::Error, utils::PhantomDataSendSync, Config, Metadata};
 
@@ -177,16 +176,6 @@ impl<T: Config> Rpc<T> {
     /// Fetch system version
     pub async fn system_version(&self) -> Result<String, Error> {
         self.client.request("system_version", rpc_params![]).await
-    }
-
-    /// Fetch the current nonce for the given account ID.
-    pub async fn system_account_next_index<AccountId: Serialize>(
-        &self,
-        account: &AccountId,
-    ) -> Result<T::Index, Error> {
-        self.client
-            .request("system_accountNextIndex", rpc_params![account])
-            .await
     }
 
     /// Get a header

--- a/subxt/src/tx/tx_client.rs
+++ b/subxt/src/tx/tx_client.rs
@@ -174,11 +174,15 @@ where
     T: Config,
     C: OnlineClientT<T>,
 {
-    // Get the next account nonce to use.
-    async fn next_account_nonce(&self, account_id: &T::AccountId) -> Result<T::Index, Error> {
+    /// Get the account nonce for a given account ID.
+    pub async fn account_nonce(&self, account_id: &T::AccountId) -> Result<T::Index, Error> {
         self.client
             .rpc()
-            .system_account_next_index(account_id)
+            .state_call(
+                "AccountNonceApi_account_nonce",
+                Some(&account_id.encode()),
+                None,
+            )
             .await
     }
 
@@ -192,7 +196,7 @@ where
     where
         Call: TxPayload,
     {
-        let account_nonce = self.next_account_nonce(account_id).await?;
+        let account_nonce = self.account_nonce(account_id).await?;
         self.create_partial_signed_with_nonce(call, account_nonce, other_params)
     }
 
@@ -207,7 +211,7 @@ where
         Call: TxPayload,
         Signer: SignerT<T>,
     {
-        let account_nonce = self.next_account_nonce(signer.account_id()).await?;
+        let account_nonce = self.account_nonce(signer.account_id()).await?;
         self.create_signed_with_nonce(call, signer, account_nonce, other_params)
     }
 


### PR DESCRIPTION
Some chains don't have the RPC method that we were using, and using state_call will be more future proof going forwards anyway.

Also make the function public because it's come up a couple of times recently where people have needed to fetch this.