### PR TITLE
Implement legacy RPC system_account_next_index

### DIFF
--- a/subxt/src/backend/legacy/rpc_methods.rs
+++ b/subxt/src/backend/legacy/rpc_methods.rs
@@ -138,6 +138,18 @@ impl<T: Config> LegacyRpcMethods<T> {
             .await
     }
 
+    /// Fetch next nonce for an Account
+    ///
+    /// Return account nonce adjusted for extrinsics currently in transaction pool
+    pub async fn system_account_next_index(&self, account_id: &T::AccountId) -> Result<u64, Error>
+    where
+        T::AccountId: Serialize,
+    {
+        self.client
+            .request("system_accountNextIndex", rpc_params![&account_id])
+            .await
+    }
+
     /// Get a header
     pub async fn chain_get_header(
         &self,


### PR DESCRIPTION
RPC `system_account_next_index` compensates for extrinsics in transaction pool. as opposed to `get_account_nonce` which does not.