### PR TITLE
Tests: support 'substrate-node' too and allow multiple binary paths

### DIFF
--- a/testing/integration-tests/src/utils/node_proc.rs
+++ b/testing/integration-tests/src/utils/node_proc.rs
@@ -76,7 +76,7 @@ impl TestNodeProcessBuilder {
     {
         let mut node_builder = SubstrateNode::builder();
 
-        node_builder.binary_path(self.node_path);
+        node_builder.binary_paths(&[self.node_path]);
 
         if let Some(authority) = &self.authority {
             node_builder.arg(authority.to_lowercase());

--- a/testing/substrate-runner/src/lib.rs
+++ b/testing/substrate-runner/src/lib.rs
@@ -8,7 +8,7 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::ffi::OsString;
 use std::io::{self, BufRead, BufReader, Read};
-use std::process::{self, Command, Child};
+use std::process::{self, Child, Command};
 
 pub use error::Error;
 
@@ -38,9 +38,8 @@ impl SubstrateNodeBuilder {
     /// or "substrate".
     pub fn binary_paths<Paths, S>(&mut self, paths: Paths) -> &mut Self
     where
-        Paths: IntoIterator<Item=S>,
-        S: Into<OsString>
-
+        Paths: IntoIterator<Item = S>,
+        S: Into<OsString>,
     {
         self.binary_paths = paths.into_iter().map(|p| p.into()).collect();
         self
@@ -62,17 +61,20 @@ impl SubstrateNodeBuilder {
     pub fn spawn(self) -> Result<SubstrateNode, Error> {
         // Try to spawn the binary at each path, returning the
         // first "ok" or last error that we encountered.
-        let mut res = Err(io::Error::new(io::ErrorKind::Other, "No binary path provided"));
+        let mut res = Err(io::Error::new(
+            io::ErrorKind::Other,
+            "No binary path provided",
+        ));
         for binary_path in &self.binary_paths {
             res = SubstrateNodeBuilder::try_spawn(binary_path, &self.custom_flags);
             if res.is_ok() {
-                break
+                break;
             }
         }
 
         let mut proc = match res {
             Ok(proc) => proc,
-            Err(e) => return Err(Error::Io(e))
+            Err(e) => return Err(Error::Io(e)),
         };
 
         // Wait for RPC port to be logged (it's logged to stderr).
@@ -92,7 +94,10 @@ impl SubstrateNodeBuilder {
     }
 
     // Attempt to spawn a binary with the path/flags given.
-    fn try_spawn(binary_path: &OsString, custom_flags: &HashMap<CowStr, Option<CowStr>>) -> Result<Child, std::io::Error> {
+    fn try_spawn(
+        binary_path: &OsString,
+        custom_flags: &HashMap<CowStr, Option<CowStr>>,
+    ) -> Result<Child, std::io::Error> {
         let mut cmd = Command::new(binary_path);
 
         cmd.env("RUST_LOG", "info,libp2p_tcp=debug")

--- a/testing/substrate-runner/src/lib.rs
+++ b/testing/substrate-runner/src/lib.rs
@@ -7,15 +7,15 @@ mod error;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::ffi::OsString;
-use std::io::{BufRead, BufReader, Read};
-use std::process::{self, Command};
+use std::io::{self, BufRead, BufReader, Read};
+use std::process::{self, Command, Child};
 
 pub use error::Error;
 
 type CowStr = Cow<'static, str>;
 
 pub struct SubstrateNodeBuilder {
-    binary_path: OsString,
+    binary_paths: Vec<OsString>,
     custom_flags: HashMap<CowStr, Option<CowStr>>,
 }
 
@@ -29,14 +29,20 @@ impl SubstrateNodeBuilder {
     /// Configure a new Substrate node.
     pub fn new() -> Self {
         SubstrateNodeBuilder {
-            binary_path: "substrate".into(),
+            binary_paths: vec!["substrate-node".into(), "substrate".into()],
             custom_flags: Default::default(),
         }
     }
 
-    /// Set the path to the `substrate` binary; defaults to "substrate".
-    pub fn binary_path(&mut self, path: impl Into<OsString>) -> &mut Self {
-        self.binary_path = path.into();
+    /// Set the path to the `substrate` binary; defaults to "substrate-node"
+    /// or "substrate".
+    pub fn binary_paths<Paths, S>(&mut self, paths: Paths) -> &mut Self
+    where
+        Paths: IntoIterator<Item=S>,
+        S: Into<OsString>
+
+    {
+        self.binary_paths = paths.into_iter().map(|p| p.into()).collect();
         self
     }
 
@@ -54,23 +60,20 @@ impl SubstrateNodeBuilder {
 
     /// Spawn the node, handing back an object which, when dropped, will stop it.
     pub fn spawn(self) -> Result<SubstrateNode, Error> {
-        let mut cmd = Command::new(self.binary_path);
-
-        cmd.env("RUST_LOG", "info,libp2p_tcp=debug")
-            .stdout(process::Stdio::piped())
-            .stderr(process::Stdio::piped())
-            .arg("--dev")
-            .arg("--port=0");
-
-        for (key, val) in self.custom_flags {
-            let arg = match val {
-                Some(val) => format!("--{key}={val}"),
-                None => format!("--{key}"),
-            };
-            cmd.arg(arg);
+        // Try to spawn the binary at each path, returning the
+        // first "ok" or last error that we encountered.
+        let mut res = Err(io::Error::new(io::ErrorKind::Other, "No binary path provided"));
+        for binary_path in &self.binary_paths {
+            res = SubstrateNodeBuilder::try_spawn(binary_path, &self.custom_flags);
+            if res.is_ok() {
+                break
+            }
         }
 
-        let mut proc = cmd.spawn().map_err(Error::Io)?;
+        let mut proc = match res {
+            Ok(proc) => proc,
+            Err(e) => return Err(Error::Io(e))
+        };
 
         // Wait for RPC port to be logged (it's logged to stderr).
         let stderr = proc.stderr.take().unwrap();
@@ -86,6 +89,27 @@ impl SubstrateNodeBuilder {
             p2p_address,
             p2p_port,
         })
+    }
+
+    // Attempt to spawn a binary with the path/flags given.
+    fn try_spawn(binary_path: &OsString, custom_flags: &HashMap<CowStr, Option<CowStr>>) -> Result<Child, std::io::Error> {
+        let mut cmd = Command::new(binary_path);
+
+        cmd.env("RUST_LOG", "info,libp2p_tcp=debug")
+            .stdout(process::Stdio::piped())
+            .stderr(process::Stdio::piped())
+            .arg("--dev")
+            .arg("--port=0");
+
+        for (key, val) in custom_flags {
+            let arg = match val {
+                Some(val) => format!("--{key}={val}"),
+                None => format!("--{key}"),
+            };
+            cmd.arg(arg);
+        }
+
+        cmd.spawn()
     }
 }
 

--- a/testing/test-runtime/build.rs
+++ b/testing/test-runtime/build.rs
@@ -18,7 +18,7 @@ async fn run() {
     // Select substrate binary to run based on env var.
     let substrate_bins: String =
         env::var(SUBSTRATE_BIN_ENV_VAR).unwrap_or_else(|_| "substrate-node,substrate".to_owned());
-    let substrate_bins_vec: Vec<&str> = substrate_bins.split(",").map(|s| s.trim()).collect();
+    let substrate_bins_vec: Vec<&str> = substrate_bins.split(',').map(|s| s.trim()).collect();
 
     let mut node_builder = SubstrateNode::builder();
     node_builder.binary_paths(substrate_bins_vec.iter());

--- a/testing/test-runtime/build.rs
+++ b/testing/test-runtime/build.rs
@@ -16,12 +16,9 @@ async fn main() {
 
 async fn run() {
     // Select substrate binary to run based on env var.
-    let substrate_bins: String = env::var(SUBSTRATE_BIN_ENV_VAR)
-        .unwrap_or_else(|_| "substrate-node,substrate".to_owned());
-    let substrate_bins_vec: Vec<&str> = substrate_bins
-        .split(",")
-        .map(|s| s.trim())
-        .collect();
+    let substrate_bins: String =
+        env::var(SUBSTRATE_BIN_ENV_VAR).unwrap_or_else(|_| "substrate-node,substrate".to_owned());
+    let substrate_bins_vec: Vec<&str> = substrate_bins.split(",").map(|s| s.trim()).collect();
 
     let mut node_builder = SubstrateNode::builder();
     node_builder.binary_paths(substrate_bins_vec.iter());
@@ -93,10 +90,7 @@ async fn run() {
         };
 
         // Re-build if the substrate binary we're pointed to changes (mtime):
-        println!(
-            "cargo:rerun-if-changed={}",
-            full_path.to_string_lossy()
-        );
+        println!("cargo:rerun-if-changed={}", full_path.to_string_lossy());
     }
 
     // Re-build if we point to a different substrate binary:


### PR DESCRIPTION
Support passing multiple binary paths, and default to trying `substrate-node` and then `substrate`.

Closes #1095