### PR TITLE
Expose OnlineClient in LightClient

### DIFF
--- a/subxt/src/client/light_client/mod.rs
+++ b/subxt/src/client/light_client/mod.rs
@@ -115,6 +115,11 @@ impl<T: Config> LightClient<T> {
     pub fn runtime_api(&self) -> RuntimeApiClient<T, Self> {
         <Self as OfflineClientT<T>>::runtime_api(self)
     }
+
+    /// Expose the OnlineClient that the LightClient struct wraps.
+    pub fn inner_online_client(&self) -> &OnlineClient<T> {
+        &self.0
+    }
 }
 
 impl<T: Config> OnlineClientT<T> for LightClient<T> {


### PR DESCRIPTION
I am having some problems abstracting over OnlineClient and LightClient. 
Imagine I want to do some common operations like fetching a value from storage and my connection to a chain is either an OnlineClient or a LightClient (which is just a wrapper around an OnlineClient).
Both implement `OnlineClientT`, which has all the functionality I need. However because `OnlineClientT` is not object safe, I cannot create a `dyn OnlineClientT<PolakdotConfig>` trait object.

If I now call .storage() on either an OnlineClient or the LightClient, the returned StorageClient has distinct types, that we currently cannot abstract over either (`StorageClient<Config, LightClient<Config>>` vs. `StorageClient<Config, OnlineClient<Config>>`)

Possible Solutions: 
- make OnlineClientT object safe
- let the LightClients functions not return a StorageClient<Config, LightClient<Config>> but a StorageClient<Config, OnlineClient<Config>> instead
- just expose the wrapped Online Client to have access to it if needed

I opted for the last solution, maybe we can come up with something more involved later.
It should be fine exposing this, since the light client is marked as experimental anyways.