### PR TITLE
Bump scale-decode and scale-value to latest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3169,9 +3169,9 @@ dependencies = [
 
 [[package]]
 name = "scale-decode"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7789f5728e4e954aaa20cadcc370b99096fb8645fca3c9333ace44bb18f30095"
+checksum = "7caaf753f8ed1ab4752c6afb20174f03598c664724e0e32628e161c21000ff76"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
@@ -3184,9 +3184,9 @@ dependencies = [
 
 [[package]]
 name = "scale-decode-derive"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27873eb6005868f8cc72dcfe109fae664cf51223d35387bc2f28be4c28d94c47"
+checksum = "d3475108a1b62c7efd1b5c65974f30109a598b2f45f23c9ae030acb9686966db"
 dependencies = [
  "darling 0.14.4",
  "proc-macro-crate",
@@ -3251,9 +3251,9 @@ dependencies = [
 
 [[package]]
 name = "scale-value"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6538d1cc1af9c0baf401c57da8a6d4730ef582db0d330d2efa56ec946b5b0283"
+checksum = "58223c7691bf0bd46b43c9aea6f0472d1067f378d574180232358d7c6e0a8089"
 dependencies = [
  "base58",
  "blake2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,9 +64,9 @@ proc-macro2 = "1.0.69"
 quote = "1.0.33"
 regex = "1.10.2"
 scale-info = "2.10.0"
-scale-value = "0.12.0"
+scale-value = "0.13.0"
 scale-bits = "0.4.0"
-scale-decode = "0.9.0"
+scale-decode = "0.10.0"
 scale-encode = "0.5.0"
 serde = { version = "1.0.190" }
 serde_json = { version = "1.0.108" }


### PR DESCRIPTION
This makes `DecodeAsType` more useful and should resolve an issue encountered in #1235