### PR TITLE
Custom `Debug` impl for `DispatchError`

### DIFF
--- a/subxt/src/error/dispatch_error.rs
+++ b/subxt/src/error/dispatch_error.rs
@@ -122,7 +122,7 @@ pub enum TransactionalError {
 }
 
 /// Details about a module error that has occurred.
-#[derive(Clone, Debug, thiserror::Error)]
+#[derive(Clone, thiserror::Error)]
 #[non_exhaustive]
 pub struct ModuleError {
     metadata: Metadata,
@@ -141,6 +141,22 @@ impl PartialEq for ModuleError {
 }
 
 impl Eq for ModuleError {}
+
+/// Custom `Debug` implementation, ignores the very large `metadata` field, using it instead (as
+/// intended) to resolve the actual pallet and error names. This is much more useful for debugging.
+impl Debug for ModuleError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Ok(details) = self.details() else {
+            return f
+                .write_str("Unknown pallet error (pallet and error details cannot be retrieved)");
+        };
+        f.debug_struct("ModuleError")
+            .field("bytes", &self.bytes)
+            .field("pallet", &details.pallet.name())
+            .field("error", &details.variant.name)
+            .finish()
+    }
+}
 
 impl std::fmt::Display for ModuleError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/subxt/src/error/dispatch_error.rs
+++ b/subxt/src/error/dispatch_error.rs
@@ -154,7 +154,7 @@ impl Debug for ModuleError {
 impl std::fmt::Display for ModuleError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let details = self.details_string();
-        write!(f, "Pallet error: {details}")
+        write!(f, "{details}")
     }
 }
 

--- a/subxt/src/error/dispatch_error.rs
+++ b/subxt/src/error/dispatch_error.rs
@@ -146,32 +146,15 @@ impl Eq for ModuleError {}
 /// intended) to resolve the actual pallet and error names. This is much more useful for debugging.
 impl Debug for ModuleError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let details = match self.details() {
-            Ok(details) => format!(
-                "{pallet_name}::{variant_name}",
-                pallet_name = details.pallet.name(),
-                variant_name = details.variant.name,
-            ),
-            Err(_) => format!(
-                "Unknown pallet error '{bytes:?}' (pallet and error details cannot be retrieved)",
-                bytes = self.bytes
-            ),
-        };
-
+        let details = self.details_string();
         write!(f, "ModuleError(<{details}>)")
     }
 }
 
 impl std::fmt::Display for ModuleError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let Ok(details) = self.details() else {
-            return f
-                .write_str("Unknown pallet error (pallet and error details cannot be retrieved)");
-        };
-
-        let pallet = details.pallet.name();
-        let error = &details.variant.name;
-        write!(f, "Pallet error {pallet}::{error}")
+        let details = self.details_string();
+        write!(f, "Pallet error: {details}")
     }
 }
 
@@ -184,6 +167,21 @@ impl ModuleError {
             .ok_or_else(|| MetadataError::VariantIndexNotFound(self.error_index()))?;
 
         Ok(ModuleErrorDetails { pallet, variant })
+    }
+
+    /// Return a formatted string of the resolved error details for debugging/display purposes.
+    pub fn details_string(&self) -> String {
+        match self.details() {
+            Ok(details) => format!(
+                "{pallet_name}::{variant_name}",
+                pallet_name = details.pallet.name(),
+                variant_name = details.variant.name,
+            ),
+            Err(_) => format!(
+                "Unknown pallet error '{bytes:?}' (pallet and error details cannot be retrieved)",
+                bytes = self.bytes
+            ),
+        }
     }
 
     /// Return the underlying module error data that was decoded.

--- a/subxt/src/error/dispatch_error.rs
+++ b/subxt/src/error/dispatch_error.rs
@@ -146,15 +146,16 @@ impl Eq for ModuleError {}
 /// intended) to resolve the actual pallet and error names. This is much more useful for debugging.
 impl Debug for ModuleError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let Ok(details) = self.details() else {
-            return f
-                .write_str("Unknown pallet error (pallet and error details cannot be retrieved)");
+        let details = match self.details() {
+            Ok(details) => format!(
+                "{pallet_name}::{variant_name}",
+                pallet_name = details.pallet.name(),
+                variant_name = details.variant.name,
+            ),
+            Err(_) => "Unknown pallet error (pallet and error details cannot be retrieved)",
         };
-        f.debug_struct("ModuleError")
-            .field("bytes", &self.bytes)
-            .field("pallet", &details.pallet.name())
-            .field("error", &details.variant.name)
-            .finish()
+
+        write!(f, "ModuleError(<{details}>)")
     }
 }
 

--- a/subxt/src/error/dispatch_error.rs
+++ b/subxt/src/error/dispatch_error.rs
@@ -152,7 +152,10 @@ impl Debug for ModuleError {
                 pallet_name = details.pallet.name(),
                 variant_name = details.variant.name,
             ),
-            Err(_) => "Unknown pallet error (pallet and error details cannot be retrieved)",
+            Err(_) => format!(
+                "Unknown pallet error '{bytes:?}' (pallet and error details cannot be retrieved)",
+                bytes = self.bytes
+            ),
         };
 
         write!(f, "ModuleError(<{details}>)")


### PR DESCRIPTION
Currently the `Debug` implementation prints the whole `metadata` which fills the screen and doesn't help much:

![image](https://github.com/paritytech/subxt/assets/75586/08073899-d81b-4cc6-9d52-423d496504a9)

This PR adds a custom `Debug` impl which instead resolves to virtual `pallet` and `error` fields similar to the `Display` impl. To know what the actual error is extremely useful :smile:

See also https://github.com/paritytech/subxt/issues/1140#issuecomment-1706195275  