### PR TITLE
Prep for 0.31.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.31.0] - 2023-08-02
+
+This is a small release whose primary goal is to bump the versions of `scale-encode`, `scale-decode` and `scale-value` being used, to benefit from recent changes in those crates.
+
+`scale-decode` changes how compact values are decoded as part of [#1103](https://github.com/paritytech/subxt/pull/1103). A compact encoded struct should now be properly decoded into a struct of matching shape (which implements `DecodeAsType`). This will hopefully resolve issues around structs like `Perbill`. When decoding the SCALE bytes for such types into `scale_value::Value`, the `Value` will now be a composite type wrapping a value, and not just the value.
+
+We've also figured out how to sign extrinsics using browser wallets when a Subxt app is compiled to WASM; see [#1067](https://github.com/paritytech/subxt/pull/1067) for more on that!
+
+The key commits:
+
+### Added
+
+- Add browser extension signing example ([#1067](https://github.com/paritytech/subxt/pull/1067))
+
+### Changed
+
+- Bump to latest scale-encode/decode/value and fix test running ([#1103](https://github.com/paritytech/subxt/pull/1103))
+- Set minimum supported `rust-version` to `1.70` ([#1097](https://github.com/paritytech/subxt/pull/1097))
+
+### Fixed
+
+- Tests: support 'substrate-node' too and allow multiple binary paths ([#1102](https://github.com/paritytech/subxt/pull/1102))
+
+
 ## [0.30.1] - 2023-07-25
 
 This patch release fixes a small issue whereby using `runtime_metadata_url` in the Subxt macro would still attempt to download unstable metadata, which can fail at the moment if the chain has not updated to stable V15 metadata yet (which has a couple of changes from the last unstable version). Note that you're generally encouraged to use `runtime_metadata_path` instead, which does not have this issue.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1976,7 +1976,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "assert_matches",
  "frame-metadata 16.0.0",
@@ -4198,7 +4198,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-runner"
-version = "0.30.1"
+version = "0.31.0"
 
 [[package]]
 name = "subtle"
@@ -4214,7 +4214,7 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "subxt"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "assert_matches",
  "base58",
@@ -4255,7 +4255,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-cli"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "clap 4.3.19",
  "color-eyre",
@@ -4276,7 +4276,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-codegen"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "bitvec",
  "frame-metadata 16.0.0",
@@ -4296,7 +4296,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-lightclient"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "either",
  "futures",
@@ -4322,7 +4322,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "darling 0.20.3",
  "proc-macro-error",
@@ -4332,7 +4332,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-metadata"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "assert_matches",
  "bitvec",
@@ -4346,7 +4346,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-signer"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "bip39",
  "getrandom 0.2.10",
@@ -4412,7 +4412,7 @@ dependencies = [
 
 [[package]]
 name = "test-runtime"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "hex",
  "impl-serde",
@@ -4786,7 +4786,7 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "ui-tests"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "frame-metadata 16.0.0",
  "parity-scale-codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ resolver = "2"
 [workspace.package]
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
-version = "0.30.1"
+version = "0.31.0"
 rust-version = "1.70.0"
 license = "Apache-2.0 OR GPL-3.0"
 repository = "https://github.com/paritytech/subxt"
@@ -103,12 +103,12 @@ sp-keyring = "24.0.0"
 sp-version = "22.0.0"
 
 # Subxt workspace crates:
-subxt = { version = "0.30.1", path = "subxt", default-features = false }
-subxt-macro = { version = "0.30.1", path = "macro" }
-subxt-metadata = { version = "0.30.1", path = "metadata" }
-subxt-codegen = { version = "0.30.1", path = "codegen" }
-subxt-signer = { version = "0.30.1", path = "signer" }
-subxt-lightclient = { version = "0.30.1", path = "lightclient", default-features = false }
+subxt = { version = "0.31.0", path = "subxt", default-features = false }
+subxt-macro = { version = "0.31.0", path = "macro" }
+subxt-metadata = { version = "0.31.0", path = "metadata" }
+subxt-codegen = { version = "0.31.0", path = "codegen" }
+subxt-signer = { version = "0.31.0", path = "signer" }
+subxt-lightclient = { version = "0.31.0", path = "lightclient", default-features = false }
 test-runtime = { path = "testing/test-runtime" }
 substrate-runner = { path = "testing/substrate-runner" }
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -50,11 +50,14 @@ We also assume that ongoing work done is being merged directly to the `master` b
     provide `[+] Latest release tag: v0.16.0` ). Then group the PRs into "Fixed", "Added" and "Changed" sections, and make any
     other adjustments that you feel are necessary for clarity.
 
-7.  Commit any of the above changes to the release branch and open a PR in GitHub with a base of `master`.
+7.  If any of the differences impact the minimum version of `rustc` that the code will run on, please update the `rust-version`
+    field in the root `Cargo.toml` accordingly.
 
-8.  Once the branch has been reviewed and passes CI, merge it.
+8.  Commit any of the above changes to the release branch and open a PR in GitHub with a base of `master`.
 
-9.  Now, we're ready to publish the release to crates.io.
+9.  Once the branch has been reviewed and passes CI, merge it.
+
+10. Now, we're ready to publish the release to crates.io.
 
     1.  Checkout `master`, ensuring we're looking at that latest merge (`git pull`).
 
@@ -81,7 +84,7 @@ We also assume that ongoing work done is being merged directly to the `master` b
             (cd cli && cargo publish);
         ```
 
-10. If the release was successful, tag the commit that we released in the `master` branch with the
+11. If the release was successful, tag the commit that we released in the `master` branch with the
     version that we just released, for example:
 
     ```


### PR DESCRIPTION
## [0.31.0] - 2023-08-02

This is a small release whose primary goal is to bump the versions of `scale-encode`, `scale-decode` and `scale-value` being used, to benefit from recent changes in those crates.

`scale-decode` changes how compact values are decoded as part of [#1103](https://github.com/paritytech/subxt/pull/1103). A compact encoded struct should now be properly decoded into a struct of matching shape (which implements `DecodeAsType`). This will hopefully resolve issues around structs like `Perbill`. When decoding the SCALE bytes for such types into `scale_value::Value`, the `Value` will now be a composite type wrapping a value, and not just the value.

We've also figured out how to sign extrinsics using browser wallets when a Subxt app is compiled to WASM; see [#1067](https://github.com/paritytech/subxt/pull/1067) for more on that!

The key commits:

### Added

- Add browser extension signing example ([#1067](https://github.com/paritytech/subxt/pull/1067))

### Changed

- Bump to latest scale-encode/decode/value and fix test running ([#1103](https://github.com/paritytech/subxt/pull/1103))
- Set minimum supported `rust-version` to `1.70` ([#1097](https://github.com/paritytech/subxt/pull/1097))

### Fixed

- Tests: support 'substrate-node' too and allow multiple binary paths ([#1102](https://github.com/paritytech/subxt/pull/1102))
