### PR TITLE
Remove parentheses for hex output of cli

### DIFF
--- a/cli/src/commands/metadata.rs
+++ b/cli/src/commands/metadata.rs
@@ -76,7 +76,7 @@ pub async fn run(opts: Opts, output: &mut impl Write) -> color_eyre::Result<()> 
             Ok(())
         }
         "hex" => {
-            let hex_data = format!("0x{:?}", hex::encode(metadata.encode()));
+            let hex_data = format!("0x{}", hex::encode(metadata.encode()));
             write!(output, "{hex_data}")?;
             Ok(())
         }


### PR DESCRIPTION
Remove parentheses for hex output when using `subxt metadata -f hex`. 
Before is was `0x"010203..."` now it is `0x010203...` 
