### PR TITLE
cli: Write output to file

### DIFF
--- a/cli/src/commands/metadata.rs
+++ b/cli/src/commands/metadata.rs
@@ -7,7 +7,7 @@ use clap::Parser as ClapParser;
 use codec::{Decode, Encode};
 use color_eyre::eyre::{self, bail};
 use frame_metadata::{v15::RuntimeMetadataV15, RuntimeMetadata, RuntimeMetadataPrefixed};
-use std::io::Write;
+use std::{io::Write, path::PathBuf};
 use subxt_metadata::Metadata;
 
 /// Download metadata from a substrate node, for use with `subxt` codegen.
@@ -32,6 +32,9 @@ pub struct Opts {
     /// when using the option.
     #[clap(long, use_value_delimiter = true, value_parser)]
     runtime_apis: Option<Vec<String>>,
+    /// Write the output of the metadata command to the provided file path.
+    #[clap(long, short, value_parser)]
+    pub output_file: Option<PathBuf>,
 }
 
 pub async fn run(opts: Opts, output: &mut impl Write) -> color_eyre::Result<()> {
@@ -68,6 +71,11 @@ pub async fn run(opts: Opts, output: &mut impl Write) -> color_eyre::Result<()> 
             }
         }
     }
+
+    let mut output: Box<dyn Write> = match opts.output_file {
+        Some(path) => Box::new(std::fs::File::create(path)?),
+        None => Box::new(output),
+    };
 
     match opts.format.as_str() {
         "json" => {


### PR DESCRIPTION
This PR adds the ability to output the result of the subxt/cli metadata command to a dedicated file.

This is in response to https://github.com/paritytech/subxt/issues/969, where the output from the Windows process to the file results in metadata byte differences.

With this patch applied:

```bash
$> Get-FileHash .\win.scale

Algorithm       Hash                                                                   Path
---------       ----                                                                   ----
SHA256          637D22238919A0293847BB0DA3F4E3E3FCF0711AF07DE7BF3E8527437962E8BE       D:\subxt\cli\win.scale


$> shasum -a 256 mac.scale                                                     
637d22238919a0293847bb0da3f4e3e3fcf0711af07de7bf3e8527437962e8be  mac.scale
```


Closes https://github.com/paritytech/subxt/issues/969