### PR TITLE
metadata: Generate runtime outer enums if not present in V14

### DIFF
--- a/metadata/src/from_into/mod.rs
+++ b/metadata/src/from_into/mod.rs
@@ -11,7 +11,7 @@ mod v15;
 #[non_exhaustive]
 pub enum TryFromError {
     /// Type missing from type registry
-    #[error("Type {0} is expected but not found in the type registry")]
+    #[error("Type id {0} is expected but not found in the type registry")]
     TypeNotFound(u32),
     /// Type was not a variant/enum type
     #[error("Type {0} was not a variant/enum type, but is expected to be one")]
@@ -19,6 +19,9 @@ pub enum TryFromError {
     /// An unsupported metadata version was provided.
     #[error("Cannot convert v{0} metadata into Metadata type")]
     UnsupportedMetadataVersion(u32),
+    /// Type name missing from type registry
+    #[error("Type name {0} is expected but not found in the type registry")]
+    TypeNameNotFound(String),
 }
 
 impl From<crate::Metadata> for frame_metadata::RuntimeMetadataPrefixed {

--- a/metadata/src/from_into/mod.rs
+++ b/metadata/src/from_into/mod.rs
@@ -7,7 +7,7 @@ mod v15;
 
 /// An error emitted if something goes wrong converting [`frame_metadata`]
 /// types into [`crate::Metadata`].
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum TryFromError {
     /// Type missing from type registry

--- a/metadata/src/from_into/mod.rs
+++ b/metadata/src/from_into/mod.rs
@@ -22,6 +22,9 @@ pub enum TryFromError {
     /// Type name missing from type registry
     #[error("Type name {0} is expected but not found in the type registry")]
     TypeNameNotFound(String),
+    /// Invalid type path.
+    #[error("Type has an invalid path {0}")]
+    InvalidTypePath(String),
 }
 
 impl From<crate::Metadata> for frame_metadata::RuntimeMetadataPrefixed {

--- a/metadata/src/from_into/v14.rs
+++ b/metadata/src/from_into/v14.rs
@@ -307,8 +307,8 @@ impl ExtrinsicPartTypeIds {
     }
 }
 
-fn generate_outer_enums<'a>(
-    metadata: &'a mut v14::RuntimeMetadataV14,
+fn generate_outer_enums(
+    metadata: &mut v14::RuntimeMetadataV14,
 ) -> v15::OuterEnums<scale_info::form::PortableForm> {
     let mut path = None;
 
@@ -345,22 +345,19 @@ fn generate_outer_enums<'a>(
     let call_enum_ty = call_enum.unwrap_or_else(|| {
         let mut segments = path.clone();
         segments.push("RuntimeCall".into());
-        let id = generate_outer_enum_type(metadata, segments, GeneratedEnumType::Call);
-        id
+        generate_outer_enum_type(metadata, segments, GeneratedEnumType::Call)
     });
 
     let event_enum_ty = event_enum.unwrap_or_else(|| {
         let mut segments = path.clone();
         segments.push("RuntimeEvent".into());
-        let id = generate_outer_enum_type(metadata, segments, GeneratedEnumType::Event);
-        id
+        generate_outer_enum_type(metadata, segments, GeneratedEnumType::Event)
     });
 
     let error_enum_ty = error_enum.unwrap_or_else(|| {
         let mut segments = path.clone();
         segments.push("RuntimeError".into());
-        let id = generate_outer_enum_type(metadata, segments, GeneratedEnumType::Error);
-        id
+        generate_outer_enum_type(metadata, segments, GeneratedEnumType::Error)
     });
 
     v15::OuterEnums {

--- a/metadata/src/from_into/v14.rs
+++ b/metadata/src/from_into/v14.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 use super::TryFromError;
 use crate::Metadata;
 use frame_metadata::{v14, v15};
+use scale_info::TypeDef;
 
 impl TryFrom<v14::RuntimeMetadataV14> for Metadata {
     type Error = TryFromError;
@@ -320,6 +321,10 @@ fn generate_outer_enums<'a>(
             if ident != name {
                 return None;
             }
+
+            let TypeDef::Variant(_) = &ty.ty.type_def else {
+                return None;
+            };
 
             if path.is_none() {
                 let mut segments = ty.ty.path.segments.clone();

--- a/metadata/src/from_into/v14.rs
+++ b/metadata/src/from_into/v14.rs
@@ -331,9 +331,9 @@ fn generate_outer_enums<'a>(
         })
     };
 
-    let call_enum = find_type("RuntimeCall");
-    let event_enum = find_type("RuntimeEvent");
-    let error_enum = find_type("RuntimeError");
+    let call_enum = find_type("RuntimeCall").or(find_type("Call"));
+    let event_enum = find_type("RuntimeEvent").or(find_type("Event"));
+    let error_enum = find_type("RuntimeError").or(find_type("Error"));
 
     let path = path.unwrap_or_else(|| vec!["runtime_types".into()]);
 

--- a/metadata/src/from_into/v14.rs
+++ b/metadata/src/from_into/v14.rs
@@ -336,9 +336,9 @@ fn generate_outer_enums<'a>(
         })
     };
 
-    let call_enum = find_type("RuntimeCall").or(find_type("Call"));
-    let event_enum = find_type("RuntimeEvent").or(find_type("Event"));
-    let error_enum = find_type("RuntimeError").or(find_type("Error"));
+    let call_enum = find_type("RuntimeCall").or_else(|| find_type("Call"));
+    let event_enum = find_type("RuntimeEvent").or_else(|| find_type("Event"));
+    let error_enum = find_type("RuntimeError").or_else(|| find_type("Error"));
 
     let path = path.unwrap_or_else(|| vec!["runtime_types".into()]);
 


### PR DESCRIPTION
This PR avoids panics while constructing the suxbt client from an unexpected metadata format.

In doing so, the subxt is more robust in connecting to custom chains that may define different metadata formats (such as `wss://c1.hashed.live:443`).

Panics originate from two paces while converting the metadata V14 to the latest format V15:
-expectation of extrinsic types in metadata
-expectation of outer enums `RuntimeCall` and `RuntimeError` being present

For the former case, errors are propagated back to the user avoiding panic.

In the latter case:
- `RuntimeCall` is searched in metadata
- an extra check is added to ensure it is an enum that was previously taken for granted
- when the `RuntimeCall` is not found, the `Call` enum is searched
- if neither `RuntimeCall` nor `Call` are found, an outer enum is generated

Closes: https://github.com/paritytech/subxt/issues/1171