### PR TITLE
Prep for 0.30.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.30.1] - 2023-07-25
+
+This patch release fixes a small issue whereby using `runtime_metadata_url` in the Subxt macro would still attempt to download unstable metadata, which can fail at the moment if the chain has not updated to stable V15 metadata yet (which has a couple of changes from the last unstable version). Note that you're generally encouraged to use `runtime_metadata_path` instead, which does not have this issue.
+
+### Fixes
+
+- codegen: Fetch and decode metadata version then fallback ([#1092](https://github.com/paritytech/subxt/pull/1092))
+
+
 ## [0.30.0] - 2023-07-24
 
 This release beings with it a number of exciting additions. Let's cover a few of the most significant ones:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1976,7 +1976,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "assert_matches",
  "frame-metadata 16.0.0",
@@ -4199,7 +4199,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-runner"
-version = "0.30.0"
+version = "0.30.1"
 
 [[package]]
 name = "subtle"
@@ -4215,7 +4215,7 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "subxt"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "assert_matches",
  "base58",
@@ -4256,7 +4256,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-cli"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "clap 4.3.19",
  "color-eyre",
@@ -4277,7 +4277,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-codegen"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "bitvec",
  "frame-metadata 16.0.0",
@@ -4297,7 +4297,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-lightclient"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "either",
  "futures",
@@ -4323,7 +4323,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "darling 0.20.3",
  "proc-macro-error",
@@ -4333,7 +4333,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-metadata"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "assert_matches",
  "bitvec",
@@ -4347,7 +4347,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-signer"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "bip39",
  "getrandom 0.2.10",
@@ -4413,7 +4413,7 @@ dependencies = [
 
 [[package]]
 name = "test-runtime"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "hex",
  "impl-serde",
@@ -4787,7 +4787,7 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "ui-tests"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "frame-metadata 16.0.0",
  "parity-scale-codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ resolver = "2"
 [workspace.package]
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
-version = "0.30.0"
+version = "0.30.1"
 rust-version = "1.64.0"
 license = "Apache-2.0 OR GPL-3.0"
 repository = "https://github.com/paritytech/subxt"
@@ -103,12 +103,12 @@ sp-keyring = "24.0.0"
 sp-version = "22.0.0"
 
 # Subxt workspace crates:
-subxt = { version = "0.30.0", path = "subxt", default-features = false }
-subxt-macro = { version = "0.30.0", path = "macro" }
-subxt-metadata = { version = "0.30.0", path = "metadata" }
-subxt-codegen = { version = "0.30.0", path = "codegen" }
-subxt-signer = { version = "0.30.0", path = "signer" }
-subxt-lightclient = { version = "0.30.0", path = "lightclient", default-features = false }
+subxt = { version = "0.30.1", path = "subxt", default-features = false }
+subxt-macro = { version = "0.30.1", path = "macro" }
+subxt-metadata = { version = "0.30.1", path = "metadata" }
+subxt-codegen = { version = "0.30.1", path = "codegen" }
+subxt-signer = { version = "0.30.1", path = "signer" }
+subxt-lightclient = { version = "0.30.1", path = "lightclient", default-features = false }
 test-runtime = { path = "testing/test-runtime" }
 substrate-runner = { path = "testing/substrate-runner" }
 


### PR DESCRIPTION
This patch release fixes a small issue whereby using `runtime_metadata_url` in the Subxt macro would still attempt to download unstable metadata, which can fail at the moment if the chain has not updated to stable V15 metadata yet (which has a couple of changes from the last unstable version). Note that you're generally encouraged to use `runtime_metadata_path` instead, which does not have this issue.