### PR TITLE
chain_getBlock extrinsics encoding

### DIFF
--- a/subxt/src/blocks/extrinsic_types.rs
+++ b/subxt/src/blocks/extrinsic_types.rs
@@ -786,14 +786,8 @@ mod tests {
         let ids = ExtrinsicPartTypeIds::new(&metadata).unwrap();
 
         // Decode with empty bytes.
-        let result = ExtrinsicDetails::decode_from(
-            1,
-            &vec![],
-            client,
-            H256::random(),
-            Default::default(),
-            ids,
-        );
+        let result =
+            ExtrinsicDetails::decode_from(1, &[], client, H256::random(), Default::default(), ids);
         assert_matches!(result.err(), Some(crate::Error::Codec(_)));
     }
 
@@ -806,7 +800,7 @@ mod tests {
         // Decode with invalid version.
         let result = ExtrinsicDetails::decode_from(
             1,
-            &3u8.encode(),
+            &vec![3u8].encode(),
             client,
             H256::random(),
             Default::default(),
@@ -845,7 +839,7 @@ mod tests {
         // The length is handled deserializing `ChainBlockExtrinsic`, therefore the first byte is not needed.
         let extrinsic = ExtrinsicDetails::decode_from(
             1,
-            tx_encoded.encoded()[1..].into(),
+            tx_encoded.encoded(),
             client,
             H256::random(),
             Default::default(),

--- a/subxt/src/blocks/extrinsic_types.rs
+++ b/subxt/src/blocks/extrinsic_types.rs
@@ -13,11 +13,11 @@ use crate::{
     Metadata,
 };
 
+use crate::utils::strip_compact_prefix;
 use codec::Decode;
 use derivative::Derivative;
 use scale_decode::DecodeAsFields;
 use std::{collections::HashMap, sync::Arc};
-use crate::utils::strip_compact_prefix;
 
 /// Trait to uniquely identify the extrinsic's identity from the runtime metadata.
 ///
@@ -217,7 +217,7 @@ where
         let metadata = client.metadata();
 
         // removing the compact encoded prefix:
-        let bytes: Arc<[u8]> =  strip_compact_prefix(extrinsic_bytes)?.1.into();
+        let bytes: Arc<[u8]> = strip_compact_prefix(extrinsic_bytes)?.1.into();
 
         // Extrinsic are encoded in memory in the following way:
         //   - first byte: abbbbbbb (a = 0 for unsigned, 1 for signed, b = version)

--- a/subxt/src/rpc/types.rs
+++ b/subxt/src/rpc/types.rs
@@ -110,20 +110,8 @@ pub type ConsensusEngineId = [u8; 4];
 pub type EncodedJustification = Vec<u8>;
 
 /// Bytes representing an extrinsic in a [`ChainBlock`].
-#[derive(Clone, Debug)]
-pub struct ChainBlockExtrinsic(pub Vec<u8>);
-
-impl<'a> ::serde::Deserialize<'a> for ChainBlockExtrinsic {
-    fn deserialize<D>(de: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::Deserializer<'a>,
-    {
-        let r = impl_serde::serialize::deserialize(de)?;
-        let bytes = Decode::decode(&mut &r[..])
-            .map_err(|e| ::serde::de::Error::custom(format!("Decode error: {e}")))?;
-        Ok(ChainBlockExtrinsic(bytes))
-    }
-}
+#[derive(Clone, Debug, Deserialize)]
+pub struct ChainBlockExtrinsic(#[serde(with = "impl_serde::serialize")] pub Vec<u8>);
 
 /// Wrapper for NumberOrHex to allow custom From impls
 #[derive(Serialize)]

--- a/subxt/src/tx/tx_progress.rs
+++ b/subxt/src/tx/tx_progress.rs
@@ -389,7 +389,7 @@ impl<T: Config, C: OnlineClientT<T>> TxInBlock<T, C> {
             .iter()
             .position(|ext| {
                 use crate::config::Hasher;
-                let Ok((_,stripped)) = strip_compact_prefix(&ext.0)else {
+                let Ok((_,stripped)) = strip_compact_prefix(&ext.0) else {
                     return false;
                 };
                 let hash = T::Hasher::hash_of(&stripped);

--- a/subxt/src/tx/tx_progress.rs
+++ b/subxt/src/tx/tx_progress.rs
@@ -4,6 +4,7 @@
 
 //! Types representing extrinsics/transactions that have been submitted to a node.
 
+use codec::Decode;
 use std::task::Poll;
 
 use crate::{
@@ -80,7 +81,7 @@ where
                 TxStatus::InBlock(s) | TxStatus::Finalized(s) => return Ok(s),
                 // Error scenarios; return the error.
                 TxStatus::FinalityTimeout(_) => {
-                    return Err(TransactionError::FinalityTimeout.into())
+                    return Err(TransactionError::FinalityTimeout.into());
                 }
                 TxStatus::Invalid => return Err(TransactionError::Invalid.into()),
                 TxStatus::Usurped(_) => return Err(TransactionError::Usurped.into()),
@@ -109,7 +110,7 @@ where
                 TxStatus::Finalized(s) => return Ok(s),
                 // Error scenarios; return the error.
                 TxStatus::FinalityTimeout(_) => {
-                    return Err(TransactionError::FinalityTimeout.into())
+                    return Err(TransactionError::FinalityTimeout.into());
                 }
                 TxStatus::Invalid => return Err(TransactionError::Invalid.into()),
                 TxStatus::Usurped(_) => return Err(TransactionError::Usurped.into()),
@@ -260,7 +261,6 @@ impl<T: Config, C: Clone> Stream for TxProgress<T, C> {
 /// In any of these cases the client side TxProgress stream is also closed.
 /// In those cases the stream is closed however, so you currently have no way to find
 /// out if they finally made it into a block or not.
-
 #[derive(Derivative)]
 #[derivative(Debug(bound = "C: std::fmt::Debug"))]
 pub enum TxStatus<T: Config, C> {
@@ -389,7 +389,10 @@ impl<T: Config, C: OnlineClientT<T>> TxInBlock<T, C> {
             .iter()
             .position(|ext| {
                 use crate::config::Hasher;
-                let hash = T::Hasher::hash_of(&ext.0);
+                let Ok(ext_without_prefix) = <Vec<u8>>::decode(&mut &ext.0[..]) else {
+                    return false;
+                };
+                let hash = T::Hasher::hash_of(&ext_without_prefix);
                 hash == self.ext_hash
             })
             // If we successfully obtain the block hash we think contains our

--- a/subxt/src/tx/tx_progress.rs
+++ b/subxt/src/tx/tx_progress.rs
@@ -6,6 +6,7 @@
 
 use std::task::Poll;
 
+use crate::utils::strip_compact_prefix;
 use crate::{
     client::OnlineClientT,
     error::{DispatchError, Error, RpcError, TransactionError},
@@ -15,7 +16,6 @@ use crate::{
 };
 use derivative::Derivative;
 use futures::{Stream, StreamExt};
-use crate::utils::strip_compact_prefix;
 
 /// This struct represents a subscription to the progress of some transaction.
 #[derive(Derivative)]

--- a/subxt/src/utils/mod.rs
+++ b/subxt/src/utils/mod.rs
@@ -35,7 +35,7 @@ impl codec::Encode for Encoded {
     }
 }
 
-pub(crate) fn strip_compact_prefix(bytes: &[u8]) -> Result<(u64, &[u8]), codec::Error>{
+pub(crate) fn strip_compact_prefix(bytes: &[u8]) -> Result<(u64, &[u8]), codec::Error> {
     let cursor = &mut &*bytes;
     let val = <Compact<u64>>::decode(cursor)?;
     Ok((val.0, *cursor))

--- a/subxt/src/utils/mod.rs
+++ b/subxt/src/utils/mod.rs
@@ -11,7 +11,7 @@ mod multi_signature;
 mod static_type;
 mod wrapper_opaque;
 
-use codec::{Decode, Encode};
+use codec::{Compact, Decode, Encode};
 use derivative::Derivative;
 
 pub use account_id::AccountId32;
@@ -33,6 +33,12 @@ impl codec::Encode for Encoded {
     fn encode(&self) -> Vec<u8> {
         self.0.to_owned()
     }
+}
+
+pub(crate) fn strip_compact_prefix(bytes: &[u8]) -> Result<(u64, &[u8]), codec::Error>{
+    let cursor = &mut &*bytes;
+    let val = <Compact<u64>>::decode(cursor)?;
+    Ok((val.0, *cursor))
 }
 
 /// A version of [`std::marker::PhantomData`] that is also Send and Sync (which is fine

--- a/subxt/src/utils/mod.rs
+++ b/subxt/src/utils/mod.rs
@@ -35,6 +35,8 @@ impl codec::Encode for Encoded {
     }
 }
 
+/// Decodes a compact encoded value from the beginning of the provided bytes,
+/// returning the value and any remaining bytes.
 pub(crate) fn strip_compact_prefix(bytes: &[u8]) -> Result<(u64, &[u8]), codec::Error> {
     let cursor = &mut &*bytes;
     let val = <Compact<u64>>::decode(cursor)?;


### PR DESCRIPTION
fixes #1010.

The scale encoded extrinsic bytes are now only decoded when the `ExtrinsicDetails` are constructed from the raw bytes (so a bit more down the line and not directly in the RPC call).