### PR TITLE
integration-tests: Increase the number of expected events

### DIFF
--- a/testing/integration-tests/src/full_client/client/unstable_rpcs.rs
+++ b/testing/integration-tests/src/full_client/client/unstable_rpcs.rs
@@ -293,8 +293,10 @@ async fn transaction_unstable_submit_and_watch() {
 async fn next_operation_event<T: serde::de::DeserializeOwned>(
     sub: &mut RpcSubscription<FollowEvent<T>>,
 ) -> FollowEvent<T> {
-    // At most 5 retries.
-    for _ in 0..5 {
+    // Number of events to wait for the next operation event.
+    const NUM_EVENTS: usize = 10;
+
+    for _ in 0..NUM_EVENTS {
         let event = sub.next().await.unwrap().unwrap();
 
         match event {
@@ -309,5 +311,5 @@ async fn next_operation_event<T: serde::de::DeserializeOwned>(
         return event;
     }
 
-    panic!("Cannot find operation related event after 5 produced events");
+    panic!("Cannot find operation related event after {NUM_EVENTS} produced events");
 }


### PR DESCRIPTION
This PR increases the number of maximum events we can skip until a specific operation event is detected.

The number is increased from 5 to 10 in response to https://github.com/paritytech/subxt/actions/runs/6067893999/job/16460142713?pr=1149.