### PR TITLE
runtime API: Substitute `UncheckedExtrinsic` with custom encoding

### DIFF
--- a/codegen/src/types/substitutes.rs
+++ b/codegen/src/types/substitutes.rs
@@ -99,6 +99,14 @@ impl TypeSubstitutes {
                 parse_quote!(#crate_path::utils::KeyedVec),
             ),
             (path_segments!(BTreeSet), parse_quote!(::std::vec::Vec)),
+            // The `UncheckedExtrinsic(pub Vec<u8>)` is part of the runtime API calls.
+            // The inner bytes represent the encoded extrinsic, however when deriving the
+            // `EncodeAsType` the bytes would be re-encoded. This leads to the bytes
+            // being altered by adding the length prefix in front of them.
+            (
+                path_segments!(sp_runtime::generic::unchecked_extrinsic::UncheckedExtrinsic),
+                parse_quote!(#crate_path::utils::UncheckedExtrinsic),
+            ),
         ];
 
         let default_substitutes = defaults
@@ -339,7 +347,7 @@ impl<T: scale_info::form::Form> From<&scale_info::Path<T>> for PathSegments {
 /// to = ::subxt::utils::Static<::sp_runtime::MultiAddress<A, B>>
 /// ```
 ///
-/// And we encounter a `sp_runtime::MultiAddress<Foo, bar>`, then we will pass the `::sp_runtime::MultiAddress<A, B>`
+/// And we encounter a `sp_runtime::MultiAddress<Foo, Bar>`, then we will pass the `::sp_runtime::MultiAddress<A, B>`
 /// type param value into this call to turn it into `::sp_runtime::MultiAddress<Foo, Bar>`.
 fn replace_path_params_recursively<I: Borrow<syn::Ident>, P: Borrow<TypePath>>(
     path: &mut syn::Path,

--- a/subxt/src/utils/mod.rs
+++ b/subxt/src/utils/mod.rs
@@ -9,6 +9,7 @@ pub mod bits;
 mod multi_address;
 mod multi_signature;
 mod static_type;
+mod unchecked_extrinsic;
 mod wrapper_opaque;
 
 use codec::{Compact, Decode, Encode};
@@ -18,6 +19,7 @@ pub use account_id::AccountId32;
 pub use multi_address::MultiAddress;
 pub use multi_signature::MultiSignature;
 pub use static_type::Static;
+pub use unchecked_extrinsic::UncheckedExtrinsic;
 pub use wrapper_opaque::WrapperKeepOpaque;
 
 // Used in codegen

--- a/subxt/src/utils/mod.rs
+++ b/subxt/src/utils/mod.rs
@@ -28,7 +28,7 @@ pub use primitive_types::{H160, H256, H512};
 
 /// Wraps an already encoded byte vector, prevents being encoded as a raw byte vector as part of
 /// the transaction payload
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Decode)]
 pub struct Encoded(pub Vec<u8>);
 
 impl codec::Encode for Encoded {

--- a/subxt/src/utils/unchecked_extrinsic.rs
+++ b/subxt/src/utils/unchecked_extrinsic.rs
@@ -114,7 +114,8 @@ pub mod tests {
 
     #[test]
     fn unchecked_extrinsic_encoding() {
-        let tx_bytes = vec![1, 2, 3];
+        // A tx is basically some bytes with a compact length prefix; ie an encoded vec:
+        let tx_bytes = vec![1u8, 2, 3].encode();
 
         let unchecked_extrinsic = UncheckedExtrinsic::<(), (), (), ()>::new(tx_bytes.clone());
         let encoded_tx_bytes = unchecked_extrinsic.encode();
@@ -124,12 +125,12 @@ pub mod tests {
 
         // However, for decoding we expect to be able to read the extrinsic from the wire
         // which would be length prefixed.
-        let wire_bytes = tx_bytes.encode();
-        let decoded_tx =
-            UncheckedExtrinsic::<(), (), (), ()>::decode(&mut &wire_bytes[..]).unwrap();
+        let decoded_tx = UncheckedExtrinsic::<(), (), (), ()>::decode(&mut &tx_bytes[..]).unwrap();
+        let decoded_tx_bytes = decoded_tx.bytes();
         let encoded_tx_bytes = decoded_tx.encode();
 
-        assert_eq!(decoded_tx.bytes(), encoded_tx_bytes);
-        assert_eq!(tx_bytes, encoded_tx_bytes);
+        assert_eq!(decoded_tx_bytes, encoded_tx_bytes);
+        // Ensure we can decode the tx and fetch only the tx bytes.
+        assert_eq!(vec![1, 2, 3], encoded_tx_bytes);
     }
 }

--- a/subxt/src/utils/unchecked_extrinsic.rs
+++ b/subxt/src/utils/unchecked_extrinsic.rs
@@ -1,0 +1,91 @@
+// Copyright 2019-2023 Parity Technologies (UK) Ltd.
+// This file is dual-licensed as Apache-2.0 or GPL-3.0.
+// see LICENSE for license details.
+
+//! The "default" Substrate/Polkadot UncheckedExtrinsic.
+//! This is used in codegen for runtime API calls.
+//!
+//! The inner bytes represent the encoded extrinsic expected by the
+//! runtime APIs. Deriving `EncodeAsType` would lead to the inner
+//! bytes to be re-encoded (length prefixed).
+
+use std::marker::PhantomData;
+
+use codec::Decode;
+use scale_decode::{visitor::DecodeAsTypeResult, IntoVisitor, Visitor};
+
+/// The unchecked extrinsic from substrate.
+#[derive(Clone, Debug, Eq, PartialEq, Decode)]
+pub struct UncheckedExtrinsic<Address, Call, Signature, Extra>(
+    pub Vec<u8>,
+    #[codec(skip)] pub PhantomData<(Address, Call, Signature, Extra)>,
+);
+
+impl<Address, Call, Signature, Extra> codec::Encode
+    for UncheckedExtrinsic<Address, Call, Signature, Extra>
+{
+    fn encode(&self) -> Vec<u8> {
+        self.0.to_owned()
+    }
+}
+
+impl<Address, Call, Signature, Extra> scale_encode::EncodeAsType
+    for UncheckedExtrinsic<Address, Call, Signature, Extra>
+{
+    fn encode_as_type_to(
+        &self,
+        _type_id: u32,
+        _types: &scale_info::PortableRegistry,
+        out: &mut Vec<u8>,
+    ) -> Result<(), scale_encode::Error> {
+        out.extend_from_slice(&self.0);
+        Ok(())
+    }
+}
+
+impl<Address, Call, Signature, Extra> scale_encode::EncodeAsFields
+    for UncheckedExtrinsic<Address, Call, Signature, Extra>
+{
+    fn encode_as_fields_to(
+        &self,
+        _fields: &mut dyn scale_encode::FieldIter<'_>,
+        _types: &scale_info::PortableRegistry,
+        out: &mut Vec<u8>,
+    ) -> Result<(), scale_encode::Error> {
+        out.extend_from_slice(&self.0);
+        Ok(())
+    }
+}
+
+pub struct UncheckedExtrinsicDecodeAsTypeVisitor<Address, Call, Signature, Extra>(
+    PhantomData<(Address, Call, Signature, Extra)>,
+);
+
+impl<Address, Call, Signature, Extra> Visitor
+    for UncheckedExtrinsicDecodeAsTypeVisitor<Address, Call, Signature, Extra>
+{
+    type Value<'scale, 'info> = UncheckedExtrinsic<Address, Call, Signature, Extra>;
+    type Error = scale_decode::Error;
+
+    fn unchecked_decode_as_type<'scale, 'info>(
+        self,
+        input: &mut &'scale [u8],
+        _type_id: scale_decode::visitor::TypeId,
+        _types: &'info scale_info::PortableRegistry,
+    ) -> DecodeAsTypeResult<Self, Result<Self::Value<'scale, 'info>, Self::Error>> {
+        use scale_decode::{visitor::DecodeError, Error};
+        let decoded = UncheckedExtrinsic::decode(input)
+            .map_err(|e| Error::new(DecodeError::CodecError(e).into()));
+        DecodeAsTypeResult::Decoded(decoded)
+    }
+}
+
+impl<Address, Call, Signature, Extra> IntoVisitor
+    for UncheckedExtrinsic<Address, Call, Signature, Extra>
+{
+    type Visitor = UncheckedExtrinsicDecodeAsTypeVisitor<Address, Call, Signature, Extra>;
+
+    fn into_visitor() -> Self::Visitor {
+        UncheckedExtrinsicDecodeAsTypeVisitor(PhantomData)
+    }
+}

--- a/subxt/src/utils/unchecked_extrinsic.rs
+++ b/subxt/src/utils/unchecked_extrinsic.rs
@@ -40,12 +40,11 @@ impl<Address, Call, Signature, Extra> scale_encode::EncodeAsType
 {
     fn encode_as_type_to(
         &self,
-        _type_id: u32,
-        _types: &scale_info::PortableRegistry,
+        type_id: u32,
+        types: &scale_info::PortableRegistry,
         out: &mut Vec<u8>,
     ) -> Result<(), scale_encode::Error> {
-        self.0.encode_to(out);
-        Ok(())
+        self.0.encode_as_type_to(type_id, types, out)
     }
 }
 

--- a/subxt/src/utils/unchecked_extrinsic.rs
+++ b/subxt/src/utils/unchecked_extrinsic.rs
@@ -12,7 +12,7 @@
 use std::marker::PhantomData;
 
 use codec::{Decode, Encode};
-use scale_decode::{visitor::DecodeAsTypeResult, IntoVisitor, Visitor};
+use scale_decode::{visitor::DecodeAsTypeResult, DecodeAsType, IntoVisitor, Visitor};
 
 use super::{Encoded, Static};
 
@@ -78,13 +78,10 @@ impl<Address, Call, Signature, Extra> Visitor
     fn unchecked_decode_as_type<'scale, 'info>(
         self,
         input: &mut &'scale [u8],
-        _type_id: scale_decode::visitor::TypeId,
-        _types: &'info scale_info::PortableRegistry,
+        type_id: scale_decode::visitor::TypeId,
+        types: &'info scale_info::PortableRegistry,
     ) -> DecodeAsTypeResult<Self, Result<Self::Value<'scale, 'info>, Self::Error>> {
-        use scale_decode::{visitor::DecodeError, Error};
-        let decoded = UncheckedExtrinsic::decode(input)
-            .map_err(|e| Error::new(DecodeError::CodecError(e).into()));
-        DecodeAsTypeResult::Decoded(decoded)
+        DecodeAsTypeResult::Decoded(Self::Value::decode_as_type(input, type_id.0, types))
     }
 }
 

--- a/subxt/src/utils/unchecked_extrinsic.rs
+++ b/subxt/src/utils/unchecked_extrinsic.rs
@@ -11,13 +11,13 @@
 
 use std::marker::PhantomData;
 
-use codec::Decode;
+use codec::{Decode, Encode};
 use scale_decode::{visitor::DecodeAsTypeResult, IntoVisitor, Visitor};
 
 use super::{Encoded, Static};
 
 /// The unchecked extrinsic from substrate.
-#[derive(Clone, Debug, Eq, PartialEq, Decode)]
+#[derive(Clone, Debug, Eq, PartialEq, Encode, Decode, scale_encode::EncodeAsType)]
 pub struct UncheckedExtrinsic<Address, Call, Signature, Extra>(
     Static<Encoded>,
     #[codec(skip)] PhantomData<(Address, Call, Signature, Extra)>,
@@ -48,28 +48,6 @@ impl<Address, Call, Signature, Extra> From<UncheckedExtrinsic<Address, Call, Sig
 {
     fn from(bytes: UncheckedExtrinsic<Address, Call, Signature, Extra>) -> Self {
         bytes.0 .0 .0
-    }
-}
-
-impl<Address, Call, Signature, Extra> codec::Encode
-    for UncheckedExtrinsic<Address, Call, Signature, Extra>
-{
-    fn encode_to<T: codec::Output + ?Sized>(&self, dest: &mut T) {
-        dest.write(self.bytes())
-    }
-}
-
-impl<Address, Call, Signature, Extra> scale_encode::EncodeAsType
-    for UncheckedExtrinsic<Address, Call, Signature, Extra>
-{
-    fn encode_as_type_to(
-        &self,
-        _type_id: u32,
-        _types: &scale_info::PortableRegistry,
-        out: &mut Vec<u8>,
-    ) -> Result<(), scale_encode::Error> {
-        out.extend_from_slice(self.bytes());
-        Ok(())
     }
 }
 

--- a/subxt/src/utils/unchecked_extrinsic.rs
+++ b/subxt/src/utils/unchecked_extrinsic.rs
@@ -17,9 +17,37 @@ use scale_decode::{visitor::DecodeAsTypeResult, IntoVisitor, Visitor};
 /// The unchecked extrinsic from substrate.
 #[derive(Clone, Debug, Eq, PartialEq, Decode)]
 pub struct UncheckedExtrinsic<Address, Call, Signature, Extra>(
-    pub Vec<u8>,
-    #[codec(skip)] pub PhantomData<(Address, Call, Signature, Extra)>,
+    Vec<u8>,
+    #[codec(skip)] PhantomData<(Address, Call, Signature, Extra)>,
 );
+
+impl<Address, Call, Signature, Extra> UncheckedExtrinsic<Address, Call, Signature, Extra> {
+    /// Construct a new [`UncheckedExtrinsic`].
+    pub fn new(bytes: Vec<u8>) -> Self {
+        Self(bytes, PhantomData)
+    }
+
+    /// Get the bytes of the encoded extrinsic.
+    pub fn bytes(&self) -> &[u8] {
+        self.0.as_slice()
+    }
+}
+
+impl<Address, Call, Signature, Extra> From<Vec<u8>>
+    for UncheckedExtrinsic<Address, Call, Signature, Extra>
+{
+    fn from(bytes: Vec<u8>) -> Self {
+        UncheckedExtrinsic(bytes, PhantomData)
+    }
+}
+
+impl<Address, Call, Signature, Extra> From<UncheckedExtrinsic<Address, Call, Signature, Extra>>
+    for Vec<u8>
+{
+    fn from(bytes: UncheckedExtrinsic<Address, Call, Signature, Extra>) -> Self {
+        bytes.0
+    }
+}
 
 impl<Address, Call, Signature, Extra> codec::Encode
     for UncheckedExtrinsic<Address, Call, Signature, Extra>

--- a/subxt/src/utils/unchecked_extrinsic.rs
+++ b/subxt/src/utils/unchecked_extrinsic.rs
@@ -17,7 +17,7 @@ use scale_decode::{visitor::DecodeAsTypeResult, DecodeAsType, IntoVisitor, Visit
 use super::{Encoded, Static};
 
 /// The unchecked extrinsic from substrate.
-#[derive(Clone, Debug, Eq, PartialEq, Decode, Encode)]
+#[derive(Clone, Debug, Eq, PartialEq, Encode)]
 pub struct UncheckedExtrinsic<Address, Call, Signature, Extra>(
     Static<Encoded>,
     #[codec(skip)] PhantomData<(Address, Call, Signature, Extra)>,
@@ -32,6 +32,15 @@ impl<Address, Call, Signature, Extra> UncheckedExtrinsic<Address, Call, Signatur
     /// Get the bytes of the encoded extrinsic.
     pub fn bytes(&self) -> &[u8] {
         self.0 .0 .0.as_slice()
+    }
+}
+
+impl<Address, Call, Signature, Extra> Decode
+    for UncheckedExtrinsic<Address, Call, Signature, Extra>
+{
+    fn decode<I: codec::Input>(input: &mut I) -> Result<Self, codec::Error> {
+        let xt_vec: Vec<u8> = Decode::decode(input)?;
+        Ok(UncheckedExtrinsic::new(xt_vec))
     }
 }
 

--- a/subxt/src/utils/unchecked_extrinsic.rs
+++ b/subxt/src/utils/unchecked_extrinsic.rs
@@ -24,8 +24,8 @@ pub struct UncheckedExtrinsic<Address, Call, Signature, Extra>(
 impl<Address, Call, Signature, Extra> codec::Encode
     for UncheckedExtrinsic<Address, Call, Signature, Extra>
 {
-    fn encode(&self) -> Vec<u8> {
-        self.0.to_owned()
+    fn encode_to<T: codec::Output + ?Sized>(&self, dest: &mut T) {
+        dest.write(&self.0)
     }
 }
 

--- a/subxt/src/utils/unchecked_extrinsic.rs
+++ b/subxt/src/utils/unchecked_extrinsic.rs
@@ -39,6 +39,11 @@ impl<Address, Call, Signature, Extra> Decode
     for UncheckedExtrinsic<Address, Call, Signature, Extra>
 {
     fn decode<I: codec::Input>(input: &mut I) -> Result<Self, codec::Error> {
+        // The bytes for an UncheckedExtrinsic are first a compact
+        // encoded length, and then the bytes following. This is the
+        // same encoding as a Vec, so easiest ATM is just to decode 
+        // into that, and then encode the vec bytes to get our extrinsic 
+        // bytes, which we save into an `Encoded` to preserve as-is.
         let xt_vec: Vec<u8> = Decode::decode(input)?;
         Ok(UncheckedExtrinsic::new(xt_vec))
     }

--- a/subxt/src/utils/unchecked_extrinsic.rs
+++ b/subxt/src/utils/unchecked_extrinsic.rs
@@ -41,8 +41,8 @@ impl<Address, Call, Signature, Extra> Decode
     fn decode<I: codec::Input>(input: &mut I) -> Result<Self, codec::Error> {
         // The bytes for an UncheckedExtrinsic are first a compact
         // encoded length, and then the bytes following. This is the
-        // same encoding as a Vec, so easiest ATM is just to decode 
-        // into that, and then encode the vec bytes to get our extrinsic 
+        // same encoding as a Vec, so easiest ATM is just to decode
+        // into that, and then encode the vec bytes to get our extrinsic
         // bytes, which we save into an `Encoded` to preserve as-is.
         let xt_vec: Vec<u8> = Decode::decode(input)?;
         Ok(UncheckedExtrinsic::new(xt_vec))

--- a/subxt/src/utils/unchecked_extrinsic.rs
+++ b/subxt/src/utils/unchecked_extrinsic.rs
@@ -107,3 +107,29 @@ impl<Address, Call, Signature, Extra> IntoVisitor
         UncheckedExtrinsicDecodeAsTypeVisitor(PhantomData)
     }
 }
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+
+    #[test]
+    fn unchecked_extrinsic_encoding() {
+        let tx_bytes = vec![1, 2, 3];
+
+        let unchecked_extrinsic = UncheckedExtrinsic::<(), (), (), ()>::new(tx_bytes.clone());
+        let encoded_tx_bytes = unchecked_extrinsic.encode();
+
+        // The encoded representation must not alter the provided bytes.
+        assert_eq!(tx_bytes, encoded_tx_bytes);
+
+        // However, for decoding we expect to be able to read the extrinsic from the wire
+        // which would be length prefixed.
+        let wire_bytes = tx_bytes.encode();
+        let decoded_tx =
+            UncheckedExtrinsic::<(), (), (), ()>::decode(&mut &wire_bytes[..]).unwrap();
+        let encoded_tx_bytes = decoded_tx.encode();
+
+        assert_eq!(decoded_tx.bytes(), encoded_tx_bytes);
+        assert_eq!(tx_bytes, encoded_tx_bytes);
+    }
+}

--- a/subxt/src/utils/unchecked_extrinsic.rs
+++ b/subxt/src/utils/unchecked_extrinsic.rs
@@ -17,7 +17,7 @@ use scale_decode::{visitor::DecodeAsTypeResult, IntoVisitor, Visitor};
 use super::{Encoded, Static};
 
 /// The unchecked extrinsic from substrate.
-#[derive(Clone, Debug, Eq, PartialEq, Encode, Decode, scale_encode::EncodeAsType)]
+#[derive(Clone, Debug, Eq, PartialEq, Decode, Encode)]
 pub struct UncheckedExtrinsic<Address, Call, Signature, Extra>(
     Static<Encoded>,
     #[codec(skip)] PhantomData<(Address, Call, Signature, Extra)>,
@@ -32,6 +32,20 @@ impl<Address, Call, Signature, Extra> UncheckedExtrinsic<Address, Call, Signatur
     /// Get the bytes of the encoded extrinsic.
     pub fn bytes(&self) -> &[u8] {
         self.0 .0 .0.as_slice()
+    }
+}
+
+impl<Address, Call, Signature, Extra> scale_encode::EncodeAsType
+    for UncheckedExtrinsic<Address, Call, Signature, Extra>
+{
+    fn encode_as_type_to(
+        &self,
+        _type_id: u32,
+        _types: &scale_info::PortableRegistry,
+        out: &mut Vec<u8>,
+    ) -> Result<(), scale_encode::Error> {
+        self.0.encode_to(out);
+        Ok(())
     }
 }
 

--- a/subxt/src/utils/unchecked_extrinsic.rs
+++ b/subxt/src/utils/unchecked_extrinsic.rs
@@ -43,20 +43,6 @@ impl<Address, Call, Signature, Extra> scale_encode::EncodeAsType
     }
 }
 
-impl<Address, Call, Signature, Extra> scale_encode::EncodeAsFields
-    for UncheckedExtrinsic<Address, Call, Signature, Extra>
-{
-    fn encode_as_fields_to(
-        &self,
-        _fields: &mut dyn scale_encode::FieldIter<'_>,
-        _types: &scale_info::PortableRegistry,
-        out: &mut Vec<u8>,
-    ) -> Result<(), scale_encode::Error> {
-        out.extend_from_slice(&self.0);
-        Ok(())
-    }
-}
-
 pub struct UncheckedExtrinsicDecodeAsTypeVisitor<Address, Call, Signature, Extra>(
     PhantomData<(Address, Call, Signature, Extra)>,
 );

--- a/testing/integration-tests/src/full_client/runtime_api/mod.rs
+++ b/testing/integration-tests/src/full_client/runtime_api/mod.rs
@@ -3,6 +3,8 @@
 // see LICENSE for license details.
 
 use crate::{node_runtime, test_context};
+use codec::Encode;
+use core::marker::PhantomData;
 use subxt::utils::AccountId32;
 use subxt_signer::sr25519::dev;
 
@@ -44,6 +46,63 @@ async fn account_nonce() -> Result<(), subxt::Error> {
         .call(runtime_api_call)
         .await?;
     assert_eq!(nonce, 1);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn unchecked_extrinsic_encoding() -> Result<(), subxt::Error> {
+    let ctx = test_context().await;
+    let api = ctx.client();
+
+    let alice = dev::alice();
+    let bob = dev::bob();
+    let bob_address = bob.public_key().to_address();
+
+    // Construct a tx from Alice to Bob.
+    let tx = node_runtime::tx().balances().transfer(bob_address, 10_000);
+
+    let signed_extrinsic = api
+        .tx()
+        .create_signed(&tx, &alice, Default::default())
+        .await
+        .unwrap();
+
+    let tx_bytes = signed_extrinsic.into_encoded();
+    let len = tx_bytes.len() as u32;
+
+    // Manually encode the runtime API call arguments to make a raw call.
+    let mut encoded = tx_bytes.clone();
+    encoded.extend(len.encode());
+
+    let expected_result: node_runtime::runtime_types::pallet_transaction_payment::types::FeeDetails<
+        ::core::primitive::u128,
+    > = api
+        .runtime_api()
+        .at_latest()
+        .await?
+        .call_raw(
+            "TransactionPaymentApi_query_fee_details",
+            Some(encoded.as_ref()),
+        )
+        .await?;
+
+    // Use the generated API to confirm the result with the raw call.
+    let runtime_api_call = node_runtime::apis()
+        .transaction_payment_api()
+        .query_fee_details(
+            subxt::utils::UncheckedExtrinsic(tx_bytes, PhantomData),
+            len.into(),
+        );
+
+    let result = api
+        .runtime_api()
+        .at_latest()
+        .await?
+        .call(runtime_api_call)
+        .await?;
+
+    assert_eq!(expected_result, result);
 
     Ok(())
 }

--- a/testing/integration-tests/src/full_client/runtime_api/mod.rs
+++ b/testing/integration-tests/src/full_client/runtime_api/mod.rs
@@ -90,10 +90,7 @@ async fn unchecked_extrinsic_encoding() -> Result<(), subxt::Error> {
     // Use the generated API to confirm the result with the raw call.
     let runtime_api_call = node_runtime::apis()
         .transaction_payment_api()
-        .query_fee_details(
-            subxt::utils::UncheckedExtrinsic(tx_bytes, PhantomData),
-            len.into(),
-        );
+        .query_fee_details(subxt::utils::UncheckedExtrinsic(tx_bytes, PhantomData), len);
 
     let result = api
         .runtime_api()

--- a/testing/integration-tests/src/full_client/runtime_api/mod.rs
+++ b/testing/integration-tests/src/full_client/runtime_api/mod.rs
@@ -4,7 +4,6 @@
 
 use crate::{node_runtime, test_context};
 use codec::Encode;
-use core::marker::PhantomData;
 use subxt::utils::AccountId32;
 use subxt_signer::sr25519::dev;
 

--- a/testing/integration-tests/src/full_client/runtime_api/mod.rs
+++ b/testing/integration-tests/src/full_client/runtime_api/mod.rs
@@ -90,7 +90,7 @@ async fn unchecked_extrinsic_encoding() -> Result<(), subxt::Error> {
     // Use the generated API to confirm the result with the raw call.
     let runtime_api_call = node_runtime::apis()
         .transaction_payment_api()
-        .query_fee_details(subxt::utils::UncheckedExtrinsic(tx_bytes, PhantomData), len);
+        .query_fee_details(tx_bytes.into(), len);
 
     let result = api
         .runtime_api()


### PR DESCRIPTION
The `substrate::UncheckedExtrinsic` type is substituted in codgen with a local type that implements custom encoding.

The old `UncheckedExtrinsic(pub Vec<u8>)` would re-encode the inner bytes of the extrinsic leading to a length prefix byte. This payload is then rejected by substrate WASM code, since the `TransactionPaymentApi` expects the bytes without the length prefix.

The following type was generated by the codegen:

```rust
pub struct UncheckedExtrinsic<_0, _1, _2, _3>(
    pub ::std::vec::Vec<::core::primitive::u8>,
    #[codec(skip)] pub ::core::marker::PhantomData<(_1, _0, _2, _3)>,
);
```

The type could not be passed to the runtime API because the encoding would expect only a sequence of data.
In contrast, this type is deduced to be a tuple. 

```bash
Error: Encode(Error { context: Context { path: [Location { inner: Field("uxt") }] }, kind: WrongShape { actual: Tuple, expected: 13 } })
```

- Add a new type for `UncheckedExtrinsic` that is capable of passing through the provided bytes without any further encoding
- Substitute `substrate::UncheckedExtrinsic` with our custom `UncheckedExtrinsic`
- Validate a raw runtime API call with the statically generated API from codegen

Closes: https://github.com/paritytech/substrate/issues/14584
