### PR TITLE
Allow getting account nonce at arbitrary blocks, too

### DIFF
--- a/subxt/examples/runtime_apis_dynamic.rs
+++ b/subxt/examples/runtime_apis_dynamic.rs
@@ -2,9 +2,6 @@ use subxt::dynamic::Value;
 use subxt::{config::PolkadotConfig, OnlineClient};
 use subxt_signer::sr25519::dev;
 
-#[subxt::subxt(runtime_metadata_path = "../artifacts/polkadot_metadata_small.scale")]
-pub mod polkadot {}
-
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create a client to use:

--- a/subxt/src/blocks/mod.rs
+++ b/subxt/src/blocks/mod.rs
@@ -14,3 +14,6 @@ pub use crate::backend::BlockRef;
 pub use block_types::Block;
 pub use blocks_client::BlocksClient;
 pub use extrinsic_types::{ExtrinsicDetails, ExtrinsicEvents, Extrinsics, StaticExtrinsic};
+
+// We get account nonce info in tx_client, too, so re-use the logic:
+pub(crate) use block_types::get_account_nonce;


### PR DESCRIPTION
We have an `account_nonce` function on `client.tx()` already, which fetches the account nonce based on the latest finalized block. In some cases (eg when using `manual-seal` in testing which doesn't produce finalized blocks), we'd like to be able to get the acocunt nonce for other blocks. So this just exposes it on the "blocks" API for that purpose, sharing the logic.