### PR TITLE
Wee tidy to subxt-signer flags

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -65,8 +65,8 @@ jobs:
             - name: Cargo check subxt-signer
               run: |
                   cargo check -p subxt-signer
-                  cargo check -p subxt-signer --no-default-features --features sr25519
-                  cargo check -p subxt-signer --no-default-features --features ecdsa
+                  cargo check -p subxt-signer --no-default-features --features sr25519,native
+                  cargo check -p subxt-signer --no-default-features --features ecdsa,native
 
             # We can't enable web features here, so no cargo hack.
             - name: Cargo check subxt-lightclient

--- a/signer/Cargo.toml
+++ b/signer/Cargo.toml
@@ -30,8 +30,8 @@ subxt = ["dep:subxt"]
 
 # The getrandom package is used via schnorrkel. We need to enable the JS
 # feature on it if compiling for the web.
-web = ["getrandom/js", "subxt?/web"]
-native = ["subxt?/native"]
+web = ["getrandom/js"]
+native = []
 
 [dependencies]
 subxt = { workspace = true, optional = true, default-features = false }

--- a/signer/Cargo.toml
+++ b/signer/Cargo.toml
@@ -30,8 +30,8 @@ subxt = ["dep:subxt"]
 
 # The getrandom package is used via schnorrkel. We need to enable the JS
 # feature on it if compiling for the web.
-web = ["getrandom/js"]
-native = []
+web = ["getrandom/js", "subxt?/web"]
+native = ["subxt?/native"]
 
 [dependencies]
 subxt = { workspace = true, optional = true, default-features = false }

--- a/signer/src/lib.rs
+++ b/signer/src/lib.rs
@@ -39,5 +39,5 @@ pub use secrecy::{ExposeSecret, SecretString};
 // DeriveJunctions are the "path" part of these SecretUris.
 pub use crypto::{DeriveJunction, SecretUri, SecretUriError, DEV_PHRASE};
 
-#[cfg(all(feature = "subxt", not(any(feature = "web", feature = "native"))))]
-compile_error!("subxt-signer: When using the 'subxt' feature, exactly one of the 'web' and 'native' features should be used.");
+#[cfg(not(any(feature = "web", feature = "native")))]
+compile_error!("subxt-signer: exactly one of the 'web' and 'native' features should be used.");

--- a/signer/src/lib.rs
+++ b/signer/src/lib.rs
@@ -39,5 +39,8 @@ pub use secrecy::{ExposeSecret, SecretString};
 // DeriveJunctions are the "path" part of these SecretUris.
 pub use crypto::{DeriveJunction, SecretUri, SecretUriError, DEV_PHRASE};
 
-#[cfg(not(any(feature = "web", feature = "native")))]
+#[cfg(any(
+    all(feature = "web", feature = "native"),
+    not(any(feature = "web", feature = "native"))
+))]
 compile_error!("subxt-signer: exactly one of the 'web' and 'native' features should be used.");


### PR DESCRIPTION
Subxt-signer probably shouldn't bother trying to set the corresponding subxt feature flags when it's enabled; just expect them to be set for each crate independently. And compile_error regardless of whether subxt is enabled