### PR TITLE
tests: Wait for transaction to be in a finalized block

### DIFF
--- a/testing/integration-tests/src/full_client/blocks/mod.rs
+++ b/testing/integration-tests/src/full_client/blocks/mod.rs
@@ -182,7 +182,7 @@ async fn fetch_block_and_decode_extrinsic_details() {
         .submit_and_watch()
         .await
         .unwrap()
-        .wait_for_in_block()
+        .wait_for_finalized()
         .await
         .unwrap();
 


### PR DESCRIPTION
The test `fetch_block_and_decode_extrinsic_details` failed on [this CI job](https://github.com/paritytech/subxt/actions/runs/6686871740/job/18166793166?pr=1229):

```bash
Rpc(ClientError(Call(ErrorObject { code: ServerError(2001), message: "Invalid block hash", data: None })))
```

The test is submitting an extrinsic and waiting for inclusion in _any block_.

Submitting an extrinsic with the unstable backend (rpc v2) implies:
- subscribing to `chainHead` for related block hashes
- calling `transaction` rpc method

It is entirely possible that the block hash reported by the `transaction` method was not reported yet by the `chainHead` class yet:

https://github.com/paritytech/subxt/blob/ff3a08688b8d7339aee2386126cf2480587657c7/subxt/src/backend/unstable/mod.rs#L513-L524

Given that the test was waiting for any block inclusion (`wait_for_in_block`), the test attempted to call `chainHead_header` before the block hash was reported.

To mitigate this, the `wait_for_in_block` is replaced by `wait_for_finalized`. The `submit_transaction` will return `TransactionStatus::InFinalizedBlock` only after the block hash has been reported by `chainHead`.
The downside of this approach is that the test may wait for a longer time (until the block becomes finalized + overhead of reporting the block via chainHead).

I was unable to reproduce the CI error in ~900 runs.
