### PR TITLE
[Bugfix] Invalid generation of types with >1 generic parameters

### DIFF
--- a/codegen/src/types/composite_def.rs
+++ b/codegen/src/types/composite_def.rs
@@ -113,7 +113,7 @@ impl quote::ToTokens for CompositeDef {
                     self.fields,
                     CompositeDefFields::NoFields | CompositeDefFields::Unnamed(_)
                 )
-                    .then(|| quote!(;));
+                .then(|| quote!(;));
 
                 quote! {
                     #derives
@@ -173,7 +173,11 @@ impl CompositeDefFields {
         let mut unnamed_fields = Vec::new();
 
         for field in fields {
-            let type_path = type_gen.resolve_field_type_path(field.ty.id, parent_type_params, field.type_name.as_deref());
+            let type_path = type_gen.resolve_field_type_path(
+                field.ty.id,
+                parent_type_params,
+                field.type_name.as_deref(),
+            );
             let field_type =
                 CompositeDefFieldType::new(field.ty.id, type_path, field.type_name.clone());
 
@@ -198,7 +202,7 @@ impl CompositeDefFields {
     }
 
     /// Returns the set of composite fields.
-    pub fn field_types(&self) -> Box<dyn Iterator<Item=&CompositeDefFieldType> + '_> {
+    pub fn field_types(&self) -> Box<dyn Iterator<Item = &CompositeDefFieldType> + '_> {
         match self {
             Self::NoFields => Box::new([].iter()),
             Self::Named(named_fields) => Box::new(named_fields.iter().map(|(_, f)| f)),

--- a/codegen/src/types/composite_def.rs
+++ b/codegen/src/types/composite_def.rs
@@ -113,7 +113,7 @@ impl quote::ToTokens for CompositeDef {
                     self.fields,
                     CompositeDefFields::NoFields | CompositeDefFields::Unnamed(_)
                 )
-                .then(|| quote!(;));
+                    .then(|| quote!(;));
 
                 quote! {
                     #derives
@@ -173,7 +173,7 @@ impl CompositeDefFields {
         let mut unnamed_fields = Vec::new();
 
         for field in fields {
-            let type_path = type_gen.resolve_field_type_path(field.ty.id, parent_type_params);
+            let type_path = type_gen.resolve_field_type_path(field.ty.id, parent_type_params, field.type_name.as_deref());
             let field_type =
                 CompositeDefFieldType::new(field.ty.id, type_path, field.type_name.clone());
 
@@ -198,7 +198,7 @@ impl CompositeDefFields {
     }
 
     /// Returns the set of composite fields.
-    pub fn field_types(&self) -> Box<dyn Iterator<Item = &CompositeDefFieldType> + '_> {
+    pub fn field_types(&self) -> Box<dyn Iterator<Item=&CompositeDefFieldType> + '_> {
         match self {
             Self::NoFields => Box::new([].iter()),
             Self::Named(named_fields) => Box::new(named_fields.iter().map(|(_, f)| f)),

--- a/codegen/src/types/mod.rs
+++ b/codegen/src/types/mod.rs
@@ -163,10 +163,10 @@ impl<'a> TypeGenerator<'a> {
         parent_type_params: &[TypeParameter],
         original_name: Option<&str>,
     ) -> TypePath {
-        if let Some(parent_type_param) = parent_type_params
-            .iter()
-            .find(|tp| tp.concrete_type_id == id && original_name.map_or(true, |original_name| tp.original_name == original_name))
-        {
+        if let Some(parent_type_param) = parent_type_params.iter().find(|tp| {
+            tp.concrete_type_id == id
+                && original_name.map_or(true, |original_name| tp.original_name == original_name)
+        }) {
             return TypePath::from_parameter(parent_type_param.clone());
         }
 
@@ -315,12 +315,12 @@ impl Module {
     }
 
     /// Returns this `Module`s child `mod`s.
-    pub fn children(&self) -> impl Iterator<Item=(&Ident, &Module)> {
+    pub fn children(&self) -> impl Iterator<Item = (&Ident, &Module)> {
         self.children.iter()
     }
 
     /// Returns the generated types.
-    pub fn types(&self) -> impl Iterator<Item=(&scale_info::Path<PortableForm>, &TypeDefGen)> {
+    pub fn types(&self) -> impl Iterator<Item = (&scale_info::Path<PortableForm>, &TypeDefGen)> {
         self.types.iter()
     }
 

--- a/codegen/src/types/mod.rs
+++ b/codegen/src/types/mod.rs
@@ -137,8 +137,9 @@ impl<'a> TypeGenerator<'a> {
         &self,
         id: u32,
         parent_type_params: &[TypeParameter],
+        original_name: Option<&str>,
     ) -> TypePath {
-        self.resolve_type_path_recurse(id, true, parent_type_params)
+        self.resolve_type_path_recurse(id, true, parent_type_params, original_name)
     }
 
     /// Get the type path for the given type identifier.
@@ -147,21 +148,24 @@ impl<'a> TypeGenerator<'a> {
     ///
     /// If no type with the given id found in the type registry.
     pub fn resolve_type_path(&self, id: u32) -> TypePath {
-        self.resolve_type_path_recurse(id, false, &[])
+        self.resolve_type_path_recurse(id, false, &[], None)
     }
 
     /// Visit each node in a possibly nested type definition to produce a type path.
     ///
     /// e.g `Result<GenericStruct<NestedGenericStruct<T>>, String>`
+    ///
+    /// if `original_name` is `Some(original_name)`, the resolved type needs to have the same `original_name`.
     fn resolve_type_path_recurse(
         &self,
         id: u32,
         is_field: bool,
         parent_type_params: &[TypeParameter],
+        original_name: Option<&str>,
     ) -> TypePath {
         if let Some(parent_type_param) = parent_type_params
             .iter()
-            .find(|tp| tp.concrete_type_id == id)
+            .find(|tp| tp.concrete_type_id == id && original_name.map_or(true, |original_name| tp.original_name == original_name))
         {
             return TypePath::from_parameter(parent_type_param.clone());
         }
@@ -181,7 +185,7 @@ impl<'a> TypeGenerator<'a> {
             .type_params
             .iter()
             .filter_map(|f| {
-                f.ty.map(|f| self.resolve_type_path_recurse(f.id, false, parent_type_params))
+                f.ty.map(|f| self.resolve_type_path_recurse(f.id, false, parent_type_params, None))
             })
             .collect();
 
@@ -205,6 +209,7 @@ impl<'a> TypeGenerator<'a> {
                     arr.type_param.id,
                     false,
                     parent_type_params,
+                    None,
                 )),
             },
             TypeDef::Sequence(seq) => TypePathType::Vec {
@@ -212,13 +217,14 @@ impl<'a> TypeGenerator<'a> {
                     seq.type_param.id,
                     false,
                     parent_type_params,
+                    None,
                 )),
             },
             TypeDef::Tuple(tuple) => TypePathType::Tuple {
                 elements: tuple
                     .fields
                     .iter()
-                    .map(|f| self.resolve_type_path_recurse(f.id, false, parent_type_params))
+                    .map(|f| self.resolve_type_path_recurse(f.id, false, parent_type_params, None))
                     .collect(),
             },
             TypeDef::Compact(compact) => TypePathType::Compact {
@@ -226,6 +232,7 @@ impl<'a> TypeGenerator<'a> {
                     compact.type_param.id,
                     false,
                     parent_type_params,
+                    None,
                 )),
                 is_field,
                 crate_path: self.crate_path.clone(),
@@ -235,11 +242,13 @@ impl<'a> TypeGenerator<'a> {
                     bitseq.bit_order_type.id,
                     false,
                     parent_type_params,
+                    None,
                 )),
                 bit_store_type: Box::new(self.resolve_type_path_recurse(
                     bitseq.bit_store_type.id,
                     false,
                     parent_type_params,
+                    None,
                 )),
                 crate_path: self.crate_path.clone(),
             },
@@ -306,12 +315,12 @@ impl Module {
     }
 
     /// Returns this `Module`s child `mod`s.
-    pub fn children(&self) -> impl Iterator<Item = (&Ident, &Module)> {
+    pub fn children(&self) -> impl Iterator<Item=(&Ident, &Module)> {
         self.children.iter()
     }
 
     /// Returns the generated types.
-    pub fn types(&self) -> impl Iterator<Item = (&scale_info::Path<PortableForm>, &TypeDefGen)> {
+    pub fn types(&self) -> impl Iterator<Item=(&scale_info::Path<PortableForm>, &TypeDefGen)> {
         self.types.iter()
     }
 

--- a/codegen/src/types/type_def_params.rs
+++ b/codegen/src/types/type_def_params.rs
@@ -27,7 +27,7 @@ impl TypeDefParameters {
 
     /// Update the set of unused type parameters by removing those that are used in the given
     /// fields.
-    pub fn update_unused<'a>(&mut self, fields: impl Iterator<Item = &'a CompositeDefFieldType>) {
+    pub fn update_unused<'a>(&mut self, fields: impl Iterator<Item=&'a CompositeDefFieldType>) {
         let mut used_type_params = BTreeSet::new();
         for field in fields {
             field.type_path.parent_type_params(&mut used_type_params)

--- a/codegen/src/types/type_def_params.rs
+++ b/codegen/src/types/type_def_params.rs
@@ -27,7 +27,7 @@ impl TypeDefParameters {
 
     /// Update the set of unused type parameters by removing those that are used in the given
     /// fields.
-    pub fn update_unused<'a>(&mut self, fields: impl Iterator<Item=&'a CompositeDefFieldType>) {
+    pub fn update_unused<'a>(&mut self, fields: impl Iterator<Item = &'a CompositeDefFieldType>) {
         let mut used_type_params = BTreeSet::new();
         for field in fields {
             field.type_path.parent_type_params(&mut used_type_params)


### PR DESCRIPTION
fixes #550

**Investigated reason for the bug:** In subxt, when calling `resolve_field_type_path()` to get the type of a generic, we were not taking into account multiple generics with different names (`originial_name` e.g. `T`, `U`, `V`, ...). The function just looked for the first type where the type (e.g. `u8`) matches (see: `parent_type_params.iter().find(...)`). 

**Fix:** add an optional parameter `original_name: Option<&str>` to the type resolving function to also check the name of the generic argument.

Added a test to confirm the behavior is now as desired. The test matches the problem statement in #550.