### PR TITLE
chore(subxt): make payload details public

### DIFF
--- a/subxt/src/tx/tx_payload.rs
+++ b/subxt/src/tx/tx_payload.rs
@@ -120,6 +120,16 @@ impl<CallData> Payload<CallData> {
     pub fn call_data(&self) -> &CallData {
         &self.call_data
     }
+
+    /// Returns the pallet name.
+    pub fn pallet_name(&self) -> &str {
+        &self.pallet_name
+    }
+
+    /// Returns the call name.
+    pub fn call_name(&self) -> &str {
+        &self.call_name
+    }
 }
 
 impl Payload<Composite<()>> {


### PR DESCRIPTION
the payload details are really useful for logging, for our situation, we have arch with dynamic API with subxt which manages the calls with the built `payload`, so making these two fields public again is the simpliest way we can get them for logging

https://github.com/gear-tech/gear/blob/640136c0b83f9fc16b978c1ec1aacfc7f1a9f4e4/gsdk/src/signer/calls.rs#L426