### PR TITLE
codegen: Fetch and decode metadata version then fallback

### DIFF
--- a/cli/src/commands/codegen.rs
+++ b/cli/src/commands/codegen.rs
@@ -6,7 +6,7 @@ use crate::utils::FileOrUrl;
 use clap::Parser as ClapParser;
 use color_eyre::eyre;
 use color_eyre::eyre::eyre;
-use subxt_codegen::{DerivesRegistry, TypeSubstitutes, TypeSubstitutionError};
+use subxt_codegen::{DerivesRegistry, GenerateRuntimeApi, TypeSubstitutes, TypeSubstitutionError};
 
 /// Generate runtime API client code from metadata.
 ///

--- a/cli/src/commands/codegen.rs
+++ b/cli/src/commands/codegen.rs
@@ -185,16 +185,14 @@ fn codegen(
     }
 
     let should_gen_docs = !no_docs;
-    let runtime_api = subxt_codegen::generate_runtime_api_from_bytes(
-        item_mod,
-        metadata_bytes,
-        derives,
-        type_substitutes,
-        crate_path,
-        should_gen_docs,
-        runtime_types_only,
-    )
-    .map_err(|code_gen_err| eyre!("{code_gen_err}"))?;
+
+    let runtime_api = GenerateRuntimeApi::new(item_mod, crate_path)
+        .derives_registry(derives)
+        .type_substitutes(type_substitutes)
+        .generate_docs(should_gen_docs)
+        .runtime_types_only(runtime_types_only)
+        .generate_from_bytes(metadata_bytes)
+        .map_err(|code_gen_err| eyre!("{code_gen_err}"))?;
     writeln!(output, "{runtime_api}")?;
     Ok(())
 }

--- a/codegen/src/api/mod.rs
+++ b/codegen/src/api/mod.rs
@@ -28,140 +28,155 @@ use quote::{format_ident, quote};
 use std::{collections::HashMap, fs, io::Read, path, string::ToString};
 use syn::parse_quote;
 
-/// Generates the API for interacting with a Substrate runtime.
-///
-/// # Arguments
-///
-/// * `item_mod` - The module declaration for which the API is implemented.
-/// * `path` - The path to the scale encoded metadata of the runtime node.
-/// * `derives` - Provide custom derives for the generated types.
-/// * `type_substitutes` - Provide custom type substitutes.
-/// * `crate_path` - Path to the `subxt` crate.
-/// * `should_gen_docs` - True if the generated API contains the documentation from the metadata.
-/// * `runtime_types_only` - Whether to limit code generation to only runtime types.
-///
-/// **Note:** This is a wrapper over [RuntimeGenerator] for static metadata use-cases.
-pub fn generate_runtime_api_from_path<P>(
+/// Generate the runtime API for interacting with a substrate runtime.
+pub struct GenerateRuntimeApi {
     item_mod: syn::ItemMod,
-    path: P,
-    derives: DerivesRegistry,
-    type_substitutes: TypeSubstitutes,
-    crate_path: CratePath,
-    should_gen_docs: bool,
-    runtime_types_only: bool,
-) -> Result<TokenStream2, CodegenError>
-where
-    P: AsRef<path::Path>,
-{
-    let to_err = |err| CodegenError::Io(path.as_ref().to_string_lossy().into(), err);
-
-    let mut file = fs::File::open(&path).map_err(to_err)?;
-    let mut bytes = Vec::new();
-    file.read_to_end(&mut bytes).map_err(to_err)?;
-
-    generate_runtime_api_from_bytes(
-        item_mod,
-        &bytes,
-        derives,
-        type_substitutes,
-        crate_path,
-        should_gen_docs,
-        runtime_types_only,
-    )
-}
-
-/// Generates the API for interacting with a substrate runtime, using metadata
-/// that can be downloaded from a node at the provided URL. This function blocks
-/// while retrieving the metadata.
-///
-/// # Arguments
-///
-/// * `item_mod` - The module declaration for which the API is implemented.
-/// * `url` - HTTP/WS URL to the substrate node you'd like to pull metadata from.
-/// * `derives` - Provide custom derives for the generated types.
-/// * `type_substitutes` - Provide custom type substitutes.
-/// * `crate_path` - Path to the `subxt` crate.
-/// * `should_gen_docs` - True if the generated API contains the documentation from the metadata.
-/// * `runtime_types_only` - Whether to limit code generation to only runtime types.
-/// * `unstable_metadata` - Whether to fetch the unstable metadata first.
-///
-/// **Note:** This is a wrapper over [RuntimeGenerator] for static metadata use-cases.
-pub fn generate_runtime_api_from_url(
-    item_mod: syn::ItemMod,
-    url: &Uri,
     derives: DerivesRegistry,
     type_substitutes: TypeSubstitutes,
     crate_path: CratePath,
     should_gen_docs: bool,
     runtime_types_only: bool,
     unstable_metadata: bool,
-) -> Result<TokenStream2, CodegenError> {
-    fn fetch_metadata(url: &Uri, version: MetadataVersion) -> Result<Metadata, CodegenError> {
-        let bytes = fetch_metadata_bytes_blocking(url, version)?;
-        Ok(Metadata::decode(&mut &bytes[..])?)
+}
+
+impl GenerateRuntimeApi {
+    /// Construct a new [`GenerateRuntimeApi`].
+    pub fn new(item_mod: syn::ItemMod, crate_path: CratePath) -> Self {
+        GenerateRuntimeApi {
+            item_mod,
+            derives: DerivesRegistry::new(),
+            type_substitutes: TypeSubstitutes::new(),
+            crate_path,
+            should_gen_docs: false,
+            runtime_types_only: false,
+            unstable_metadata: false,
+        }
     }
 
-    let metadata = unstable_metadata
-        .then(|| fetch_metadata(url, MetadataVersion::Unstable).ok())
-        .flatten();
+    /// Provide custom derives for the generated types.
+    ///
+    /// Default is no derives.
+    pub fn derives_registry(mut self, derives: DerivesRegistry) -> Self {
+        self.derives = derives;
+        self
+    }
 
-    let metadata = if let Some(unstable) = metadata {
-        unstable
-    } else {
-        match fetch_metadata(url, MetadataVersion::Version(15)) {
-            Ok(metadata) => metadata,
-            Err(_) => fetch_metadata(url, MetadataVersion::Version(14))?,
+    /// Provide custom type substitutes.
+    ///
+    /// Default is no substitutes.
+    pub fn type_substitutes(mut self, type_substitutes: TypeSubstitutes) -> Self {
+        self.type_substitutes = type_substitutes;
+        self
+    }
+
+    /// True if the generated API contains the documentation from the metadata.
+    ///
+    /// Default: false.
+    pub fn generate_docs(mut self, should_gen_docs: bool) -> Self {
+        self.should_gen_docs = should_gen_docs;
+        self
+    }
+
+    /// Whether to limit code generation to only runtime types.
+    ///
+    /// Default: false.
+    pub fn runtime_types_only(mut self, runtime_types_only: bool) -> Self {
+        self.runtime_types_only = runtime_types_only;
+        self
+    }
+
+    /// Whether to fetch the unstable metadata first.
+    ///
+    /// # Note
+    ///
+    /// This takes effect only if the API is generated from URL.
+    ///
+    /// Default: false.
+    pub fn unstable_metadata(mut self, unstable_metadata: bool) -> Self {
+        self.unstable_metadata = unstable_metadata;
+        self
+    }
+
+    /// Generate the runtime API from path.
+    pub fn generate_from_path<P>(self, path: P) -> Result<TokenStream2, CodegenError>
+    where
+        P: AsRef<path::Path>,
+    {
+        let to_err = |err| CodegenError::Io(path.as_ref().to_string_lossy().into(), err);
+
+        let mut file = fs::File::open(&path).map_err(to_err)?;
+        let mut bytes = Vec::new();
+        file.read_to_end(&mut bytes).map_err(to_err)?;
+
+        let metadata = Metadata::decode(&mut &bytes[..])?;
+
+        generate_runtime_api_with_metadata(
+            self.item_mod,
+            metadata,
+            self.derives,
+            self.type_substitutes,
+            self.crate_path,
+            self.should_gen_docs,
+            self.runtime_types_only,
+        )
+    }
+
+    /// Generate the runtime API from the provided metadata bytes.
+    pub fn generate_from_bytes(self, bytes: &[u8]) -> Result<TokenStream2, CodegenError> {
+        let metadata = Metadata::decode(&mut &bytes[..])?;
+
+        generate_runtime_api_with_metadata(
+            self.item_mod,
+            metadata,
+            self.derives,
+            self.type_substitutes,
+            self.crate_path,
+            self.should_gen_docs,
+            self.runtime_types_only,
+        )
+    }
+
+    /// Generate the runtime API from URL.
+    ///
+    /// The metadata will be downloaded from a node at the provided URL.
+    /// This function blocks while retrieving the metadata.
+    ///
+    /// # Warning
+    ///
+    /// Not recommended to be used in production environments.
+    pub fn generate_from_url(self, url: &Uri) -> Result<TokenStream2, CodegenError> {
+        fn fetch_metadata(url: &Uri, version: MetadataVersion) -> Result<Metadata, CodegenError> {
+            let bytes = fetch_metadata_bytes_blocking(url, version)?;
+            Ok(Metadata::decode(&mut &bytes[..])?)
         }
-    };
 
-    generate_runtime_api_with_metadata(
-        item_mod,
-        metadata,
-        derives,
-        type_substitutes,
-        crate_path,
-        should_gen_docs,
-        runtime_types_only,
-    )
+        let metadata = self
+            .unstable_metadata
+            .then(|| fetch_metadata(url, MetadataVersion::Unstable).ok())
+            .flatten();
+
+        let metadata = if let Some(unstable) = metadata {
+            unstable
+        } else {
+            match fetch_metadata(url, MetadataVersion::Version(15)) {
+                Ok(metadata) => metadata,
+                Err(_) => fetch_metadata(url, MetadataVersion::Version(14))?,
+            }
+        };
+
+        generate_runtime_api_with_metadata(
+            self.item_mod,
+            metadata,
+            self.derives,
+            self.type_substitutes,
+            self.crate_path,
+            self.should_gen_docs,
+            self.runtime_types_only,
+        )
+    }
 }
 
-/// Generates the API for interacting with a substrate runtime, using metadata bytes.
-///
-/// # Arguments
-///
-/// * `item_mod` - The module declaration for which the API is implemented.
-/// * `bytes` - The raw metadata bytes.
-/// * `derives` - Provide custom derives for the generated types.
-/// * `type_substitutes` - Provide custom type substitutes.
-/// * `crate_path` - Path to the `subxt` crate.
-/// * `should_gen_docs` - True if the generated API contains the documentation from the metadata.
-/// * `runtime_types_only` - Whether to limit code generation to only runtime types.
-///
-/// **Note:** This is a wrapper over [RuntimeGenerator] for static metadata use-cases.
-pub fn generate_runtime_api_from_bytes(
-    item_mod: syn::ItemMod,
-    bytes: &[u8],
-    derives: DerivesRegistry,
-    type_substitutes: TypeSubstitutes,
-    crate_path: CratePath,
-    should_gen_docs: bool,
-    runtime_types_only: bool,
-) -> Result<TokenStream2, CodegenError> {
-    let metadata = Metadata::decode(&mut &bytes[..])?;
-
-    generate_runtime_api_with_metadata(
-        item_mod,
-        metadata,
-        derives,
-        type_substitutes,
-        crate_path,
-        should_gen_docs,
-        runtime_types_only,
-    )
-}
-
-/// Similar to [`generate_runtime_api_from_bytes`] that works with decoded `subxt::Metadata` instead
-/// of raw bytes.
+/// Generates the API for interacting with a substrate runtime, using the `subxt::Metadata`.
 fn generate_runtime_api_with_metadata(
     item_mod: syn::ItemMod,
     metadata: Metadata,
@@ -200,8 +215,7 @@ impl RuntimeGenerator {
     /// Create a new runtime generator from the provided metadata.
     ///
     /// **Note:** If you have the metadata path, URL or bytes to hand, prefer to use
-    /// one of the `generate_runtime_api_from_*` functions for generating the runtime API
-    /// from that.
+    /// `GenerateRuntimeApi` for generating the runtime API from that.
     ///
     /// # Panics
     ///

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -53,10 +53,7 @@ mod types;
 pub mod utils;
 
 pub use self::{
-    api::{
-        generate_runtime_api_from_bytes, generate_runtime_api_from_path,
-        generate_runtime_api_from_url, RuntimeGenerator,
-    },
+    api::{GenerateRuntimeApi, RuntimeGenerator},
     error::{CodegenError, TypeSubstitutionError},
     types::{CratePath, Derives, DerivesRegistry, Module, TypeGenerator, TypeSubstitutes},
 };

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -147,7 +147,7 @@ pub fn subxt(args: TokenStream, input: TokenStream) -> TokenStream {
         (Some(rest_of_path), None) => {
             if unstable_metadata {
                 abort_call_site!(
-                    "The 'unstable_metadata' is expected only for `runtime_metadata_url`"
+                    "The 'unstable_metadata' attribute requires `runtime_metadata_url`"
                 )
             }
 

--- a/subxt/src/lib.rs
+++ b/subxt/src/lib.rs
@@ -298,9 +298,9 @@ pub mod ext {
 /// ## `unstable_metadata`
 ///
 /// This attribute works only in combination with `runtime_metadata_url`. By default, the macro will fetch the latest stable
-/// version of the metadata from the target node. This attribute makes the codegen fetch the unstable version of the metadata.
-/// This can be useful in CI, but is **not recommended** in production code, since it runs at compile time and will cause
-/// compilation to fail if the node at the given address is unavailable or unresponsive.
+/// version of the metadata from the target node. This attribute makes the codegen attempt to fetch the unstable version of 
+/// the metadata first. This is **not recommended** in production code, since the unstable metadata a node is providing is likely 
+/// to be incompatible with Subxt.
 ///
 /// ```rust,no_run
 /// #[subxt::subxt(

--- a/subxt/src/lib.rs
+++ b/subxt/src/lib.rs
@@ -279,6 +279,7 @@ pub mod ext {
 /// )]
 /// mod polkadot {}
 /// ```
+///
 /// ## `no_default_derives`
 ///
 /// By default, the macro will add all derives necessary for the generated code to play nicely with Subxt. Adding this attribute
@@ -290,6 +291,21 @@ pub mod ext {
 ///     runtime_types_only,
 ///     no_default_derives,
 ///     derive_for_all_types="codec::Encode, codec::Decode"
+/// )]
+/// mod polkadot {}
+/// ```
+///
+/// ## `unstable_metadata`
+///
+/// This attribute works only in combination with `runtime_metadata_url`. By default, the macro will fetch the latest stable
+/// version of the metadata from the target node. This attribute makes the codegen fetch the unstable version of the metadata.
+/// This can be useful in CI, but is **not recommended** in production code, since it runs at compile time and will cause
+/// compilation to fail if the node at the given address is unavailable or unresponsive.
+///
+/// ```rust,no_run
+/// #[subxt::subxt(
+///     runtime_metadata_url = "wss://rpc.polkadot.io:443"
+///     unstable_metadata,
 /// )]
 /// mod polkadot {}
 /// ```

--- a/subxt/src/lib.rs
+++ b/subxt/src/lib.rs
@@ -295,11 +295,16 @@ pub mod ext {
 /// mod polkadot {}
 /// ```
 ///
+/// **Note**: At the moment, you must derive at least one of `codec::Encode` or `codec::Decode` or `scale_encode::EncodeAsType` or
+/// `scale_decode::DecodeAsType` (because we add `#[codec(..)]` attributes on some fields/types during codegen), and you must use this
+/// feature in conjunction with `runtime_types_only` (or manually specify a bunch of defaults to make codegen work properly when
+/// generating the subxt interfaces).
+///
 /// ## `unstable_metadata`
 ///
 /// This attribute works only in combination with `runtime_metadata_url`. By default, the macro will fetch the latest stable
-/// version of the metadata from the target node. This attribute makes the codegen attempt to fetch the unstable version of 
-/// the metadata first. This is **not recommended** in production code, since the unstable metadata a node is providing is likely 
+/// version of the metadata from the target node. This attribute makes the codegen attempt to fetch the unstable version of
+/// the metadata first. This is **not recommended** in production code, since the unstable metadata a node is providing is likely
 /// to be incompatible with Subxt.
 ///
 /// ```rust,no_run
@@ -309,9 +314,4 @@ pub mod ext {
 /// )]
 /// mod polkadot {}
 /// ```
-///
-/// **Note**: At the moment, you must derive at least one of `codec::Encode` or `codec::Decode` or `scale_encode::EncodeAsType` or
-/// `scale_decode::DecodeAsType` (because we add `#[codec(..)]` attributes on some fields/types during codegen), and you must use this
-/// feature in conjunction with `runtime_types_only` (or manually specify a bunch of defaults to make codegen work properly when
-/// generating the subxt interfaces).
 pub use subxt_macro::subxt;

--- a/subxt/src/lib.rs
+++ b/subxt/src/lib.rs
@@ -304,8 +304,8 @@ pub mod ext {
 ///
 /// ```rust,no_run
 /// #[subxt::subxt(
-///     runtime_metadata_url = "wss://rpc.polkadot.io:443"
-///     unstable_metadata,
+///     runtime_metadata_url = "wss://rpc.polkadot.io:443",
+///     unstable_metadata
 /// )]
 /// mod polkadot {}
 /// ```


### PR DESCRIPTION
The https://github.com/paritytech/subxt/issues/1091 exposed an error on out-of-date chains in terms of metadata with the latest substrate.

The code could fetch the latest unstable metadata, but that metadata version would fail to decode.
Failing to decode the metadata is a terminal error in our codegen.

To mitigate this behavior, the codegen would fetch and decode the metadata, the fallback on fetching older versions if that fails.

The order of fetching operations:
1. Unstable if the `unstable-metadata` attribute is provided
3. V15
4. V14

This is a bit overkill but hopefully would continue to work fine with fallbacks always on stable v15 and v14.

Closes: https://github.com/paritytech/subxt/issues/1091