### PR TITLE
Introduce `sp_arithmetic` as `subxt::ext::sp_arithmetic` and implement default substitues behind `substrate-compat` feature.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4243,6 +4243,7 @@ dependencies = [
  "scale-value",
  "serde",
  "serde_json",
+ "sp-arithmetic",
  "sp-core",
  "sp-core-hashing",
  "sp-keyring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,7 @@ tokio-util = "0.7.9"
 sp-core = { version = "21.0.0", default-features = false }
 sp-core-hashing = { version = "9.0.0", default-features = false }
 sp-runtime = "24.0.0"
+sp-arithmetic = "16.0.0"
 sp-keyring = "24.0.0"
 
 # Subxt workspace crates:

--- a/codegen/src/types/mod.rs
+++ b/codegen/src/types/mod.rs
@@ -358,6 +358,12 @@ impl From<syn::Path> for CratePath {
     }
 }
 
+impl From<CratePath> for syn::Path {
+    fn from(path: CratePath) -> syn::Path {
+        path.0
+    }
+}
+
 impl ToTokens for CratePath {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         self.0.to_tokens(tokens)

--- a/subxt/Cargo.toml
+++ b/subxt/Cargo.toml
@@ -82,6 +82,7 @@ jsonrpsee = { workspace = true, optional = true, features = ["jsonrpsee-types"] 
 # Included if the "substrate-compat" feature is enabled.
 sp-core = { workspace = true, optional = true }
 sp-runtime = { workspace = true, optional = true }
+sp-arithmetic = { workspace = true }
 
 # Other subxt crates we depend on.
 subxt-macro = { workspace = true }

--- a/subxt/src/lib.rs
+++ b/subxt/src/lib.rs
@@ -96,6 +96,7 @@ pub mod ext {
     pub use scale_decode;
     pub use scale_encode;
     pub use scale_value;
+    pub use sp_arithmetic;
     #[cfg(feature = "substrate-compat")]
     pub use sp_core;
     #[cfg(feature = "substrate-compat")]

--- a/testing/integration-tests/src/full_client/codegen/polkadot.rs
+++ b/testing/integration-tests/src/full_client/codegen/polkadot.rs
@@ -198,7 +198,7 @@ pub mod api {
                 #[doc = " Execute the given block."]
                 pub fn execute_block(
                     &self,
-                    block : runtime_types :: sp_runtime :: generic :: block :: Block < runtime_types :: sp_runtime :: generic :: header :: Header < :: core :: primitive :: u32 , runtime_types :: sp_runtime :: traits :: BlakeTwo256 > , runtime_types :: sp_runtime :: generic :: unchecked_extrinsic :: UncheckedExtrinsic < :: subxt :: utils :: MultiAddress < :: subxt :: utils :: AccountId32 , () > , runtime_types :: polkadot_runtime :: RuntimeCall , runtime_types :: sp_runtime :: MultiSignature , (runtime_types :: frame_system :: extensions :: check_non_zero_sender :: CheckNonZeroSender , runtime_types :: frame_system :: extensions :: check_spec_version :: CheckSpecVersion , runtime_types :: frame_system :: extensions :: check_tx_version :: CheckTxVersion , runtime_types :: frame_system :: extensions :: check_genesis :: CheckGenesis , runtime_types :: frame_system :: extensions :: check_mortality :: CheckMortality , runtime_types :: frame_system :: extensions :: check_nonce :: CheckNonce , runtime_types :: frame_system :: extensions :: check_weight :: CheckWeight , runtime_types :: pallet_transaction_payment :: ChargeTransactionPayment , runtime_types :: polkadot_runtime_common :: claims :: PrevalidateAttests ,) > >,
+                    block : runtime_types :: sp_runtime :: generic :: block :: Block < runtime_types :: sp_runtime :: generic :: header :: Header < :: core :: primitive :: u32 , runtime_types :: sp_runtime :: traits :: BlakeTwo256 > , :: subxt :: utils :: UncheckedExtrinsic < :: subxt :: utils :: MultiAddress < :: subxt :: utils :: AccountId32 , () > , runtime_types :: polkadot_runtime :: RuntimeCall , runtime_types :: sp_runtime :: MultiSignature , (runtime_types :: frame_system :: extensions :: check_non_zero_sender :: CheckNonZeroSender , runtime_types :: frame_system :: extensions :: check_spec_version :: CheckSpecVersion , runtime_types :: frame_system :: extensions :: check_tx_version :: CheckTxVersion , runtime_types :: frame_system :: extensions :: check_genesis :: CheckGenesis , runtime_types :: frame_system :: extensions :: check_mortality :: CheckMortality , runtime_types :: frame_system :: extensions :: check_nonce :: CheckNonce , runtime_types :: frame_system :: extensions :: check_weight :: CheckWeight , runtime_types :: pallet_transaction_payment :: ChargeTransactionPayment , runtime_types :: polkadot_runtime_common :: claims :: PrevalidateAttests ,) > >,
                 ) -> ::subxt::runtime_api::Payload<types::ExecuteBlock, ()> {
                     ::subxt::runtime_api::Payload::new_static(
                         "Core",
@@ -254,7 +254,7 @@ pub mod api {
                 # [codec (crate = :: subxt :: ext :: codec)]
                 #[decode_as_type(crate_path = ":: subxt :: ext :: scale_decode")]
                 #[encode_as_type(crate_path = ":: subxt :: ext :: scale_encode")]
-                pub struct ExecuteBlock { pub block : runtime_types :: sp_runtime :: generic :: block :: Block < runtime_types :: sp_runtime :: generic :: header :: Header < :: core :: primitive :: u32 , runtime_types :: sp_runtime :: traits :: BlakeTwo256 > , runtime_types :: sp_runtime :: generic :: unchecked_extrinsic :: UncheckedExtrinsic < :: subxt :: utils :: MultiAddress < :: subxt :: utils :: AccountId32 , () > , runtime_types :: polkadot_runtime :: RuntimeCall , runtime_types :: sp_runtime :: MultiSignature , (runtime_types :: frame_system :: extensions :: check_non_zero_sender :: CheckNonZeroSender , runtime_types :: frame_system :: extensions :: check_spec_version :: CheckSpecVersion , runtime_types :: frame_system :: extensions :: check_tx_version :: CheckTxVersion , runtime_types :: frame_system :: extensions :: check_genesis :: CheckGenesis , runtime_types :: frame_system :: extensions :: check_mortality :: CheckMortality , runtime_types :: frame_system :: extensions :: check_nonce :: CheckNonce , runtime_types :: frame_system :: extensions :: check_weight :: CheckWeight , runtime_types :: pallet_transaction_payment :: ChargeTransactionPayment , runtime_types :: polkadot_runtime_common :: claims :: PrevalidateAttests ,) > > , }
+                pub struct ExecuteBlock { pub block : runtime_types :: sp_runtime :: generic :: block :: Block < runtime_types :: sp_runtime :: generic :: header :: Header < :: core :: primitive :: u32 , runtime_types :: sp_runtime :: traits :: BlakeTwo256 > , :: subxt :: utils :: UncheckedExtrinsic < :: subxt :: utils :: MultiAddress < :: subxt :: utils :: AccountId32 , () > , runtime_types :: polkadot_runtime :: RuntimeCall , runtime_types :: sp_runtime :: MultiSignature , (runtime_types :: frame_system :: extensions :: check_non_zero_sender :: CheckNonZeroSender , runtime_types :: frame_system :: extensions :: check_spec_version :: CheckSpecVersion , runtime_types :: frame_system :: extensions :: check_tx_version :: CheckTxVersion , runtime_types :: frame_system :: extensions :: check_genesis :: CheckGenesis , runtime_types :: frame_system :: extensions :: check_mortality :: CheckMortality , runtime_types :: frame_system :: extensions :: check_nonce :: CheckNonce , runtime_types :: frame_system :: extensions :: check_weight :: CheckWeight , runtime_types :: pallet_transaction_payment :: ChargeTransactionPayment , runtime_types :: polkadot_runtime_common :: claims :: PrevalidateAttests ,) > > , }
                 #[derive(
                     :: subxt :: ext :: codec :: Decode,
                     :: subxt :: ext :: codec :: Encode,
@@ -393,7 +393,7 @@ pub mod api {
                 #[doc = " this block or not."]
                 pub fn apply_extrinsic(
                     &self,
-                    extrinsic : runtime_types :: sp_runtime :: generic :: unchecked_extrinsic :: UncheckedExtrinsic < :: subxt :: utils :: MultiAddress < :: subxt :: utils :: AccountId32 , () > , runtime_types :: polkadot_runtime :: RuntimeCall , runtime_types :: sp_runtime :: MultiSignature , (runtime_types :: frame_system :: extensions :: check_non_zero_sender :: CheckNonZeroSender , runtime_types :: frame_system :: extensions :: check_spec_version :: CheckSpecVersion , runtime_types :: frame_system :: extensions :: check_tx_version :: CheckTxVersion , runtime_types :: frame_system :: extensions :: check_genesis :: CheckGenesis , runtime_types :: frame_system :: extensions :: check_mortality :: CheckMortality , runtime_types :: frame_system :: extensions :: check_nonce :: CheckNonce , runtime_types :: frame_system :: extensions :: check_weight :: CheckWeight , runtime_types :: pallet_transaction_payment :: ChargeTransactionPayment , runtime_types :: polkadot_runtime_common :: claims :: PrevalidateAttests ,) >,
+                    extrinsic : :: subxt :: utils :: UncheckedExtrinsic < :: subxt :: utils :: MultiAddress < :: subxt :: utils :: AccountId32 , () > , runtime_types :: polkadot_runtime :: RuntimeCall , runtime_types :: sp_runtime :: MultiSignature , (runtime_types :: frame_system :: extensions :: check_non_zero_sender :: CheckNonZeroSender , runtime_types :: frame_system :: extensions :: check_spec_version :: CheckSpecVersion , runtime_types :: frame_system :: extensions :: check_tx_version :: CheckTxVersion , runtime_types :: frame_system :: extensions :: check_genesis :: CheckGenesis , runtime_types :: frame_system :: extensions :: check_mortality :: CheckMortality , runtime_types :: frame_system :: extensions :: check_nonce :: CheckNonce , runtime_types :: frame_system :: extensions :: check_weight :: CheckWeight , runtime_types :: pallet_transaction_payment :: ChargeTransactionPayment , runtime_types :: polkadot_runtime_common :: claims :: PrevalidateAttests ,) >,
                 ) -> ::subxt::runtime_api::Payload<
                     types::ApplyExtrinsic,
                     ::core::result::Result<
@@ -433,7 +433,7 @@ pub mod api {
                         ],
                     )
                 }
-                #[doc = " Generate inherent extrinsics. The inherent data will vary from chain to chain."]                pub fn inherent_extrinsics (& self , inherent : runtime_types :: sp_inherents :: InherentData ,) -> :: subxt :: runtime_api :: Payload < types :: InherentExtrinsics , :: std :: vec :: Vec < runtime_types :: sp_runtime :: generic :: unchecked_extrinsic :: UncheckedExtrinsic < :: subxt :: utils :: MultiAddress < :: subxt :: utils :: AccountId32 , () > , runtime_types :: polkadot_runtime :: RuntimeCall , runtime_types :: sp_runtime :: MultiSignature , (runtime_types :: frame_system :: extensions :: check_non_zero_sender :: CheckNonZeroSender , runtime_types :: frame_system :: extensions :: check_spec_version :: CheckSpecVersion , runtime_types :: frame_system :: extensions :: check_tx_version :: CheckTxVersion , runtime_types :: frame_system :: extensions :: check_genesis :: CheckGenesis , runtime_types :: frame_system :: extensions :: check_mortality :: CheckMortality , runtime_types :: frame_system :: extensions :: check_nonce :: CheckNonce , runtime_types :: frame_system :: extensions :: check_weight :: CheckWeight , runtime_types :: pallet_transaction_payment :: ChargeTransactionPayment , runtime_types :: polkadot_runtime_common :: claims :: PrevalidateAttests ,) > > >{
+                #[doc = " Generate inherent extrinsics. The inherent data will vary from chain to chain."]                pub fn inherent_extrinsics (& self , inherent : runtime_types :: sp_inherents :: InherentData ,) -> :: subxt :: runtime_api :: Payload < types :: InherentExtrinsics , :: std :: vec :: Vec < :: subxt :: utils :: UncheckedExtrinsic < :: subxt :: utils :: MultiAddress < :: subxt :: utils :: AccountId32 , () > , runtime_types :: polkadot_runtime :: RuntimeCall , runtime_types :: sp_runtime :: MultiSignature , (runtime_types :: frame_system :: extensions :: check_non_zero_sender :: CheckNonZeroSender , runtime_types :: frame_system :: extensions :: check_spec_version :: CheckSpecVersion , runtime_types :: frame_system :: extensions :: check_tx_version :: CheckTxVersion , runtime_types :: frame_system :: extensions :: check_genesis :: CheckGenesis , runtime_types :: frame_system :: extensions :: check_mortality :: CheckMortality , runtime_types :: frame_system :: extensions :: check_nonce :: CheckNonce , runtime_types :: frame_system :: extensions :: check_weight :: CheckWeight , runtime_types :: pallet_transaction_payment :: ChargeTransactionPayment , runtime_types :: polkadot_runtime_common :: claims :: PrevalidateAttests ,) > > >{
                     ::subxt::runtime_api::Payload::new_static(
                         "BlockBuilder",
                         "inherent_extrinsics",
@@ -449,7 +449,7 @@ pub mod api {
                 #[doc = " Check that the inherents are valid. The inherent data will vary from chain to chain."]
                 pub fn check_inherents(
                     &self,
-                    block : runtime_types :: sp_runtime :: generic :: block :: Block < runtime_types :: sp_runtime :: generic :: header :: Header < :: core :: primitive :: u32 , runtime_types :: sp_runtime :: traits :: BlakeTwo256 > , runtime_types :: sp_runtime :: generic :: unchecked_extrinsic :: UncheckedExtrinsic < :: subxt :: utils :: MultiAddress < :: subxt :: utils :: AccountId32 , () > , runtime_types :: polkadot_runtime :: RuntimeCall , runtime_types :: sp_runtime :: MultiSignature , (runtime_types :: frame_system :: extensions :: check_non_zero_sender :: CheckNonZeroSender , runtime_types :: frame_system :: extensions :: check_spec_version :: CheckSpecVersion , runtime_types :: frame_system :: extensions :: check_tx_version :: CheckTxVersion , runtime_types :: frame_system :: extensions :: check_genesis :: CheckGenesis , runtime_types :: frame_system :: extensions :: check_mortality :: CheckMortality , runtime_types :: frame_system :: extensions :: check_nonce :: CheckNonce , runtime_types :: frame_system :: extensions :: check_weight :: CheckWeight , runtime_types :: pallet_transaction_payment :: ChargeTransactionPayment , runtime_types :: polkadot_runtime_common :: claims :: PrevalidateAttests ,) > >,
+                    block : runtime_types :: sp_runtime :: generic :: block :: Block < runtime_types :: sp_runtime :: generic :: header :: Header < :: core :: primitive :: u32 , runtime_types :: sp_runtime :: traits :: BlakeTwo256 > , :: subxt :: utils :: UncheckedExtrinsic < :: subxt :: utils :: MultiAddress < :: subxt :: utils :: AccountId32 , () > , runtime_types :: polkadot_runtime :: RuntimeCall , runtime_types :: sp_runtime :: MultiSignature , (runtime_types :: frame_system :: extensions :: check_non_zero_sender :: CheckNonZeroSender , runtime_types :: frame_system :: extensions :: check_spec_version :: CheckSpecVersion , runtime_types :: frame_system :: extensions :: check_tx_version :: CheckTxVersion , runtime_types :: frame_system :: extensions :: check_genesis :: CheckGenesis , runtime_types :: frame_system :: extensions :: check_mortality :: CheckMortality , runtime_types :: frame_system :: extensions :: check_nonce :: CheckNonce , runtime_types :: frame_system :: extensions :: check_weight :: CheckWeight , runtime_types :: pallet_transaction_payment :: ChargeTransactionPayment , runtime_types :: polkadot_runtime_common :: claims :: PrevalidateAttests ,) > >,
                     data: runtime_types::sp_inherents::InherentData,
                 ) -> ::subxt::runtime_api::Payload<
                     types::CheckInherents,
@@ -480,7 +480,7 @@ pub mod api {
                 # [codec (crate = :: subxt :: ext :: codec)]
                 #[decode_as_type(crate_path = ":: subxt :: ext :: scale_decode")]
                 #[encode_as_type(crate_path = ":: subxt :: ext :: scale_encode")]
-                pub struct ApplyExtrinsic { pub extrinsic : runtime_types :: sp_runtime :: generic :: unchecked_extrinsic :: UncheckedExtrinsic < :: subxt :: utils :: MultiAddress < :: subxt :: utils :: AccountId32 , () > , runtime_types :: polkadot_runtime :: RuntimeCall , runtime_types :: sp_runtime :: MultiSignature , (runtime_types :: frame_system :: extensions :: check_non_zero_sender :: CheckNonZeroSender , runtime_types :: frame_system :: extensions :: check_spec_version :: CheckSpecVersion , runtime_types :: frame_system :: extensions :: check_tx_version :: CheckTxVersion , runtime_types :: frame_system :: extensions :: check_genesis :: CheckGenesis , runtime_types :: frame_system :: extensions :: check_mortality :: CheckMortality , runtime_types :: frame_system :: extensions :: check_nonce :: CheckNonce , runtime_types :: frame_system :: extensions :: check_weight :: CheckWeight , runtime_types :: pallet_transaction_payment :: ChargeTransactionPayment , runtime_types :: polkadot_runtime_common :: claims :: PrevalidateAttests ,) > , }
+                pub struct ApplyExtrinsic { pub extrinsic : :: subxt :: utils :: UncheckedExtrinsic < :: subxt :: utils :: MultiAddress < :: subxt :: utils :: AccountId32 , () > , runtime_types :: polkadot_runtime :: RuntimeCall , runtime_types :: sp_runtime :: MultiSignature , (runtime_types :: frame_system :: extensions :: check_non_zero_sender :: CheckNonZeroSender , runtime_types :: frame_system :: extensions :: check_spec_version :: CheckSpecVersion , runtime_types :: frame_system :: extensions :: check_tx_version :: CheckTxVersion , runtime_types :: frame_system :: extensions :: check_genesis :: CheckGenesis , runtime_types :: frame_system :: extensions :: check_mortality :: CheckMortality , runtime_types :: frame_system :: extensions :: check_nonce :: CheckNonce , runtime_types :: frame_system :: extensions :: check_weight :: CheckWeight , runtime_types :: pallet_transaction_payment :: ChargeTransactionPayment , runtime_types :: polkadot_runtime_common :: claims :: PrevalidateAttests ,) > , }
                 #[derive(
                     :: subxt :: ext :: codec :: Decode,
                     :: subxt :: ext :: codec :: Encode,
@@ -515,7 +515,7 @@ pub mod api {
                 # [codec (crate = :: subxt :: ext :: codec)]
                 #[decode_as_type(crate_path = ":: subxt :: ext :: scale_decode")]
                 #[encode_as_type(crate_path = ":: subxt :: ext :: scale_encode")]
-                pub struct CheckInherents { pub block : runtime_types :: sp_runtime :: generic :: block :: Block < runtime_types :: sp_runtime :: generic :: header :: Header < :: core :: primitive :: u32 , runtime_types :: sp_runtime :: traits :: BlakeTwo256 > , runtime_types :: sp_runtime :: generic :: unchecked_extrinsic :: UncheckedExtrinsic < :: subxt :: utils :: MultiAddress < :: subxt :: utils :: AccountId32 , () > , runtime_types :: polkadot_runtime :: RuntimeCall , runtime_types :: sp_runtime :: MultiSignature , (runtime_types :: frame_system :: extensions :: check_non_zero_sender :: CheckNonZeroSender , runtime_types :: frame_system :: extensions :: check_spec_version :: CheckSpecVersion , runtime_types :: frame_system :: extensions :: check_tx_version :: CheckTxVersion , runtime_types :: frame_system :: extensions :: check_genesis :: CheckGenesis , runtime_types :: frame_system :: extensions :: check_mortality :: CheckMortality , runtime_types :: frame_system :: extensions :: check_nonce :: CheckNonce , runtime_types :: frame_system :: extensions :: check_weight :: CheckWeight , runtime_types :: pallet_transaction_payment :: ChargeTransactionPayment , runtime_types :: polkadot_runtime_common :: claims :: PrevalidateAttests ,) > > , pub data : runtime_types :: sp_inherents :: InherentData , }
+                pub struct CheckInherents { pub block : runtime_types :: sp_runtime :: generic :: block :: Block < runtime_types :: sp_runtime :: generic :: header :: Header < :: core :: primitive :: u32 , runtime_types :: sp_runtime :: traits :: BlakeTwo256 > , :: subxt :: utils :: UncheckedExtrinsic < :: subxt :: utils :: MultiAddress < :: subxt :: utils :: AccountId32 , () > , runtime_types :: polkadot_runtime :: RuntimeCall , runtime_types :: sp_runtime :: MultiSignature , (runtime_types :: frame_system :: extensions :: check_non_zero_sender :: CheckNonZeroSender , runtime_types :: frame_system :: extensions :: check_spec_version :: CheckSpecVersion , runtime_types :: frame_system :: extensions :: check_tx_version :: CheckTxVersion , runtime_types :: frame_system :: extensions :: check_genesis :: CheckGenesis , runtime_types :: frame_system :: extensions :: check_mortality :: CheckMortality , runtime_types :: frame_system :: extensions :: check_nonce :: CheckNonce , runtime_types :: frame_system :: extensions :: check_weight :: CheckWeight , runtime_types :: pallet_transaction_payment :: ChargeTransactionPayment , runtime_types :: polkadot_runtime_common :: claims :: PrevalidateAttests ,) > > , pub data : runtime_types :: sp_inherents :: InherentData , }
             }
         }
         pub mod nomination_pools_api {
@@ -685,7 +685,7 @@ pub mod api {
                 pub fn validate_transaction(
                     &self,
                     source: runtime_types::sp_runtime::transaction_validity::TransactionSource,
-                    tx : runtime_types :: sp_runtime :: generic :: unchecked_extrinsic :: UncheckedExtrinsic < :: subxt :: utils :: MultiAddress < :: subxt :: utils :: AccountId32 , () > , runtime_types :: polkadot_runtime :: RuntimeCall , runtime_types :: sp_runtime :: MultiSignature , (runtime_types :: frame_system :: extensions :: check_non_zero_sender :: CheckNonZeroSender , runtime_types :: frame_system :: extensions :: check_spec_version :: CheckSpecVersion , runtime_types :: frame_system :: extensions :: check_tx_version :: CheckTxVersion , runtime_types :: frame_system :: extensions :: check_genesis :: CheckGenesis , runtime_types :: frame_system :: extensions :: check_mortality :: CheckMortality , runtime_types :: frame_system :: extensions :: check_nonce :: CheckNonce , runtime_types :: frame_system :: extensions :: check_weight :: CheckWeight , runtime_types :: pallet_transaction_payment :: ChargeTransactionPayment , runtime_types :: polkadot_runtime_common :: claims :: PrevalidateAttests ,) >,
+                    tx : :: subxt :: utils :: UncheckedExtrinsic < :: subxt :: utils :: MultiAddress < :: subxt :: utils :: AccountId32 , () > , runtime_types :: polkadot_runtime :: RuntimeCall , runtime_types :: sp_runtime :: MultiSignature , (runtime_types :: frame_system :: extensions :: check_non_zero_sender :: CheckNonZeroSender , runtime_types :: frame_system :: extensions :: check_spec_version :: CheckSpecVersion , runtime_types :: frame_system :: extensions :: check_tx_version :: CheckTxVersion , runtime_types :: frame_system :: extensions :: check_genesis :: CheckGenesis , runtime_types :: frame_system :: extensions :: check_mortality :: CheckMortality , runtime_types :: frame_system :: extensions :: check_nonce :: CheckNonce , runtime_types :: frame_system :: extensions :: check_weight :: CheckWeight , runtime_types :: pallet_transaction_payment :: ChargeTransactionPayment , runtime_types :: polkadot_runtime_common :: claims :: PrevalidateAttests ,) >,
                     block_hash: ::subxt::utils::H256,
                 ) -> ::subxt::runtime_api::Payload<
                     types::ValidateTransaction,
@@ -722,7 +722,7 @@ pub mod api {
                 # [codec (crate = :: subxt :: ext :: codec)]
                 #[decode_as_type(crate_path = ":: subxt :: ext :: scale_decode")]
                 #[encode_as_type(crate_path = ":: subxt :: ext :: scale_encode")]
-                pub struct ValidateTransaction { pub source : runtime_types :: sp_runtime :: transaction_validity :: TransactionSource , pub tx : runtime_types :: sp_runtime :: generic :: unchecked_extrinsic :: UncheckedExtrinsic < :: subxt :: utils :: MultiAddress < :: subxt :: utils :: AccountId32 , () > , runtime_types :: polkadot_runtime :: RuntimeCall , runtime_types :: sp_runtime :: MultiSignature , (runtime_types :: frame_system :: extensions :: check_non_zero_sender :: CheckNonZeroSender , runtime_types :: frame_system :: extensions :: check_spec_version :: CheckSpecVersion , runtime_types :: frame_system :: extensions :: check_tx_version :: CheckTxVersion , runtime_types :: frame_system :: extensions :: check_genesis :: CheckGenesis , runtime_types :: frame_system :: extensions :: check_mortality :: CheckMortality , runtime_types :: frame_system :: extensions :: check_nonce :: CheckNonce , runtime_types :: frame_system :: extensions :: check_weight :: CheckWeight , runtime_types :: pallet_transaction_payment :: ChargeTransactionPayment , runtime_types :: polkadot_runtime_common :: claims :: PrevalidateAttests ,) > , pub block_hash : :: subxt :: utils :: H256 , }
+                pub struct ValidateTransaction { pub source : runtime_types :: sp_runtime :: transaction_validity :: TransactionSource , pub tx : :: subxt :: utils :: UncheckedExtrinsic < :: subxt :: utils :: MultiAddress < :: subxt :: utils :: AccountId32 , () > , runtime_types :: polkadot_runtime :: RuntimeCall , runtime_types :: sp_runtime :: MultiSignature , (runtime_types :: frame_system :: extensions :: check_non_zero_sender :: CheckNonZeroSender , runtime_types :: frame_system :: extensions :: check_spec_version :: CheckSpecVersion , runtime_types :: frame_system :: extensions :: check_tx_version :: CheckTxVersion , runtime_types :: frame_system :: extensions :: check_genesis :: CheckGenesis , runtime_types :: frame_system :: extensions :: check_mortality :: CheckMortality , runtime_types :: frame_system :: extensions :: check_nonce :: CheckNonce , runtime_types :: frame_system :: extensions :: check_weight :: CheckWeight , runtime_types :: pallet_transaction_payment :: ChargeTransactionPayment , runtime_types :: polkadot_runtime_common :: claims :: PrevalidateAttests ,) > , pub block_hash : :: subxt :: utils :: H256 , }
             }
         }
         pub mod offchain_worker_api {
@@ -2615,7 +2615,7 @@ pub mod api {
             impl TransactionPaymentApi {
                 pub fn query_info(
                     &self,
-                    uxt : runtime_types :: sp_runtime :: generic :: unchecked_extrinsic :: UncheckedExtrinsic < :: subxt :: utils :: MultiAddress < :: subxt :: utils :: AccountId32 , () > , runtime_types :: polkadot_runtime :: RuntimeCall , runtime_types :: sp_runtime :: MultiSignature , (runtime_types :: frame_system :: extensions :: check_non_zero_sender :: CheckNonZeroSender , runtime_types :: frame_system :: extensions :: check_spec_version :: CheckSpecVersion , runtime_types :: frame_system :: extensions :: check_tx_version :: CheckTxVersion , runtime_types :: frame_system :: extensions :: check_genesis :: CheckGenesis , runtime_types :: frame_system :: extensions :: check_mortality :: CheckMortality , runtime_types :: frame_system :: extensions :: check_nonce :: CheckNonce , runtime_types :: frame_system :: extensions :: check_weight :: CheckWeight , runtime_types :: pallet_transaction_payment :: ChargeTransactionPayment , runtime_types :: polkadot_runtime_common :: claims :: PrevalidateAttests ,) >,
+                    uxt : :: subxt :: utils :: UncheckedExtrinsic < :: subxt :: utils :: MultiAddress < :: subxt :: utils :: AccountId32 , () > , runtime_types :: polkadot_runtime :: RuntimeCall , runtime_types :: sp_runtime :: MultiSignature , (runtime_types :: frame_system :: extensions :: check_non_zero_sender :: CheckNonZeroSender , runtime_types :: frame_system :: extensions :: check_spec_version :: CheckSpecVersion , runtime_types :: frame_system :: extensions :: check_tx_version :: CheckTxVersion , runtime_types :: frame_system :: extensions :: check_genesis :: CheckGenesis , runtime_types :: frame_system :: extensions :: check_mortality :: CheckMortality , runtime_types :: frame_system :: extensions :: check_nonce :: CheckNonce , runtime_types :: frame_system :: extensions :: check_weight :: CheckWeight , runtime_types :: pallet_transaction_payment :: ChargeTransactionPayment , runtime_types :: polkadot_runtime_common :: claims :: PrevalidateAttests ,) >,
                     len: ::core::primitive::u32,
                 ) -> ::subxt::runtime_api::Payload<
                     types::QueryInfo,
@@ -2637,7 +2637,7 @@ pub mod api {
                 }
                 pub fn query_fee_details(
                     &self,
-                    uxt : runtime_types :: sp_runtime :: generic :: unchecked_extrinsic :: UncheckedExtrinsic < :: subxt :: utils :: MultiAddress < :: subxt :: utils :: AccountId32 , () > , runtime_types :: polkadot_runtime :: RuntimeCall , runtime_types :: sp_runtime :: MultiSignature , (runtime_types :: frame_system :: extensions :: check_non_zero_sender :: CheckNonZeroSender , runtime_types :: frame_system :: extensions :: check_spec_version :: CheckSpecVersion , runtime_types :: frame_system :: extensions :: check_tx_version :: CheckTxVersion , runtime_types :: frame_system :: extensions :: check_genesis :: CheckGenesis , runtime_types :: frame_system :: extensions :: check_mortality :: CheckMortality , runtime_types :: frame_system :: extensions :: check_nonce :: CheckNonce , runtime_types :: frame_system :: extensions :: check_weight :: CheckWeight , runtime_types :: pallet_transaction_payment :: ChargeTransactionPayment , runtime_types :: polkadot_runtime_common :: claims :: PrevalidateAttests ,) >,
+                    uxt : :: subxt :: utils :: UncheckedExtrinsic < :: subxt :: utils :: MultiAddress < :: subxt :: utils :: AccountId32 , () > , runtime_types :: polkadot_runtime :: RuntimeCall , runtime_types :: sp_runtime :: MultiSignature , (runtime_types :: frame_system :: extensions :: check_non_zero_sender :: CheckNonZeroSender , runtime_types :: frame_system :: extensions :: check_spec_version :: CheckSpecVersion , runtime_types :: frame_system :: extensions :: check_tx_version :: CheckTxVersion , runtime_types :: frame_system :: extensions :: check_genesis :: CheckGenesis , runtime_types :: frame_system :: extensions :: check_mortality :: CheckMortality , runtime_types :: frame_system :: extensions :: check_nonce :: CheckNonce , runtime_types :: frame_system :: extensions :: check_weight :: CheckWeight , runtime_types :: pallet_transaction_payment :: ChargeTransactionPayment , runtime_types :: polkadot_runtime_common :: claims :: PrevalidateAttests ,) >,
                     len: ::core::primitive::u32,
                 ) -> ::subxt::runtime_api::Payload<
                     types::QueryFeeDetails,
@@ -2703,7 +2703,7 @@ pub mod api {
                 # [codec (crate = :: subxt :: ext :: codec)]
                 #[decode_as_type(crate_path = ":: subxt :: ext :: scale_decode")]
                 #[encode_as_type(crate_path = ":: subxt :: ext :: scale_encode")]
-                pub struct QueryInfo { pub uxt : runtime_types :: sp_runtime :: generic :: unchecked_extrinsic :: UncheckedExtrinsic < :: subxt :: utils :: MultiAddress < :: subxt :: utils :: AccountId32 , () > , runtime_types :: polkadot_runtime :: RuntimeCall , runtime_types :: sp_runtime :: MultiSignature , (runtime_types :: frame_system :: extensions :: check_non_zero_sender :: CheckNonZeroSender , runtime_types :: frame_system :: extensions :: check_spec_version :: CheckSpecVersion , runtime_types :: frame_system :: extensions :: check_tx_version :: CheckTxVersion , runtime_types :: frame_system :: extensions :: check_genesis :: CheckGenesis , runtime_types :: frame_system :: extensions :: check_mortality :: CheckMortality , runtime_types :: frame_system :: extensions :: check_nonce :: CheckNonce , runtime_types :: frame_system :: extensions :: check_weight :: CheckWeight , runtime_types :: pallet_transaction_payment :: ChargeTransactionPayment , runtime_types :: polkadot_runtime_common :: claims :: PrevalidateAttests ,) > , pub len : :: core :: primitive :: u32 , }
+                pub struct QueryInfo { pub uxt : :: subxt :: utils :: UncheckedExtrinsic < :: subxt :: utils :: MultiAddress < :: subxt :: utils :: AccountId32 , () > , runtime_types :: polkadot_runtime :: RuntimeCall , runtime_types :: sp_runtime :: MultiSignature , (runtime_types :: frame_system :: extensions :: check_non_zero_sender :: CheckNonZeroSender , runtime_types :: frame_system :: extensions :: check_spec_version :: CheckSpecVersion , runtime_types :: frame_system :: extensions :: check_tx_version :: CheckTxVersion , runtime_types :: frame_system :: extensions :: check_genesis :: CheckGenesis , runtime_types :: frame_system :: extensions :: check_mortality :: CheckMortality , runtime_types :: frame_system :: extensions :: check_nonce :: CheckNonce , runtime_types :: frame_system :: extensions :: check_weight :: CheckWeight , runtime_types :: pallet_transaction_payment :: ChargeTransactionPayment , runtime_types :: polkadot_runtime_common :: claims :: PrevalidateAttests ,) > , pub len : :: core :: primitive :: u32 , }
                 #[derive(
                     :: subxt :: ext :: codec :: Decode,
                     :: subxt :: ext :: codec :: Encode,
@@ -2714,7 +2714,7 @@ pub mod api {
                 # [codec (crate = :: subxt :: ext :: codec)]
                 #[decode_as_type(crate_path = ":: subxt :: ext :: scale_decode")]
                 #[encode_as_type(crate_path = ":: subxt :: ext :: scale_encode")]
-                pub struct QueryFeeDetails { pub uxt : runtime_types :: sp_runtime :: generic :: unchecked_extrinsic :: UncheckedExtrinsic < :: subxt :: utils :: MultiAddress < :: subxt :: utils :: AccountId32 , () > , runtime_types :: polkadot_runtime :: RuntimeCall , runtime_types :: sp_runtime :: MultiSignature , (runtime_types :: frame_system :: extensions :: check_non_zero_sender :: CheckNonZeroSender , runtime_types :: frame_system :: extensions :: check_spec_version :: CheckSpecVersion , runtime_types :: frame_system :: extensions :: check_tx_version :: CheckTxVersion , runtime_types :: frame_system :: extensions :: check_genesis :: CheckGenesis , runtime_types :: frame_system :: extensions :: check_mortality :: CheckMortality , runtime_types :: frame_system :: extensions :: check_nonce :: CheckNonce , runtime_types :: frame_system :: extensions :: check_weight :: CheckWeight , runtime_types :: pallet_transaction_payment :: ChargeTransactionPayment , runtime_types :: polkadot_runtime_common :: claims :: PrevalidateAttests ,) > , pub len : :: core :: primitive :: u32 , }
+                pub struct QueryFeeDetails { pub uxt : :: subxt :: utils :: UncheckedExtrinsic < :: subxt :: utils :: MultiAddress < :: subxt :: utils :: AccountId32 , () > , runtime_types :: polkadot_runtime :: RuntimeCall , runtime_types :: sp_runtime :: MultiSignature , (runtime_types :: frame_system :: extensions :: check_non_zero_sender :: CheckNonZeroSender , runtime_types :: frame_system :: extensions :: check_spec_version :: CheckSpecVersion , runtime_types :: frame_system :: extensions :: check_tx_version :: CheckTxVersion , runtime_types :: frame_system :: extensions :: check_genesis :: CheckGenesis , runtime_types :: frame_system :: extensions :: check_mortality :: CheckMortality , runtime_types :: frame_system :: extensions :: check_nonce :: CheckNonce , runtime_types :: frame_system :: extensions :: check_weight :: CheckWeight , runtime_types :: pallet_transaction_payment :: ChargeTransactionPayment , runtime_types :: polkadot_runtime_common :: claims :: PrevalidateAttests ,) > , pub len : :: core :: primitive :: u32 , }
                 #[derive(
                     :: subxt :: ext :: codec :: Decode,
                     :: subxt :: ext :: codec :: Encode,
@@ -2888,6 +2888,11 @@ pub mod api {
             }
         }
     }
+    pub fn custom() -> CustomValuesApi {
+        CustomValuesApi
+    }
+    pub struct CustomValuesApi;
+    impl CustomValuesApi {}
     pub struct ConstantsApi;
     impl ConstantsApi {
         pub fn system(&self) -> system::constants::ConstantsApi {
@@ -3323,9 +3328,9 @@ pub mod api {
             .hash();
         runtime_metadata_hash
             == [
-                204u8, 158u8, 238u8, 144u8, 220u8, 96u8, 96u8, 35u8, 147u8, 66u8, 177u8, 19u8,
-                58u8, 106u8, 24u8, 55u8, 42u8, 156u8, 131u8, 153u8, 182u8, 103u8, 67u8, 242u8,
-                32u8, 199u8, 203u8, 120u8, 169u8, 2u8, 171u8, 125u8,
+                63u8, 112u8, 153u8, 58u8, 108u8, 232u8, 33u8, 100u8, 197u8, 178u8, 237u8, 162u8,
+                47u8, 16u8, 185u8, 0u8, 6u8, 96u8, 45u8, 233u8, 217u8, 166u8, 1u8, 188u8, 28u8,
+                141u8, 116u8, 206u8, 125u8, 179u8, 115u8, 76u8,
             ]
     }
     pub mod system {
@@ -7624,7 +7629,7 @@ pub mod api {
                     &self,
                 ) -> ::subxt::storage::address::Address<
                     ::subxt::storage::address::StaticStorageMapKey,
-                    runtime_types::sp_arithmetic::fixed_point::FixedU128,
+                    ::subxt::ext::sp_arithmetic::fixed_point::FixedU128,
                     ::subxt::storage::address::Yes,
                     ::subxt::storage::address::Yes,
                     (),
@@ -7958,7 +7963,7 @@ pub mod api {
                 #[decode_as_type(crate_path = ":: subxt :: ext :: scale_decode")]
                 #[encode_as_type(crate_path = ":: subxt :: ext :: scale_encode")]
                 pub struct ScaleValidatorCount {
-                    pub factor: runtime_types::sp_arithmetic::per_things::Percent,
+                    pub factor: ::subxt::ext::sp_arithmetic::per_things::Percent,
                 }
                 impl ::subxt::blocks::StaticExtrinsic for ScaleValidatorCount {
                     const PALLET: &'static str = "Staking";
@@ -8161,10 +8166,10 @@ pub mod api {
                             ::core::primitive::u32,
                         >,
                     pub chill_threshold: runtime_types::pallet_staking::pallet::pallet::ConfigOp<
-                        runtime_types::sp_arithmetic::per_things::Percent,
+                        ::subxt::ext::sp_arithmetic::per_things::Percent,
                     >,
                     pub min_commission: runtime_types::pallet_staking::pallet::pallet::ConfigOp<
-                        runtime_types::sp_arithmetic::per_things::Perbill,
+                        ::subxt::ext::sp_arithmetic::per_things::Perbill,
                     >,
                 }
                 impl ::subxt::blocks::StaticExtrinsic for SetStakingConfigs {
@@ -8216,7 +8221,7 @@ pub mod api {
                 #[decode_as_type(crate_path = ":: subxt :: ext :: scale_decode")]
                 #[encode_as_type(crate_path = ":: subxt :: ext :: scale_encode")]
                 pub struct SetMinCommission {
-                    pub new: runtime_types::sp_arithmetic::per_things::Perbill,
+                    pub new: ::subxt::ext::sp_arithmetic::per_things::Perbill,
                 }
                 impl ::subxt::blocks::StaticExtrinsic for SetMinCommission {
                     const PALLET: &'static str = "Staking";
@@ -8411,7 +8416,7 @@ pub mod api {
                 #[doc = "See [`Pallet::scale_validator_count`]."]
                 pub fn scale_validator_count(
                     &self,
-                    factor: runtime_types::sp_arithmetic::per_things::Percent,
+                    factor: ::subxt::ext::sp_arithmetic::per_things::Percent,
                 ) -> ::subxt::tx::Payload<types::ScaleValidatorCount> {
                     ::subxt::tx::Payload::new_static(
                         "Staking",
@@ -8611,10 +8616,10 @@ pub mod api {
                         ::core::primitive::u32,
                     >,
                     chill_threshold: runtime_types::pallet_staking::pallet::pallet::ConfigOp<
-                        runtime_types::sp_arithmetic::per_things::Percent,
+                        ::subxt::ext::sp_arithmetic::per_things::Percent,
                     >,
                     min_commission: runtime_types::pallet_staking::pallet::pallet::ConfigOp<
-                        runtime_types::sp_arithmetic::per_things::Perbill,
+                        ::subxt::ext::sp_arithmetic::per_things::Perbill,
                     >,
                 ) -> ::subxt::tx::Payload<types::SetStakingConfigs> {
                     ::subxt::tx::Payload::new_static(
@@ -8670,7 +8675,7 @@ pub mod api {
                 #[doc = "See [`Pallet::set_min_commission`]."]
                 pub fn set_min_commission(
                     &self,
-                    new: runtime_types::sp_arithmetic::per_things::Perbill,
+                    new: ::subxt::ext::sp_arithmetic::per_things::Perbill,
                 ) -> ::subxt::tx::Payload<types::SetMinCommission> {
                     ::subxt::tx::Payload::new_static(
                         "Staking",
@@ -8763,7 +8768,7 @@ pub mod api {
             #[doc = "era as been reported."]
             pub struct SlashReported {
                 pub validator: ::subxt::utils::AccountId32,
-                pub fraction: runtime_types::sp_arithmetic::per_things::Perbill,
+                pub fraction: ::subxt::ext::sp_arithmetic::per_things::Perbill,
                 pub slash_era: ::core::primitive::u32,
             }
             impl ::subxt::events::StaticEvent for SlashReported {
@@ -9171,7 +9176,7 @@ pub mod api {
                     &self,
                 ) -> ::subxt::storage::address::Address<
                     ::subxt::storage::address::StaticStorageMapKey,
-                    runtime_types::sp_arithmetic::per_things::Perbill,
+                    ::subxt::ext::sp_arithmetic::per_things::Perbill,
                     ::subxt::storage::address::Yes,
                     ::subxt::storage::address::Yes,
                     (),
@@ -10070,7 +10075,7 @@ pub mod api {
                     &self,
                 ) -> ::subxt::storage::address::Address<
                     ::subxt::storage::address::StaticStorageMapKey,
-                    runtime_types::sp_arithmetic::per_things::Perbill,
+                    ::subxt::ext::sp_arithmetic::per_things::Perbill,
                     ::subxt::storage::address::Yes,
                     ::subxt::storage::address::Yes,
                     (),
@@ -10199,7 +10204,7 @@ pub mod api {
                 ) -> ::subxt::storage::address::Address<
                     ::subxt::storage::address::StaticStorageMapKey,
                     (
-                        runtime_types::sp_arithmetic::per_things::Perbill,
+                        ::subxt::ext::sp_arithmetic::per_things::Perbill,
                         ::core::primitive::u128,
                     ),
                     (),
@@ -10225,7 +10230,7 @@ pub mod api {
                 ) -> ::subxt::storage::address::Address<
                     ::subxt::storage::address::StaticStorageMapKey,
                     (
-                        runtime_types::sp_arithmetic::per_things::Perbill,
+                        ::subxt::ext::sp_arithmetic::per_things::Perbill,
                         ::core::primitive::u128,
                     ),
                     (),
@@ -10254,7 +10259,7 @@ pub mod api {
                 ) -> ::subxt::storage::address::Address<
                     ::subxt::storage::address::StaticStorageMapKey,
                     (
-                        runtime_types::sp_arithmetic::per_things::Perbill,
+                        ::subxt::ext::sp_arithmetic::per_things::Perbill,
                         ::core::primitive::u128,
                     ),
                     ::subxt::storage::address::Yes,
@@ -10527,7 +10532,7 @@ pub mod api {
                     &self,
                 ) -> ::subxt::storage::address::Address<
                     ::subxt::storage::address::StaticStorageMapKey,
-                    runtime_types::sp_arithmetic::per_things::Percent,
+                    ::subxt::ext::sp_arithmetic::per_things::Percent,
                     ::subxt::storage::address::Yes,
                     (),
                     (),
@@ -16569,7 +16574,7 @@ pub mod api {
                 #[doc = " An accepted proposal gets these back. A rejected proposal does not."]
                 pub fn proposal_bond(
                     &self,
-                ) -> ::subxt::constants::Address<runtime_types::sp_arithmetic::per_things::Permill>
+                ) -> ::subxt::constants::Address<::subxt::ext::sp_arithmetic::per_things::Permill>
                 {
                     ::subxt::constants::Address::new_static(
                         "Treasury",
@@ -16627,7 +16632,7 @@ pub mod api {
                 #[doc = " Percentage of spare funds (if any) that are burnt per spend period."]
                 pub fn burn(
                     &self,
-                ) -> ::subxt::constants::Address<runtime_types::sp_arithmetic::per_things::Permill>
+                ) -> ::subxt::constants::Address<::subxt::ext::sp_arithmetic::per_things::Permill>
                 {
                     ::subxt::constants::Address::new_static(
                         "Treasury",
@@ -22664,7 +22669,7 @@ pub mod api {
                 #[doc = " `CuratorDepositMin`."]
                 pub fn curator_deposit_multiplier(
                     &self,
-                ) -> ::subxt::constants::Address<runtime_types::sp_arithmetic::per_things::Permill>
+                ) -> ::subxt::constants::Address<::subxt::ext::sp_arithmetic::per_things::Permill>
                 {
                     ::subxt::constants::Address::new_static(
                         "Bounties",
@@ -23943,7 +23948,7 @@ pub mod api {
                 #[doc = " The percent of the final tip which goes to the original reporter of the tip."]
                 pub fn tip_finders_fee(
                     &self,
-                ) -> ::subxt::constants::Address<runtime_types::sp_arithmetic::per_things::Percent>
+                ) -> ::subxt::constants::Address<::subxt::ext::sp_arithmetic::per_things::Percent>
                 {
                     ::subxt::constants::Address::new_static(
                         "Tips",
@@ -24664,7 +24669,7 @@ pub mod api {
                 #[doc = " \"better\" in the Signed phase."]
                 pub fn better_signed_threshold(
                     &self,
-                ) -> ::subxt::constants::Address<runtime_types::sp_arithmetic::per_things::Perbill>
+                ) -> ::subxt::constants::Address<::subxt::ext::sp_arithmetic::per_things::Perbill>
                 {
                     ::subxt::constants::Address::new_static(
                         "ElectionProviderMultiPhase",
@@ -24680,7 +24685,7 @@ pub mod api {
                 #[doc = " \"better\" in the Unsigned phase."]
                 pub fn better_unsigned_threshold(
                     &self,
-                ) -> ::subxt::constants::Address<runtime_types::sp_arithmetic::per_things::Perbill>
+                ) -> ::subxt::constants::Address<::subxt::ext::sp_arithmetic::per_things::Perbill>
                 {
                     ::subxt::constants::Address::new_static(
                         "ElectionProviderMultiPhase",
@@ -25503,7 +25508,7 @@ pub mod api {
                     pub max_members_per_pool:
                         runtime_types::pallet_nomination_pools::ConfigOp<::core::primitive::u32>,
                     pub global_max_commission: runtime_types::pallet_nomination_pools::ConfigOp<
-                        runtime_types::sp_arithmetic::per_things::Perbill,
+                        ::subxt::ext::sp_arithmetic::per_things::Perbill,
                     >,
                 }
                 impl ::subxt::blocks::StaticExtrinsic for SetConfigs {
@@ -25620,7 +25625,7 @@ pub mod api {
                 pub struct SetCommission {
                     pub pool_id: ::core::primitive::u32,
                     pub new_commission: ::core::option::Option<(
-                        runtime_types::sp_arithmetic::per_things::Perbill,
+                        ::subxt::ext::sp_arithmetic::per_things::Perbill,
                         ::subxt::utils::AccountId32,
                     )>,
                 }
@@ -25640,7 +25645,7 @@ pub mod api {
                 #[encode_as_type(crate_path = ":: subxt :: ext :: scale_encode")]
                 pub struct SetCommissionMax {
                     pub pool_id: ::core::primitive::u32,
-                    pub max_commission: runtime_types::sp_arithmetic::per_things::Perbill,
+                    pub max_commission: ::subxt::ext::sp_arithmetic::per_things::Perbill,
                 }
                 impl ::subxt::blocks::StaticExtrinsic for SetCommissionMax {
                     const PALLET: &'static str = "NominationPools";
@@ -25922,7 +25927,7 @@ pub mod api {
                         ::core::primitive::u32,
                     >,
                     global_max_commission: runtime_types::pallet_nomination_pools::ConfigOp<
-                        runtime_types::sp_arithmetic::per_things::Perbill,
+                        ::subxt::ext::sp_arithmetic::per_things::Perbill,
                     >,
                 ) -> ::subxt::tx::Payload<types::SetConfigs> {
                     ::subxt::tx::Payload::new_static(
@@ -26048,7 +26053,7 @@ pub mod api {
                     &self,
                     pool_id: ::core::primitive::u32,
                     new_commission: ::core::option::Option<(
-                        runtime_types::sp_arithmetic::per_things::Perbill,
+                        ::subxt::ext::sp_arithmetic::per_things::Perbill,
                         ::subxt::utils::AccountId32,
                     )>,
                 ) -> ::subxt::tx::Payload<types::SetCommission> {
@@ -26070,7 +26075,7 @@ pub mod api {
                 pub fn set_commission_max(
                     &self,
                     pool_id: ::core::primitive::u32,
-                    max_commission: runtime_types::sp_arithmetic::per_things::Perbill,
+                    max_commission: ::subxt::ext::sp_arithmetic::per_things::Perbill,
                 ) -> ::subxt::tx::Payload<types::SetCommissionMax> {
                     ::subxt::tx::Payload::new_static(
                         "NominationPools",
@@ -26382,7 +26387,7 @@ pub mod api {
             pub struct PoolCommissionUpdated {
                 pub pool_id: ::core::primitive::u32,
                 pub current: ::core::option::Option<(
-                    runtime_types::sp_arithmetic::per_things::Perbill,
+                    ::subxt::ext::sp_arithmetic::per_things::Perbill,
                     ::subxt::utils::AccountId32,
                 )>,
             }
@@ -26403,7 +26408,7 @@ pub mod api {
             #[doc = "A pool's maximum commission setting has been changed."]
             pub struct PoolMaxCommissionUpdated {
                 pub pool_id: ::core::primitive::u32,
-                pub max_commission: runtime_types::sp_arithmetic::per_things::Perbill,
+                pub max_commission: ::subxt::ext::sp_arithmetic::per_things::Perbill,
             }
             impl ::subxt::events::StaticEvent for PoolMaxCommissionUpdated {
                 const PALLET: &'static str = "NominationPools";
@@ -26578,7 +26583,7 @@ pub mod api {
                     &self,
                 ) -> ::subxt::storage::address::Address<
                     ::subxt::storage::address::StaticStorageMapKey,
-                    runtime_types::sp_arithmetic::per_things::Perbill,
+                    ::subxt::ext::sp_arithmetic::per_things::Perbill,
                     ::subxt::storage::address::Yes,
                     (),
                     (),
@@ -31270,7 +31275,7 @@ pub mod api {
                     &self,
                 ) -> ::subxt::storage::address::Address<
                     ::subxt::storage::address::StaticStorageMapKey,
-                    runtime_types::sp_arithmetic::fixed_point::FixedU128,
+                    ::subxt::ext::sp_arithmetic::fixed_point::FixedU128,
                     (),
                     ::subxt::storage::address::Yes,
                     ::subxt::storage::address::Yes,
@@ -31292,7 +31297,7 @@ pub mod api {
                     _0: impl ::std::borrow::Borrow<runtime_types::polkadot_parachain::primitives::Id>,
                 ) -> ::subxt::storage::address::Address<
                     ::subxt::storage::address::StaticStorageMapKey,
-                    runtime_types::sp_arithmetic::fixed_point::FixedU128,
+                    ::subxt::ext::sp_arithmetic::fixed_point::FixedU128,
                     ::subxt::storage::address::Yes,
                     ::subxt::storage::address::Yes,
                     (),
@@ -42015,7 +42020,7 @@ pub mod api {
                             ::core::primitive::u32,
                         >,
                         global_max_commission: runtime_types::pallet_nomination_pools::ConfigOp<
-                            runtime_types::sp_arithmetic::per_things::Perbill,
+                            ::subxt::ext::sp_arithmetic::per_things::Perbill,
                         >,
                     },
                     #[codec(index = 12)]
@@ -42056,7 +42061,7 @@ pub mod api {
                     set_commission {
                         pool_id: ::core::primitive::u32,
                         new_commission: ::core::option::Option<(
-                            runtime_types::sp_arithmetic::per_things::Perbill,
+                            ::subxt::ext::sp_arithmetic::per_things::Perbill,
                             ::subxt::utils::AccountId32,
                         )>,
                     },
@@ -42064,7 +42069,7 @@ pub mod api {
                     #[doc = "See [`Pallet::set_commission_max`]."]
                     set_commission_max {
                         pool_id: ::core::primitive::u32,
-                        max_commission: runtime_types::sp_arithmetic::per_things::Perbill,
+                        max_commission: ::subxt::ext::sp_arithmetic::per_things::Perbill,
                     },
                     #[codec(index = 19)]
                     #[doc = "See [`Pallet::set_commission_change_rate`]."]
@@ -42319,7 +42324,7 @@ pub mod api {
                     PoolCommissionUpdated {
                         pool_id: ::core::primitive::u32,
                         current: ::core::option::Option<(
-                            runtime_types::sp_arithmetic::per_things::Perbill,
+                            ::subxt::ext::sp_arithmetic::per_things::Perbill,
                             ::subxt::utils::AccountId32,
                         )>,
                     },
@@ -42327,7 +42332,7 @@ pub mod api {
                     #[doc = "A pool's maximum commission setting has been changed."]
                     PoolMaxCommissionUpdated {
                         pool_id: ::core::primitive::u32,
-                        max_commission: runtime_types::sp_arithmetic::per_things::Perbill,
+                        max_commission: ::subxt::ext::sp_arithmetic::per_things::Perbill,
                     },
                     #[codec(index = 13)]
                     #[doc = "A pool's commission `change_rate` has been changed."]
@@ -42411,10 +42416,10 @@ pub mod api {
             #[encode_as_type(crate_path = ":: subxt :: ext :: scale_encode")]
             pub struct Commission {
                 pub current: ::core::option::Option<(
-                    runtime_types::sp_arithmetic::per_things::Perbill,
+                    ::subxt::ext::sp_arithmetic::per_things::Perbill,
                     ::subxt::utils::AccountId32,
                 )>,
-                pub max: ::core::option::Option<runtime_types::sp_arithmetic::per_things::Perbill>,
+                pub max: ::core::option::Option<::subxt::ext::sp_arithmetic::per_things::Perbill>,
                 pub change_rate: ::core::option::Option<
                     runtime_types::pallet_nomination_pools::CommissionChangeRate<
                         ::core::primitive::u32,
@@ -42433,7 +42438,7 @@ pub mod api {
             #[decode_as_type(crate_path = ":: subxt :: ext :: scale_decode")]
             #[encode_as_type(crate_path = ":: subxt :: ext :: scale_encode")]
             pub struct CommissionChangeRate<_0> {
-                pub max_increase: runtime_types::sp_arithmetic::per_things::Perbill,
+                pub max_increase: ::subxt::ext::sp_arithmetic::per_things::Perbill,
                 pub min_delay: _0,
             }
             #[derive(
@@ -42468,7 +42473,7 @@ pub mod api {
                 pub pool_id: ::core::primitive::u32,
                 pub points: ::core::primitive::u128,
                 pub last_recorded_reward_counter:
-                    runtime_types::sp_arithmetic::fixed_point::FixedU128,
+                    ::subxt::ext::sp_arithmetic::fixed_point::FixedU128,
                 pub unbonding_eras:
                     runtime_types::bounded_collections::bounded_btree_map::BoundedBTreeMap<
                         ::core::primitive::u32,
@@ -42521,7 +42526,7 @@ pub mod api {
             #[encode_as_type(crate_path = ":: subxt :: ext :: scale_encode")]
             pub struct RewardPool {
                 pub last_recorded_reward_counter:
-                    runtime_types::sp_arithmetic::fixed_point::FixedU128,
+                    ::subxt::ext::sp_arithmetic::fixed_point::FixedU128,
                 pub last_recorded_total_payouts: ::core::primitive::u128,
                 pub total_rewards_claimed: ::core::primitive::u128,
                 pub total_commission_pending: ::core::primitive::u128,
@@ -43148,22 +43153,22 @@ pub mod api {
                 pub enum Curve {
                     #[codec(index = 0)]
                     LinearDecreasing {
-                        length: runtime_types::sp_arithmetic::per_things::Perbill,
-                        floor: runtime_types::sp_arithmetic::per_things::Perbill,
-                        ceil: runtime_types::sp_arithmetic::per_things::Perbill,
+                        length: ::subxt::ext::sp_arithmetic::per_things::Perbill,
+                        floor: ::subxt::ext::sp_arithmetic::per_things::Perbill,
+                        ceil: ::subxt::ext::sp_arithmetic::per_things::Perbill,
                     },
                     #[codec(index = 1)]
                     SteppedDecreasing {
-                        begin: runtime_types::sp_arithmetic::per_things::Perbill,
-                        end: runtime_types::sp_arithmetic::per_things::Perbill,
-                        step: runtime_types::sp_arithmetic::per_things::Perbill,
-                        period: runtime_types::sp_arithmetic::per_things::Perbill,
+                        begin: ::subxt::ext::sp_arithmetic::per_things::Perbill,
+                        end: ::subxt::ext::sp_arithmetic::per_things::Perbill,
+                        step: ::subxt::ext::sp_arithmetic::per_things::Perbill,
+                        period: ::subxt::ext::sp_arithmetic::per_things::Perbill,
                     },
                     #[codec(index = 2)]
                     Reciprocal {
-                        factor: runtime_types::sp_arithmetic::fixed_point::FixedI64,
-                        x_offset: runtime_types::sp_arithmetic::fixed_point::FixedI64,
-                        y_offset: runtime_types::sp_arithmetic::fixed_point::FixedI64,
+                        factor: ::subxt::ext::sp_arithmetic::fixed_point::FixedI64,
+                        x_offset: ::subxt::ext::sp_arithmetic::fixed_point::FixedI64,
+                        y_offset: ::subxt::ext::sp_arithmetic::fixed_point::FixedI64,
                     },
                 }
                 #[derive(
@@ -43644,7 +43649,7 @@ pub mod api {
                         #[codec(index = 11)]
                         #[doc = "See [`Pallet::scale_validator_count`]."]
                         scale_validator_count {
-                            factor: runtime_types::sp_arithmetic::per_things::Percent,
+                            factor: ::subxt::ext::sp_arithmetic::per_things::Percent,
                         },
                         #[codec(index = 12)]
                         #[doc = "See [`Pallet::force_no_eras`]."]
@@ -43718,10 +43723,10 @@ pub mod api {
                                 >,
                             chill_threshold:
                                 runtime_types::pallet_staking::pallet::pallet::ConfigOp<
-                                    runtime_types::sp_arithmetic::per_things::Percent,
+                                    ::subxt::ext::sp_arithmetic::per_things::Percent,
                                 >,
                             min_commission: runtime_types::pallet_staking::pallet::pallet::ConfigOp<
-                                runtime_types::sp_arithmetic::per_things::Perbill,
+                                ::subxt::ext::sp_arithmetic::per_things::Perbill,
                             >,
                         },
                         #[codec(index = 23)]
@@ -43737,7 +43742,7 @@ pub mod api {
                         #[codec(index = 25)]
                         #[doc = "See [`Pallet::set_min_commission`]."]
                         set_min_commission {
-                            new: runtime_types::sp_arithmetic::per_things::Perbill,
+                            new: ::subxt::ext::sp_arithmetic::per_things::Perbill,
                         },
                     }
                     #[derive(
@@ -43887,7 +43892,7 @@ pub mod api {
                         #[doc = "era as been reported."]
                         SlashReported {
                             validator: ::subxt::utils::AccountId32,
-                            fraction: runtime_types::sp_arithmetic::per_things::Perbill,
+                            fraction: ::subxt::ext::sp_arithmetic::per_things::Perbill,
                             slash_era: ::core::primitive::u32,
                         },
                         #[codec(index = 4)]
@@ -44174,7 +44179,7 @@ pub mod api {
             #[encode_as_type(crate_path = ":: subxt :: ext :: scale_encode")]
             pub struct ValidatorPrefs {
                 #[codec(compact)]
-                pub commission: runtime_types::sp_arithmetic::per_things::Perbill,
+                pub commission: ::subxt::ext::sp_arithmetic::per_things::Perbill,
                 pub blocked: ::core::primitive::bool,
             }
         }
@@ -46449,7 +46454,7 @@ pub mod api {
                     (
                         ::subxt::ext::codec::Compact<::core::primitive::u16>,
                         ::subxt::ext::codec::Compact<
-                            runtime_types::sp_arithmetic::per_things::PerU16,
+                            ::subxt::ext::sp_arithmetic::per_things::PerU16,
                         >,
                     ),
                     ::subxt::ext::codec::Compact<::core::primitive::u16>,
@@ -46459,7 +46464,7 @@ pub mod api {
                     [(
                         ::subxt::ext::codec::Compact<::core::primitive::u16>,
                         ::subxt::ext::codec::Compact<
-                            runtime_types::sp_arithmetic::per_things::PerU16,
+                            ::subxt::ext::sp_arithmetic::per_things::PerU16,
                         >,
                     ); 2usize],
                     ::subxt::ext::codec::Compact<::core::primitive::u16>,
@@ -46469,7 +46474,7 @@ pub mod api {
                     [(
                         ::subxt::ext::codec::Compact<::core::primitive::u16>,
                         ::subxt::ext::codec::Compact<
-                            runtime_types::sp_arithmetic::per_things::PerU16,
+                            ::subxt::ext::sp_arithmetic::per_things::PerU16,
                         >,
                     ); 3usize],
                     ::subxt::ext::codec::Compact<::core::primitive::u16>,
@@ -46479,7 +46484,7 @@ pub mod api {
                     [(
                         ::subxt::ext::codec::Compact<::core::primitive::u16>,
                         ::subxt::ext::codec::Compact<
-                            runtime_types::sp_arithmetic::per_things::PerU16,
+                            ::subxt::ext::sp_arithmetic::per_things::PerU16,
                         >,
                     ); 4usize],
                     ::subxt::ext::codec::Compact<::core::primitive::u16>,
@@ -46489,7 +46494,7 @@ pub mod api {
                     [(
                         ::subxt::ext::codec::Compact<::core::primitive::u16>,
                         ::subxt::ext::codec::Compact<
-                            runtime_types::sp_arithmetic::per_things::PerU16,
+                            ::subxt::ext::sp_arithmetic::per_things::PerU16,
                         >,
                     ); 5usize],
                     ::subxt::ext::codec::Compact<::core::primitive::u16>,
@@ -46499,7 +46504,7 @@ pub mod api {
                     [(
                         ::subxt::ext::codec::Compact<::core::primitive::u16>,
                         ::subxt::ext::codec::Compact<
-                            runtime_types::sp_arithmetic::per_things::PerU16,
+                            ::subxt::ext::sp_arithmetic::per_things::PerU16,
                         >,
                     ); 6usize],
                     ::subxt::ext::codec::Compact<::core::primitive::u16>,
@@ -46509,7 +46514,7 @@ pub mod api {
                     [(
                         ::subxt::ext::codec::Compact<::core::primitive::u16>,
                         ::subxt::ext::codec::Compact<
-                            runtime_types::sp_arithmetic::per_things::PerU16,
+                            ::subxt::ext::sp_arithmetic::per_things::PerU16,
                         >,
                     ); 7usize],
                     ::subxt::ext::codec::Compact<::core::primitive::u16>,
@@ -46519,7 +46524,7 @@ pub mod api {
                     [(
                         ::subxt::ext::codec::Compact<::core::primitive::u16>,
                         ::subxt::ext::codec::Compact<
-                            runtime_types::sp_arithmetic::per_things::PerU16,
+                            ::subxt::ext::sp_arithmetic::per_things::PerU16,
                         >,
                     ); 8usize],
                     ::subxt::ext::codec::Compact<::core::primitive::u16>,
@@ -46529,7 +46534,7 @@ pub mod api {
                     [(
                         ::subxt::ext::codec::Compact<::core::primitive::u16>,
                         ::subxt::ext::codec::Compact<
-                            runtime_types::sp_arithmetic::per_things::PerU16,
+                            ::subxt::ext::sp_arithmetic::per_things::PerU16,
                         >,
                     ); 9usize],
                     ::subxt::ext::codec::Compact<::core::primitive::u16>,
@@ -46539,7 +46544,7 @@ pub mod api {
                     [(
                         ::subxt::ext::codec::Compact<::core::primitive::u16>,
                         ::subxt::ext::codec::Compact<
-                            runtime_types::sp_arithmetic::per_things::PerU16,
+                            ::subxt::ext::sp_arithmetic::per_things::PerU16,
                         >,
                     ); 10usize],
                     ::subxt::ext::codec::Compact<::core::primitive::u16>,
@@ -46549,7 +46554,7 @@ pub mod api {
                     [(
                         ::subxt::ext::codec::Compact<::core::primitive::u16>,
                         ::subxt::ext::codec::Compact<
-                            runtime_types::sp_arithmetic::per_things::PerU16,
+                            ::subxt::ext::sp_arithmetic::per_things::PerU16,
                         >,
                     ); 11usize],
                     ::subxt::ext::codec::Compact<::core::primitive::u16>,
@@ -46559,7 +46564,7 @@ pub mod api {
                     [(
                         ::subxt::ext::codec::Compact<::core::primitive::u16>,
                         ::subxt::ext::codec::Compact<
-                            runtime_types::sp_arithmetic::per_things::PerU16,
+                            ::subxt::ext::sp_arithmetic::per_things::PerU16,
                         >,
                     ); 12usize],
                     ::subxt::ext::codec::Compact<::core::primitive::u16>,
@@ -46569,7 +46574,7 @@ pub mod api {
                     [(
                         ::subxt::ext::codec::Compact<::core::primitive::u16>,
                         ::subxt::ext::codec::Compact<
-                            runtime_types::sp_arithmetic::per_things::PerU16,
+                            ::subxt::ext::sp_arithmetic::per_things::PerU16,
                         >,
                     ); 13usize],
                     ::subxt::ext::codec::Compact<::core::primitive::u16>,
@@ -46579,7 +46584,7 @@ pub mod api {
                     [(
                         ::subxt::ext::codec::Compact<::core::primitive::u16>,
                         ::subxt::ext::codec::Compact<
-                            runtime_types::sp_arithmetic::per_things::PerU16,
+                            ::subxt::ext::sp_arithmetic::per_things::PerU16,
                         >,
                     ); 14usize],
                     ::subxt::ext::codec::Compact<::core::primitive::u16>,
@@ -46589,7 +46594,7 @@ pub mod api {
                     [(
                         ::subxt::ext::codec::Compact<::core::primitive::u16>,
                         ::subxt::ext::codec::Compact<
-                            runtime_types::sp_arithmetic::per_things::PerU16,
+                            ::subxt::ext::sp_arithmetic::per_things::PerU16,
                         >,
                     ); 15usize],
                     ::subxt::ext::codec::Compact<::core::primitive::u16>,
@@ -50507,23 +50512,6 @@ pub mod api {
                         pub __subxt_unused_type_params: ::core::marker::PhantomData<_1>,
                     }
                 }
-                pub mod unchecked_extrinsic {
-                    use super::runtime_types;
-                    #[derive(
-                        :: subxt :: ext :: codec :: Decode,
-                        :: subxt :: ext :: codec :: Encode,
-                        :: subxt :: ext :: scale_decode :: DecodeAsType,
-                        :: subxt :: ext :: scale_encode :: EncodeAsType,
-                        Debug,
-                    )]
-                    # [codec (crate = :: subxt :: ext :: codec)]
-                    #[decode_as_type(crate_path = ":: subxt :: ext :: scale_decode")]
-                    #[encode_as_type(crate_path = ":: subxt :: ext :: scale_encode")]
-                    pub struct UncheckedExtrinsic<_0, _1, _2, _3>(
-                        pub ::std::vec::Vec<::core::primitive::u8>,
-                        #[codec(skip)] pub ::core::marker::PhantomData<(_1, _0, _2, _3)>,
-                    );
-                }
             }
             pub mod traits {
                 use super::runtime_types;
@@ -50673,7 +50661,7 @@ pub mod api {
                 #[codec(index = 7)]
                 Token(runtime_types::sp_runtime::TokenError),
                 #[codec(index = 8)]
-                Arithmetic(runtime_types::sp_arithmetic::ArithmeticError),
+                Arithmetic(::subxt::ext::sp_arithmetic::ArithmeticError),
                 #[codec(index = 9)]
                 Transactional(runtime_types::sp_runtime::TransactionalError),
                 #[codec(index = 10)]


### PR DESCRIPTION
Fixes #1170 
This PR adds  `sp_arithmetic` (16.0.0) as a dependency to subxt that is exposed unser `subxt::ext::sp_arithmetic`. 

Currently I am facing the problem, that the types from `sp_arithmetic` do not implement `EncodeAsType` and `DecodeAsType` and we cannot easily implement them because of the orphan rule.

Draft PR. Incomplete.