### PR TITLE
Remove unused `start_key` that new RPC APIs may not be able to support

### DIFF
--- a/subxt/src/backend/legacy/mod.rs
+++ b/subxt/src/backend/legacy/mod.rs
@@ -68,7 +68,6 @@ impl<T: Config + Send + Sync + 'static> Backend<T> for LegacyBackend<T> {
     async fn storage_fetch_descendant_keys(
         &self,
         key: Vec<u8>,
-        starting_at: Option<Vec<u8>>,
         at: T::Hash,
     ) -> Result<StreamOfResults<Vec<u8>>, Error> {
         Ok(StreamOf(Box::pin(StorageFetchDescendantKeysStream {
@@ -78,7 +77,7 @@ impl<T: Config + Send + Sync + 'static> Backend<T> for LegacyBackend<T> {
             done: Default::default(),
             keys: Default::default(),
             keys_fut: Default::default(),
-            pagination_start_key: starting_at,
+            pagination_start_key: None,
         })))
     }
 

--- a/subxt/src/backend/mod.rs
+++ b/subxt/src/backend/mod.rs
@@ -40,7 +40,6 @@ pub trait Backend<T: Config>: sealed::Sealed + Send + Sync + 'static {
     async fn storage_fetch_descendant_keys(
         &self,
         key: Vec<u8>,
-        starting_at: Option<Vec<u8>>,
         at: T::Hash,
     ) -> Result<StreamOfResults<Vec<u8>>, Error>;
 

--- a/subxt/src/storage/storage_type.rs
+++ b/subxt/src/storage/storage_type.rs
@@ -76,7 +76,7 @@ where
         async move {
             let keys = client
                 .backend()
-                .storage_fetch_descendant_keys(key, None, block_hash)
+                .storage_fetch_descendant_keys(key, block_hash)
                 .await?;
             Ok(keys)
         }


### PR DESCRIPTION
The new RPCs probably won't allow a `startKey` to be provided, so for now we should probably just not expose such a thing anywhere. 

(See https://github.com/paritytech/json-rpc-interface-spec/issues/85 for context)