### PR TITLE
Bump to latest scale-encode/decode/value and fix test running

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,11 +21,11 @@ jobs:
 
       - name: Download Substrate
         run: |
-            curl $SUBSTRATE_URL --output substrate --location
-            chmod +x substrate
-            ./substrate --version
+            curl $SUBSTRATE_URL --output substrate-node --location
+            chmod +x substrate-node
+            ./substrate-node --version
             mkdir -p ~/.local/bin
-            mv substrate ~/.local/bin
+            mv substrate-node ~/.local/bin
 
       - name: Install Rust stable toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,11 +33,11 @@ jobs:
 
             - name: Download Substrate
               run: |
-                  curl $SUBSTRATE_URL --output substrate --location
-                  chmod +x substrate
-                  ./substrate --version
+                  curl $SUBSTRATE_URL --output substrate-node --location
+                  chmod +x substrate-node
+                  ./substrate-node --version
                   mkdir -p ~/.local/bin
-                  mv substrate ~/.local/bin
+                  mv substrate-node ~/.local/bin
 
             - name: Install Rust stable toolchain
               uses: actions-rs/toolchain@v1
@@ -139,11 +139,11 @@ jobs:
 
             - name: Download Substrate
               run: |
-                  curl $SUBSTRATE_URL --output substrate --location
-                  chmod +x substrate
-                  ./substrate --version
+                  curl $SUBSTRATE_URL --output substrate-node --location
+                  chmod +x substrate-node
+                  ./substrate-node --version
                   mkdir -p ~/.local/bin
-                  mv substrate ~/.local/bin
+                  mv substrate-node ~/.local/bin
 
             - name: Install Rust stable toolchain
               uses: actions-rs/toolchain@v1
@@ -173,11 +173,11 @@ jobs:
 
             - name: Download Substrate
               run: |
-                  curl $SUBSTRATE_URL --output substrate --location
-                  chmod +x substrate
-                  ./substrate --version
+                  curl $SUBSTRATE_URL --output substrate-node --location
+                  chmod +x substrate-node
+                  ./substrate-node --version
                   mkdir -p ~/.local/bin
-                  mv substrate ~/.local/bin
+                  mv substrate-node ~/.local/bin
 
             - name: Install Rust stable toolchain
               uses: actions-rs/toolchain@v1
@@ -208,11 +208,11 @@ jobs:
 
             - name: Download Substrate
               run: |
-                  curl $SUBSTRATE_URL --output substrate --location
-                  chmod +x substrate
-                  ./substrate --version
+                  curl $SUBSTRATE_URL --output substrate-node --location
+                  chmod +x substrate-node
+                  ./substrate-node --version
                   mkdir -p ~/.local/bin
-                  mv substrate ~/.local/bin
+                  mv substrate-node ~/.local/bin
 
             - name: Install Rust stable toolchain
               uses: actions-rs/toolchain@v1
@@ -239,11 +239,11 @@ jobs:
 
             - name: Download Substrate
               run: |
-                  curl $SUBSTRATE_URL --output substrate --location
-                  chmod +x substrate
-                  ./substrate --version
+                  curl $SUBSTRATE_URL --output substrate-node --location
+                  chmod +x substrate-node
+                  ./substrate-node --version
                   mkdir -p ~/.local/bin
-                  mv substrate ~/.local/bin
+                  mv substrate-node ~/.local/bin
 
             - name: Install Rust stable toolchain
               uses: actions-rs/toolchain@v1
@@ -283,30 +283,30 @@ jobs:
 
             - name: Download Substrate
               run: |
-                  curl $SUBSTRATE_URL --output substrate --location
-                  chmod +x substrate
-                  ./substrate --version
+                  curl $SUBSTRATE_URL --output substrate-node --location
+                  chmod +x substrate-node
+                  ./substrate-node --version
                   mkdir -p ~/.local/bin
-                  mv substrate ~/.local/bin
+                  mv substrate-node ~/.local/bin
 
             - name: Run subxt WASM tests
               run: |
                   # `listen-addr` is used to configure p2p to accept websocket connections instead of TCP.
                   # `node-key` provides a deterministic p2p address.
-                  substrate --dev --node-key 0000000000000000000000000000000000000000000000000000000000000001 --listen-addr /ip4/0.0.0.0/tcp/30333/ws > /dev/null 2>&1 &
+                  substrate-node --dev --node-key 0000000000000000000000000000000000000000000000000000000000000001 --listen-addr /ip4/0.0.0.0/tcp/30333/ws > /dev/null 2>&1 &
                   wasm-pack test --headless --firefox
                   wasm-pack test --headless --chrome
-                  pkill substrate
+                  pkill substrate-node
               working-directory: testing/wasm-rpc-tests
 
             - name: Run subxt-lightclient WASM tests
               run: |
                   # `listen-addr` is used to configure p2p to accept websocket connections instead of TCP.
                   # `node-key` provides a deterministic p2p address.
-                  substrate --dev --node-key 0000000000000000000000000000000000000000000000000000000000000001 --listen-addr /ip4/0.0.0.0/tcp/30333/ws > /dev/null 2>&1 &
+                  substrate-node --dev --node-key 0000000000000000000000000000000000000000000000000000000000000001 --listen-addr /ip4/0.0.0.0/tcp/30333/ws > /dev/null 2>&1 &
                   wasm-pack test --headless --firefox
                   wasm-pack test --headless --chrome
-                  pkill substrate
+                  pkill substrate-node
               working-directory: testing/wasm-lightclient-tests
 
             - name: Run subxt-signer WASM tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1998,7 +1998,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber 0.3.17",
  "wabt",
- "which",
 ]
 
 [[package]]
@@ -3175,9 +3174,9 @@ dependencies = [
 
 [[package]]
 name = "scale-bits"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dd7aca73785181cc41f0bbe017263e682b585ca660540ba569133901d013ecf"
+checksum = "036575c29af9b6e4866ffb7fa055dbf623fe7a9cc159b33786de6013a6969d89"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -3186,24 +3185,20 @@ dependencies = [
 
 [[package]]
 name = "scale-decode"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0459d00b0dbd2e765009924a78ef36b2ff7ba116292d732f00eb0ed8e465d15"
+version = "0.9.0"
 dependencies = [
+ "derive_more",
  "parity-scale-codec",
  "primitive-types",
  "scale-bits",
  "scale-decode-derive",
  "scale-info",
  "smallvec",
- "thiserror",
 ]
 
 [[package]]
 name = "scale-decode-derive"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4391f0dfbb6690f035f6d2a15d6a12f88cc5395c36bcc056db07ffa2a90870ec"
+version = "0.9.0"
 dependencies = [
  "darling 0.14.4",
  "proc-macro-crate",
@@ -3214,24 +3209,20 @@ dependencies = [
 
 [[package]]
 name = "scale-encode"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0401b7cdae8b8aa33725f3611a051358d5b32887ecaa0fda5953a775b2d4d76"
+version = "0.5.0"
 dependencies = [
+ "derive_more",
  "parity-scale-codec",
  "primitive-types",
  "scale-bits",
  "scale-encode-derive",
  "scale-info",
  "smallvec",
- "thiserror",
 ]
 
 [[package]]
 name = "scale-encode-derive"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "316e0fb10ec0fee266822bd641bab5e332a4ab80ef8c5b5ff35e5401a394f5a6"
+version = "0.5.0"
 dependencies = [
  "darling 0.14.4",
  "proc-macro-crate",
@@ -3268,12 +3259,11 @@ dependencies = [
 
 [[package]]
 name = "scale-value"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2096d36e94ce9bf87d8addb752423b6b19730dc88edd7cc452bb2b90573f7a7"
+version = "0.12.0"
 dependencies = [
  "base58",
  "blake2",
+ "derive_more",
  "either",
  "frame-metadata 15.1.0",
  "parity-scale-codec",
@@ -3282,7 +3272,6 @@ dependencies = [
  "scale-encode",
  "scale-info",
  "serde",
- "thiserror",
  "yap",
 ]
 
@@ -5428,9 +5417,9 @@ checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "yap"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2a7eb6d82a11e4d0b8e6bda8347169aff4ccd8235d039bba7c47482d977dcf7"
+checksum = "ff4524214bc4629eba08d78ceb1d6507070cc0bcbbed23af74e19e6e924a24cf"
 
 [[package]]
 name = "zeroize"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3186,6 +3186,8 @@ dependencies = [
 [[package]]
 name = "scale-decode"
 version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7789f5728e4e954aaa20cadcc370b99096fb8645fca3c9333ace44bb18f30095"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
@@ -3199,6 +3201,8 @@ dependencies = [
 [[package]]
 name = "scale-decode-derive"
 version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27873eb6005868f8cc72dcfe109fae664cf51223d35387bc2f28be4c28d94c47"
 dependencies = [
  "darling 0.14.4",
  "proc-macro-crate",
@@ -3210,6 +3214,8 @@ dependencies = [
 [[package]]
 name = "scale-encode"
 version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d70cb4b29360105483fac1ed567ff95d65224a14dd275b6303ed0a654c78de5"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
@@ -3223,6 +3229,8 @@ dependencies = [
 [[package]]
 name = "scale-encode-derive"
 version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "995491f110efdc6bea96d6a746140e32bfceb4ea47510750a5467295a4707a25"
 dependencies = [
  "darling 0.14.4",
  "proc-macro-crate",
@@ -3260,6 +3268,8 @@ dependencies = [
 [[package]]
 name = "scale-value"
 version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6538d1cc1af9c0baf401c57da8a6d4730ef582db0d330d2efa56ec946b5b0283"
 dependencies = [
  "base58",
  "blake2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3186,6 +3186,8 @@ dependencies = [
 [[package]]
 name = "scale-decode"
 version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7789f5728e4e954aaa20cadcc370b99096fb8645fca3c9333ace44bb18f30095"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
@@ -3199,6 +3201,8 @@ dependencies = [
 [[package]]
 name = "scale-decode-derive"
 version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27873eb6005868f8cc72dcfe109fae664cf51223d35387bc2f28be4c28d94c47"
 dependencies = [
  "darling 0.14.4",
  "proc-macro-crate",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3186,8 +3186,6 @@ dependencies = [
 [[package]]
 name = "scale-decode"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7789f5728e4e954aaa20cadcc370b99096fb8645fca3c9333ace44bb18f30095"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
@@ -3201,8 +3199,6 @@ dependencies = [
 [[package]]
 name = "scale-decode-derive"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27873eb6005868f8cc72dcfe109fae664cf51223d35387bc2f28be4c28d94c47"
 dependencies = [
  "darling 0.14.4",
  "proc-macro-crate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,6 +121,3 @@ secp256k1 = "0.27.0"
 secrecy = "0.8.0"
 sha2 = "0.10.6"
 zeroize = { version = "1", default-features = false }
-
-[patch.crates-io]
-scale-decode = { path = "../scale-decode/scale-decode" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,3 +121,6 @@ secp256k1 = "0.27.0"
 secrecy = "0.8.0"
 sha2 = "0.10.6"
 zeroize = { version = "1", default-features = false }
+
+[patch.crates-io]
+scale-decode = { path = "../scale-decode/scale-decode" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,8 +121,3 @@ secp256k1 = "0.27.0"
 secrecy = "0.8.0"
 sha2 = "0.10.6"
 zeroize = { version = "1", default-features = false }
-
-[patch.crates-io]
-scale-encode = { path = "../scale-encode/scale-encode" }
-scale-decode = { path = "../scale-decode/scale-decode" }
-scale-value = { path = "../scale-value" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,10 +62,10 @@ proc-macro2 = "1.0.66"
 quote = "1.0.31"
 regex = "1.9.1"
 scale-info = "2.9.0"
-scale-value = "0.10.0"
-scale-bits = "0.3"
-scale-decode = "0.7.0"
-scale-encode = "0.3.0"
+scale-value = "0.12.0"
+scale-bits = "0.4.0"
+scale-decode = "0.9.0"
+scale-encode = "0.5.0"
 serde = { version = "1.0.179" }
 serde_json = { version = "1.0.104" }
 syn = { version = "2.0.15", features = ["full", "extra-traits"] }
@@ -121,3 +121,8 @@ secp256k1 = "0.27.0"
 secrecy = "0.8.0"
 sha2 = "0.10.6"
 zeroize = { version = "1", default-features = false }
+
+[patch.crates-io]
+scale-encode = { path = "../scale-encode/scale-encode" }
+scale-decode = { path = "../scale-decode/scale-decode" }
+scale-value = { path = "../scale-value" }

--- a/subxt/src/events/events_type.rs
+++ b/subxt/src/events/events_type.rs
@@ -888,7 +888,7 @@ mod tests {
                 pallet_index: 0,
                 variant: "A".to_string(),
                 variant_index: 0,
-                fields: vec![Value::u128(1)],
+                fields: vec![Value::unnamed_composite(vec![Value::u128(1)])],
             },
         );
         assert!(event_details.next().is_none());

--- a/subxt/src/events/events_type.rs
+++ b/subxt/src/events/events_type.rs
@@ -602,25 +602,9 @@ mod tests {
     /// Compare some actual [`RawEventDetails`] with a hand-constructed
     /// (probably) [`TestRawEventDetails`].
     pub fn assert_raw_events_match(
-        // Just for convenience, pass in the metadata type constructed
-        // by the `metadata` function above to simplify caller code.
-        metadata: &Metadata,
         actual: EventDetails<SubstrateConfig>,
         expected: TestRawEventDetails,
     ) {
-        let types = &metadata.types();
-
-        // Make sure that the bytes handed back line up with the fields handed back;
-        // encode the fields back into bytes and they should be equal.
-        let actual_fields = actual.field_values().expect("can decode field values (1)");
-
-        let mut actual_bytes = vec![];
-        for field in actual_fields.into_values() {
-            scale_value::scale::encode_as_type(&field, field.context, types, &mut actual_bytes)
-                .expect("should be able to encode properly");
-        }
-        assert_eq!(actual_bytes, actual.field_bytes());
-
         let actual_fields_no_context: Vec<_> = actual
             .field_values()
             .expect("can decode field values (2)")
@@ -691,7 +675,6 @@ mod tests {
 
         let mut event_details = events.iter();
         assert_raw_events_match(
-            &metadata,
             event_details.next().unwrap().unwrap(),
             TestRawEventDetails {
                 phase: Phase::ApplyExtrinsic(123),
@@ -739,7 +722,6 @@ mod tests {
         let mut event_details = events.iter();
 
         assert_raw_events_match(
-            &metadata,
             event_details.next().unwrap().unwrap(),
             TestRawEventDetails {
                 index: 0,
@@ -752,7 +734,6 @@ mod tests {
             },
         );
         assert_raw_events_match(
-            &metadata,
             event_details.next().unwrap().unwrap(),
             TestRawEventDetails {
                 index: 1,
@@ -765,7 +746,6 @@ mod tests {
             },
         );
         assert_raw_events_match(
-            &metadata,
             event_details.next().unwrap().unwrap(),
             TestRawEventDetails {
                 index: 2,
@@ -809,7 +789,6 @@ mod tests {
 
         let mut events_iter = events.iter();
         assert_raw_events_match(
-            &metadata,
             events_iter.next().unwrap().unwrap(),
             TestRawEventDetails {
                 index: 0,
@@ -822,7 +801,6 @@ mod tests {
             },
         );
         assert_raw_events_match(
-            &metadata,
             events_iter.next().unwrap().unwrap(),
             TestRawEventDetails {
                 index: 1,
@@ -862,7 +840,6 @@ mod tests {
         // Dynamically decode:
         let mut event_details = events.iter();
         assert_raw_events_match(
-            &metadata,
             event_details.next().unwrap().unwrap(),
             TestRawEventDetails {
                 index: 0,
@@ -903,7 +880,6 @@ mod tests {
         // Dynamically decode:
         let mut event_details = events.iter();
         assert_raw_events_match(
-            &metadata,
             event_details.next().unwrap().unwrap(),
             TestRawEventDetails {
                 index: 0,
@@ -945,7 +921,6 @@ mod tests {
         // Dynamically decode:
         let mut event_details = events.iter();
         assert_raw_events_match(
-            &metadata,
             event_details.next().unwrap().unwrap(),
             TestRawEventDetails {
                 index: 0,

--- a/subxt/src/tx/tx_client.rs
+++ b/subxt/src/tx/tx_client.rs
@@ -193,7 +193,7 @@ where
             2 => u16::decode(cursor)?.into(),
             4 => u32::decode(cursor)?.into(),
             8 => u64::decode(cursor)?,
-            _ => return Err(Error::Decode(DecodeError::custom(format!("state call AccountNonceApi_account_nonce returned an unexpected number of bytes: {} (expected 2, 4 or 8)", account_nonce_bytes.len()))))
+            _ => return Err(Error::Decode(DecodeError::custom_string(format!("state call AccountNonceApi_account_nonce returned an unexpected number of bytes: {} (expected 2, 4 or 8)", account_nonce_bytes.len()))))
         };
         Ok(account_nonce)
     }

--- a/subxt/src/utils/wrapper_opaque.rs
+++ b/subxt/src/utils/wrapper_opaque.rs
@@ -121,9 +121,9 @@ impl<T> Visitor for WrapperKeepOpaqueVisitor<T> {
         use scale_decode::error::{Error, ErrorKind};
 
         if value.path().ident().as_deref() != Some("WrapperKeepOpaque") {
-            return Err(Error::new(ErrorKind::Custom(
-                "Type to decode is not 'WrapperTypeKeepOpaque'".into(),
-            )));
+            return Err(Error::custom_str(
+                "Type to decode is not 'WrapperTypeKeepOpaque'"
+            ));
         }
         if value.remaining() != 2 {
             return Err(Error::new(ErrorKind::WrongLength {
@@ -140,7 +140,7 @@ impl<T> Visitor for WrapperKeepOpaqueVisitor<T> {
 
         // Sanity check that the compact length we decoded lines up with the number of bytes encoded in the next field.
         if field.bytes().len() != len as usize {
-            return Err(Error::new(ErrorKind::Custom("WrapperTypeKeepOpaque compact encoded length doesn't line up with encoded byte len".into())));
+            return Err(Error::custom_str("WrapperTypeKeepOpaque compact encoded length doesn't line up with encoded byte len".into()));
         }
 
         Ok(WrapperKeepOpaque {

--- a/subxt/src/utils/wrapper_opaque.rs
+++ b/subxt/src/utils/wrapper_opaque.rs
@@ -122,7 +122,7 @@ impl<T> Visitor for WrapperKeepOpaqueVisitor<T> {
 
         if value.path().ident().as_deref() != Some("WrapperKeepOpaque") {
             return Err(Error::custom_str(
-                "Type to decode is not 'WrapperTypeKeepOpaque'"
+                "Type to decode is not 'WrapperTypeKeepOpaque'",
             ));
         }
         if value.remaining() != 2 {

--- a/subxt/src/utils/wrapper_opaque.rs
+++ b/subxt/src/utils/wrapper_opaque.rs
@@ -140,7 +140,7 @@ impl<T> Visitor for WrapperKeepOpaqueVisitor<T> {
 
         // Sanity check that the compact length we decoded lines up with the number of bytes encoded in the next field.
         if field.bytes().len() != len as usize {
-            return Err(Error::custom_str("WrapperTypeKeepOpaque compact encoded length doesn't line up with encoded byte len".into()));
+            return Err(Error::custom_str("WrapperTypeKeepOpaque compact encoded length doesn't line up with encoded byte len"));
         }
 
         Ok(WrapperKeepOpaque {

--- a/testing/integration-tests/Cargo.toml
+++ b/testing/integration-tests/Cargo.toml
@@ -37,6 +37,5 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 wabt = { workspace = true }
-which = { workspace = true }
 substrate-runner = { workspace = true }
 sp-runtime = { workspace = true }

--- a/testing/integration-tests/src/utils/context.rs
+++ b/testing/integration-tests/src/utils/context.rs
@@ -6,21 +6,15 @@ pub(crate) use crate::{node_runtime, utils::TestNodeProcess};
 
 use subxt::SubstrateConfig;
 
-/// substrate node should be installed on the $PATH
-const SUBSTRATE_NODE_PATH: &str = "substrate";
+/// `substrate-node` should be installed on the $PATH. We fall back
+/// to also checking for an older `substrate` binary.
+const SUBSTRATE_NODE_PATHS: &str = "substrate-node,substrate";
 
 pub async fn test_context_with(authority: String) -> TestContext {
-    let path = std::env::var("SUBSTRATE_NODE_PATH").unwrap_or_else(|_| {
-        if which::which(SUBSTRATE_NODE_PATH).is_err() {
-            panic!(
-                "A substrate binary should be installed on your path for integration tests. \
-            See https://github.com/paritytech/subxt/tree/master#integration-testing"
-            )
-        }
-        SUBSTRATE_NODE_PATH.to_string()
-    });
+    let paths = std::env::var("SUBSTRATE_NODE_PATH").unwrap_or_else(|_| SUBSTRATE_NODE_PATHS.to_string());
+    let paths: Vec<_> = paths.split(',').map(|p| p.trim()).collect();
 
-    let mut proc = TestContext::build(path.as_str());
+    let mut proc = TestContext::build(&paths);
     proc.with_authority(authority);
     proc.spawn::<SubstrateConfig>().await.unwrap()
 }

--- a/testing/integration-tests/src/utils/context.rs
+++ b/testing/integration-tests/src/utils/context.rs
@@ -11,7 +11,8 @@ use subxt::SubstrateConfig;
 const SUBSTRATE_NODE_PATHS: &str = "substrate-node,substrate";
 
 pub async fn test_context_with(authority: String) -> TestContext {
-    let paths = std::env::var("SUBSTRATE_NODE_PATH").unwrap_or_else(|_| SUBSTRATE_NODE_PATHS.to_string());
+    let paths =
+        std::env::var("SUBSTRATE_NODE_PATH").unwrap_or_else(|_| SUBSTRATE_NODE_PATHS.to_string());
     let paths: Vec<_> = paths.split(',').map(|p| p.trim()).collect();
 
     let mut proc = TestContext::build(&paths);

--- a/testing/integration-tests/src/utils/node_proc.rs
+++ b/testing/integration-tests/src/utils/node_proc.rs
@@ -26,11 +26,11 @@ where
     R: Config,
 {
     /// Construct a builder for spawning a test node process.
-    pub fn build<S>(program: S) -> TestNodeProcessBuilder
+    pub fn build<P>(paths: &[P]) -> TestNodeProcessBuilder
     where
-        S: AsRef<OsStr> + Clone,
+        P: AsRef<OsStr> + Clone,
     {
-        TestNodeProcessBuilder::new(program)
+        TestNodeProcessBuilder::new(paths)
     }
 
     /// Returns the subxt client connected to the running node.
@@ -48,17 +48,24 @@ where
 
 /// Construct a test node process.
 pub struct TestNodeProcessBuilder {
-    node_path: OsString,
+    node_paths: Vec<OsString>,
     authority: Option<String>,
 }
 
 impl TestNodeProcessBuilder {
-    pub fn new<P>(node_path: P) -> TestNodeProcessBuilder
+    pub fn new<P>(node_paths: &[P]) -> TestNodeProcessBuilder
     where
         P: AsRef<OsStr>,
     {
+        // Check that paths are valid and build up vec.
+        let mut paths = Vec::new();
+        for path in node_paths {
+            let path = path.as_ref();
+            paths.push(path.to_os_string())
+        }
+
         Self {
-            node_path: node_path.as_ref().into(),
+            node_paths: paths,
             authority: None,
         }
     }
@@ -76,7 +83,7 @@ impl TestNodeProcessBuilder {
     {
         let mut node_builder = SubstrateNode::builder();
 
-        node_builder.binary_paths(&[self.node_path]);
+        node_builder.binary_paths(&self.node_paths);
 
         if let Some(authority) = &self.authority {
             node_builder.arg(authority.to_lowercase());


### PR DESCRIPTION
Running tests locally failed because we were still explicitly passing incorrect paths, so I fixed that. I also bumped versions of `scale-encode`, `scale-decode` and `scale-value` and fixed anything that broke as a result, and changed the CI to download to `substrate-node` to mirror the changed binary name.

One change that was spotted here in a failing test: previously, `scale_value::Value`'s would each come with a type ID of the type they decoded from, and this could be used to re-encode the value in the same way. This is no longer always possible, because we now "skip" over `Compact` types when decoding. It's a trade-off: 

- Previously, any compact encoded thing (value, struct, whatever) was decoded to a single number. This lost information about the structs etc on the way there, and decoding into matching structs would fail because of this.
- Now, we preserve all of the struct (composite) types in the decoding, but there's no longer a sensible place for the "compact" type ID to live (each decoded struct etc has its own type ID).

I think this is fair enough; the Type IDs that are attached to values are meant to help with diagnostics and such more than anything, and values should be encoded, as other types, by providing a target type ID to aim them at.