### PR TITLE
fix for when runtime API field name is _

### DIFF
--- a/codegen/src/api/runtime_apis.rs
+++ b/codegen/src/api/runtime_apis.rs
@@ -36,8 +36,14 @@ fn generate_runtime_api(
             .then_some(quote! { #( #[doc = #docs ] )* })
             .unwrap_or_default();
 
-        let inputs: Vec<_> = method.inputs().map(|input| {
-            let name = format_ident!("{}", &input.name);
+        let inputs: Vec<_> = method.inputs().enumerate().map(|(idx, input)| {
+            // These are method names, which can just be '_', but struct field names can't
+            // just be an underscore, so fix any such names we find to work in structs.
+            let name = if input.name == "_" {
+                format_ident!("_{}", idx)
+            } else {
+                format_ident!("{}", &input.name)
+            };
             let ty = type_gen.resolve_type_path(input.ty);
 
             let param = quote!(#name: #ty);

--- a/testing/ui-tests/src/dispatch_errors.rs
+++ b/testing/ui-tests/src/dispatch_errors.rs
@@ -11,13 +11,13 @@ use generate_custom_metadata::dispatch_error::{
 use frame_metadata::RuntimeMetadataPrefixed;
 
 pub fn metadata_array_dispatch_error() -> RuntimeMetadataPrefixed {
-    generate_metadata_from_pallets_custom_dispatch_error::<ArrayDispatchError>(vec![])
+    generate_metadata_from_pallets_custom_dispatch_error::<ArrayDispatchError>(vec![], vec![])
 }
 
 pub fn metadata_legacy_dispatch_error() -> RuntimeMetadataPrefixed {
-    generate_metadata_from_pallets_custom_dispatch_error::<LegacyDispatchError>(vec![])
+    generate_metadata_from_pallets_custom_dispatch_error::<LegacyDispatchError>(vec![], vec![])
 }
 
 pub fn metadata_named_field_dispatch_error() -> RuntimeMetadataPrefixed {
-    generate_metadata_from_pallets_custom_dispatch_error::<NamedFieldDispatchError>(vec![])
+    generate_metadata_from_pallets_custom_dispatch_error::<NamedFieldDispatchError>(vec![], vec![])
 }

--- a/testing/ui-tests/src/lib.rs
+++ b/testing/ui-tests/src/lib.rs
@@ -12,8 +12,8 @@
 //! to automatically regenerate `stderr` files, but don't forget to check that new files make sense.
 
 mod dispatch_errors;
-mod storage;
 mod runtime_apis;
+mod storage;
 mod utils;
 
 use crate::utils::MetadataTestRunner;

--- a/testing/ui-tests/src/lib.rs
+++ b/testing/ui-tests/src/lib.rs
@@ -13,6 +13,7 @@
 
 mod dispatch_errors;
 mod storage;
+mod runtime_apis;
 mod utils;
 
 use crate::utils::MetadataTestRunner;
@@ -32,6 +33,13 @@ fn ui_tests() {
         m.new_test_case()
             .name("storage_map_no_keys")
             .build(storage::metadata_storage_map_no_keys()),
+    );
+
+    // Check runtime APIs with _ in method names work
+    t.pass(
+        m.new_test_case()
+            .name("runtime_api_underscore_method_name")
+            .build(runtime_apis::metadata_runtime_api_underscore_method_name()),
     );
 
     // Test that the codegen can handle the different types of DispatchError.

--- a/testing/ui-tests/src/runtime_apis.rs
+++ b/testing/ui-tests/src/runtime_apis.rs
@@ -1,0 +1,33 @@
+// Copyright 2019-2023 Parity Technologies (UK) Ltd.
+// This file is dual-licensed as Apache-2.0 or GPL-3.0.
+// see LICENSE for license details.
+
+use frame_metadata::{
+    v15::{RuntimeApiMetadata, RuntimeApiMethodMetadata, RuntimeApiMethodParamMetadata},
+    RuntimeMetadataPrefixed,
+};
+
+use crate::utils::generate_metadata_from_runtime_apis;
+
+/// Generate metadata which contains a `Map` storage entry with no hashers/values.
+/// This is a bit of an odd case, but it was raised in https://github.com/paritytech/subxt/issues/552,
+/// and this test will fail before the fix and should pass once the fix is applied.
+pub fn metadata_runtime_api_underscore_method_name() -> RuntimeMetadataPrefixed {
+    generate_metadata_from_runtime_apis(vec![RuntimeApiMetadata {
+        name: "MyApi".to_owned(),
+        docs: vec![],
+        methods: vec![
+            RuntimeApiMethodMetadata {
+                name: "my_method".to_owned(),
+                inputs: vec![
+                    RuntimeApiMethodParamMetadata {
+                        name: "_".to_owned(), // The important bit we're testing.
+                        ty: 0.into(), // we don't care what type this is.
+                    }
+                ],
+                output: 0.into(), // we don't care what type this is.
+                docs: vec![]
+            }
+        ]
+    }])
+}

--- a/testing/ui-tests/src/runtime_apis.rs
+++ b/testing/ui-tests/src/runtime_apis.rs
@@ -16,18 +16,14 @@ pub fn metadata_runtime_api_underscore_method_name() -> RuntimeMetadataPrefixed 
     generate_metadata_from_runtime_apis(vec![RuntimeApiMetadata {
         name: "MyApi".to_owned(),
         docs: vec![],
-        methods: vec![
-            RuntimeApiMethodMetadata {
-                name: "my_method".to_owned(),
-                inputs: vec![
-                    RuntimeApiMethodParamMetadata {
-                        name: "_".to_owned(), // The important bit we're testing.
-                        ty: 0.into(), // we don't care what type this is.
-                    }
-                ],
-                output: 0.into(), // we don't care what type this is.
-                docs: vec![]
-            }
-        ]
+        methods: vec![RuntimeApiMethodMetadata {
+            name: "my_method".to_owned(),
+            inputs: vec![RuntimeApiMethodParamMetadata {
+                name: "_".to_owned(), // The important bit we're testing.
+                ty: 0.into(),         // we don't care what type this is.
+            }],
+            output: 0.into(), // we don't care what type this is.
+            docs: vec![],
+        }],
     }])
 }

--- a/testing/ui-tests/src/utils/mod.rs
+++ b/testing/ui-tests/src/utils/mod.rs
@@ -7,12 +7,12 @@ mod metadata_test_runner;
 use frame_metadata::{
     v15::{
         CustomMetadata, ExtrinsicMetadata, OuterEnums, PalletMetadata, PalletStorageMetadata,
-        RuntimeMetadataV15, StorageEntryMetadata,
+        RuntimeMetadataV15, StorageEntryMetadata, RuntimeApiMetadata,
     },
     RuntimeMetadataPrefixed,
 };
 use generate_custom_metadata::dispatch_error::ArrayDispatchError;
-use scale_info::{meta_type, IntoPortable, TypeInfo};
+use scale_info::{meta_type, IntoPortable, TypeInfo, form::PortableForm};
 
 pub use metadata_test_runner::MetadataTestRunner;
 
@@ -21,6 +21,7 @@ pub use metadata_test_runner::MetadataTestRunner;
 /// type matching the generic type param provided.
 pub fn generate_metadata_from_pallets_custom_dispatch_error<DispatchError: TypeInfo + 'static>(
     pallets: Vec<PalletMetadata>,
+    runtime_apis: Vec<RuntimeApiMetadata<PortableForm>>
 ) -> RuntimeMetadataPrefixed {
     // We don't care about the extrinsic type.
     let extrinsic = ExtrinsicMetadata {
@@ -60,7 +61,7 @@ pub fn generate_metadata_from_pallets_custom_dispatch_error<DispatchError: TypeI
         pallets,
         extrinsic,
         ty,
-        apis: vec![],
+        apis: runtime_apis,
         outer_enums: OuterEnums {
             call_enum_ty: runtime_call,
             event_enum_ty: runtime_event,
@@ -78,7 +79,14 @@ pub fn generate_metadata_from_pallets_custom_dispatch_error<DispatchError: TypeI
 /// We default to a useless extrinsic type, and register a fake `DispatchError`
 /// type so that codegen is happy with the metadata generated.
 pub fn generate_metadata_from_pallets(pallets: Vec<PalletMetadata>) -> RuntimeMetadataPrefixed {
-    generate_metadata_from_pallets_custom_dispatch_error::<ArrayDispatchError>(pallets)
+    generate_metadata_from_pallets_custom_dispatch_error::<ArrayDispatchError>(pallets, vec![])
+}
+
+/// Given some runtime API metadata, generate a [`RuntimeMetadataPrefixed`] struct.
+/// We default to a useless extrinsic type, and register a fake `DispatchError`
+/// type so that codegen is happy with the metadata generated.
+pub fn generate_metadata_from_runtime_apis(runtime_apis: Vec<RuntimeApiMetadata<PortableForm>>) -> RuntimeMetadataPrefixed {
+    generate_metadata_from_pallets_custom_dispatch_error::<ArrayDispatchError>(vec![], runtime_apis)
 }
 
 /// Given some storage entries, generate a [`RuntimeMetadataPrefixed`] struct.

--- a/testing/ui-tests/src/utils/mod.rs
+++ b/testing/ui-tests/src/utils/mod.rs
@@ -7,12 +7,12 @@ mod metadata_test_runner;
 use frame_metadata::{
     v15::{
         CustomMetadata, ExtrinsicMetadata, OuterEnums, PalletMetadata, PalletStorageMetadata,
-        RuntimeMetadataV15, StorageEntryMetadata, RuntimeApiMetadata,
+        RuntimeApiMetadata, RuntimeMetadataV15, StorageEntryMetadata,
     },
     RuntimeMetadataPrefixed,
 };
 use generate_custom_metadata::dispatch_error::ArrayDispatchError;
-use scale_info::{meta_type, IntoPortable, TypeInfo, form::PortableForm};
+use scale_info::{form::PortableForm, meta_type, IntoPortable, TypeInfo};
 
 pub use metadata_test_runner::MetadataTestRunner;
 
@@ -21,7 +21,7 @@ pub use metadata_test_runner::MetadataTestRunner;
 /// type matching the generic type param provided.
 pub fn generate_metadata_from_pallets_custom_dispatch_error<DispatchError: TypeInfo + 'static>(
     pallets: Vec<PalletMetadata>,
-    runtime_apis: Vec<RuntimeApiMetadata<PortableForm>>
+    runtime_apis: Vec<RuntimeApiMetadata<PortableForm>>,
 ) -> RuntimeMetadataPrefixed {
     // We don't care about the extrinsic type.
     let extrinsic = ExtrinsicMetadata {
@@ -85,7 +85,9 @@ pub fn generate_metadata_from_pallets(pallets: Vec<PalletMetadata>) -> RuntimeMe
 /// Given some runtime API metadata, generate a [`RuntimeMetadataPrefixed`] struct.
 /// We default to a useless extrinsic type, and register a fake `DispatchError`
 /// type so that codegen is happy with the metadata generated.
-pub fn generate_metadata_from_runtime_apis(runtime_apis: Vec<RuntimeApiMetadata<PortableForm>>) -> RuntimeMetadataPrefixed {
+pub fn generate_metadata_from_runtime_apis(
+    runtime_apis: Vec<RuntimeApiMetadata<PortableForm>>,
+) -> RuntimeMetadataPrefixed {
     generate_metadata_from_pallets_custom_dispatch_error::<ArrayDispatchError>(vec![], runtime_apis)
 }
 


### PR DESCRIPTION
Runtime APIs are methods which take arguments, but Subxt converts these argument names into struct field names. Mostly this is ok, but "_" is a valid argument name and not a valid struct name (I can't think of any other cases of valid argument names that arent valid struct names offhand; can you?).

Anyway, we fix this specific case in the runtime API codegen