### PR TITLE
git: Increase light client test timeout to 25 mins

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -169,7 +169,7 @@ jobs:
     nonwasm_light_client_tests:
         name: "Test Light Client"
         runs-on: ubuntu-latest-16-cores
-        timeout-minutes: 15
+        timeout-minutes: 25
         steps:
             - name: Checkout sources
               uses: actions/checkout@v3


### PR DESCRIPTION
This has been filtered as flaky by our CI, increase the timeout to ensure the light client has proper time to sync with the chain and perform the tests. 