### PR TITLE
config: Add `SkipCheckIfFeeless` signed extension

### DIFF
--- a/subxt/examples/setup_config_custom.rs
+++ b/subxt/examples/setup_config_custom.rs
@@ -3,7 +3,19 @@ use subxt::client::OfflineClientT;
 use subxt::config::{Config, ExtrinsicParams, ExtrinsicParamsEncoder};
 use subxt_signer::sr25519::dev;
 
-#[subxt::subxt(runtime_metadata_path = "../artifacts/polkadot_metadata_full.scale")]
+#[subxt::subxt(
+    runtime_metadata_path = "../artifacts/polkadot_metadata_full.scale",
+    derive_for_type(path = "xcm::v2::multilocation::MultiLocation", derive = "Clone"),
+    derive_for_type(path = "xcm::v2::multilocation::Junctions", derive = "Clone"),
+    derive_for_type(path = "xcm::v2::junction::Junction", derive = "Clone"),
+    derive_for_type(path = "xcm::v2::NetworkId", derive = "Clone"),
+    derive_for_type(path = "xcm::v2::BodyId", derive = "Clone"),
+    derive_for_type(path = "xcm::v2::BodyPart", derive = "Clone"),
+    derive_for_type(
+        path = "bounded_collections::weak_bounded_vec::WeakBoundedVec",
+        derive = "Clone"
+    )
+)]
 pub mod runtime {}
 use runtime::runtime_types::xcm::v2::multilocation::MultiLocation;
 

--- a/subxt/examples/setup_config_signed_extension.rs
+++ b/subxt/examples/setup_config_signed_extension.rs
@@ -81,8 +81,8 @@ impl ExtrinsicParamsEncoder for CustomSignedExtension {
 pub fn custom(
     params: DefaultExtrinsicParamsBuilder<CustomConfig>,
 ) -> <<CustomConfig as Config>::ExtrinsicParams as ExtrinsicParams<CustomConfig>>::OtherParams {
-    let (a, b, c, d, e, f, g) = params.build();
-    (a, b, c, d, e, f, g, ())
+    let (a, b, c, d, e, f, g, h) = params.build();
+    (a, b, c, d, e, f, g, (), ())
 }
 
 #[tokio::main]

--- a/subxt/examples/setup_config_signed_extension.rs
+++ b/subxt/examples/setup_config_signed_extension.rs
@@ -1,4 +1,5 @@
 use codec::Encode;
+use scale_encode::EncodeAsType;
 use subxt::client::OfflineClientT;
 use subxt::config::signed_extensions;
 use subxt::config::{
@@ -11,6 +12,7 @@ pub mod runtime {}
 
 // We don't need to construct this at runtime,
 // so an empty enum is appropriate:
+#[derive(EncodeAsType)]
 pub enum CustomConfig {}
 
 impl Config for CustomConfig {
@@ -31,9 +33,10 @@ impl Config for CustomConfig {
             signed_extensions::CheckGenesis<Self>,
             signed_extensions::CheckMortality<Self>,
             signed_extensions::ChargeAssetTxPayment<Self>,
+            signed_extensions::ChargeTransactionPayment,
             signed_extensions::SkipCheckIfFeeless<
                 Self,
-                signed_extensions::ChargeTransactionPayment,
+                signed_extensions::ChargeAssetTxPayment<Self>,
             >,
             // And add a new one of our own:
             CustomSignedExtension,
@@ -84,8 +87,8 @@ impl ExtrinsicParamsEncoder for CustomSignedExtension {
 pub fn custom(
     params: DefaultExtrinsicParamsBuilder<CustomConfig>,
 ) -> <<CustomConfig as Config>::ExtrinsicParams as ExtrinsicParams<CustomConfig>>::OtherParams {
-    let (a, b, c, d, e, f, g) = params.build();
-    (a, b, c, d, e, f, g, ())
+    let (a, b, c, d, e, f, g, h) = params.build();
+    (a, b, c, d, e, f, g, h, ())
 }
 
 #[tokio::main]

--- a/subxt/examples/setup_config_signed_extension.rs
+++ b/subxt/examples/setup_config_signed_extension.rs
@@ -81,8 +81,8 @@ impl ExtrinsicParamsEncoder for CustomSignedExtension {
 pub fn custom(
     params: DefaultExtrinsicParamsBuilder<CustomConfig>,
 ) -> <<CustomConfig as Config>::ExtrinsicParams as ExtrinsicParams<CustomConfig>>::OtherParams {
-    let (a, b, c, d, e, f, g, h) = params.build();
-    (a, b, c, d, e, f, g, (), ())
+    let (a, b, c, d, e, f, g) = params.build();
+    (a, b, c, d, e, f, g)
 }
 
 #[tokio::main]

--- a/subxt/examples/setup_config_signed_extension.rs
+++ b/subxt/examples/setup_config_signed_extension.rs
@@ -31,7 +31,10 @@ impl Config for CustomConfig {
             signed_extensions::CheckGenesis<Self>,
             signed_extensions::CheckMortality<Self>,
             signed_extensions::ChargeAssetTxPayment<Self>,
-            signed_extensions::ChargeTransactionPayment,
+            signed_extensions::SkipCheckIfFeeless<
+                Self,
+                signed_extensions::ChargeTransactionPayment,
+            >,
             // And add a new one of our own:
             CustomSignedExtension,
         ),
@@ -82,7 +85,7 @@ pub fn custom(
     params: DefaultExtrinsicParamsBuilder<CustomConfig>,
 ) -> <<CustomConfig as Config>::ExtrinsicParams as ExtrinsicParams<CustomConfig>>::OtherParams {
     let (a, b, c, d, e, f, g) = params.build();
-    (a, b, c, d, e, f, g)
+    (a, b, c, d, e, f, g, ())
 }
 
 #[tokio::main]

--- a/subxt/src/blocks/extrinsic_types.rs
+++ b/subxt/src/blocks/extrinsic_types.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 
 use crate::config::signed_extensions::{
-    ChargeAssetTxPayment, ChargeTransactionPayment, CheckNonce,
+    ChargeAssetTxPayment, ChargeTransactionPayment, CheckNonce, SkipCheckIfFeeless,
 };
 use crate::config::SignedExtension;
 use crate::dynamic::DecodedValue;
@@ -685,7 +685,7 @@ impl<'a, T: Config> ExtrinsicSignedExtensions<'a, T> {
     ///
     /// Returns `None` if  `tip` was not found or decoding failed.
     pub fn tip(&self) -> Option<u128> {
-        // Note: the overhead of iterating twice should be negligible.
+        // Note: the overhead of iterating multiple time should be negligible.
         self.find::<ChargeTransactionPayment>()
             .ok()
             .flatten()
@@ -695,6 +695,12 @@ impl<'a, T: Config> ExtrinsicSignedExtensions<'a, T> {
                     .ok()
                     .flatten()
                     .map(|e| e.tip())
+            })
+            .or_else(|| {
+                self.find::<SkipCheckIfFeeless<T, ChargeAssetTxPayment<T>>>()
+                    .ok()
+                    .flatten()
+                    .map(|skip_check| skip_check.inner_signed_extension().tip())
             })
     }
 

--- a/subxt/src/config/default_extrinsic_params.rs
+++ b/subxt/src/config/default_extrinsic_params.rs
@@ -16,7 +16,8 @@ pub type DefaultExtrinsicParams<T> = signed_extensions::AnyOf<
         signed_extensions::CheckGenesis<T>,
         signed_extensions::CheckMortality<T>,
         signed_extensions::ChargeAssetTxPayment<T>,
-        signed_extensions::SkipCheckIfFeeless<T, signed_extensions::ChargeTransactionPayment>,
+        signed_extensions::ChargeTransactionPayment,
+        signed_extensions::SkipCheckIfFeeless<T, signed_extensions::ChargeAssetTxPayment<T>>,
     ),
 >;
 
@@ -130,8 +131,9 @@ impl<T: Config> DefaultExtrinsicParamsBuilder<T> {
 
         let charge_transaction_params =
             signed_extensions::ChargeTransactionPaymentParams::tip(self.tip);
+
         let skip_check_params =
-            signed_extensions::SkipCheckIfFeelessParams::from(charge_transaction_params);
+            signed_extensions::SkipCheckIfFeelessParams::from(charge_asset_tx_params.clone());
 
         (
             (),
@@ -140,6 +142,7 @@ impl<T: Config> DefaultExtrinsicParamsBuilder<T> {
             (),
             check_mortality_params,
             charge_asset_tx_params,
+            charge_transaction_params,
             skip_check_params,
         )
     }

--- a/subxt/src/config/default_extrinsic_params.rs
+++ b/subxt/src/config/default_extrinsic_params.rs
@@ -16,8 +16,7 @@ pub type DefaultExtrinsicParams<T> = signed_extensions::AnyOf<
         signed_extensions::CheckGenesis<T>,
         signed_extensions::CheckMortality<T>,
         signed_extensions::ChargeAssetTxPayment<T>,
-        signed_extensions::SkipCheckIfFeeless,
-        signed_extensions::ChargeTransactionPayment,
+        signed_extensions::SkipCheckIfFeeless<T, signed_extensions::ChargeTransactionPayment>,
     ),
 >;
 
@@ -131,6 +130,8 @@ impl<T: Config> DefaultExtrinsicParamsBuilder<T> {
 
         let charge_transaction_params =
             signed_extensions::ChargeTransactionPaymentParams::tip(self.tip);
+        let skip_check_params =
+            signed_extensions::SkipCheckIfFeelessParams::from(charge_transaction_params);
 
         (
             (),
@@ -139,8 +140,7 @@ impl<T: Config> DefaultExtrinsicParamsBuilder<T> {
             (),
             check_mortality_params,
             charge_asset_tx_params,
-            (),
-            charge_transaction_params,
+            skip_check_params,
         )
     }
 }

--- a/subxt/src/config/default_extrinsic_params.rs
+++ b/subxt/src/config/default_extrinsic_params.rs
@@ -16,6 +16,7 @@ pub type DefaultExtrinsicParams<T> = signed_extensions::AnyOf<
         signed_extensions::CheckGenesis<T>,
         signed_extensions::CheckMortality<T>,
         signed_extensions::ChargeAssetTxPayment<T>,
+        signed_extensions::SkipCheckIfFeeless,
         signed_extensions::ChargeTransactionPayment,
     ),
 >;
@@ -138,6 +139,7 @@ impl<T: Config> DefaultExtrinsicParamsBuilder<T> {
             (),
             check_mortality_params,
             charge_asset_tx_params,
+            (),
             charge_transaction_params,
         )
     }

--- a/subxt/src/config/extrinsic_params.rs
+++ b/subxt/src/config/extrinsic_params.rs
@@ -18,12 +18,16 @@ pub enum ExtrinsicParamsError {
     /// A signed extension was encountered that we don't know about.
     #[error("Error constructing extrinsic parameters: Unknown signed extension '{0}'")]
     UnknownSignedExtension(String),
+    /// Cannot find the type id of a signed extension in the metadata.
     #[error("Cannot find extension's '{0}' type id '{1} in the metadata")]
     MissingTypeId(String, u32),
+    /// User provided a different signed extension than the one expected.
     #[error("Provided a different signed extension for '{0}', the metadata expect '{1}'")]
     ExpectedAnotherExtension(String, String),
+    /// The inner type of a signed extension is not present in the metadata.
     #[error("The inner type of the signed extension '{0}' is not present in the metadata")]
     MissingInnerSignedExtension(String),
+    /// The inner type of the signed extension is not named.
     #[error("The signed extension's '{0}' type id '{1}' does not have a name in the metadata")]
     ExpectedNamedTypeId(String, u32),
     /// Some custom error.s

--- a/subxt/src/config/extrinsic_params.rs
+++ b/subxt/src/config/extrinsic_params.rs
@@ -18,7 +18,15 @@ pub enum ExtrinsicParamsError {
     /// A signed extension was encountered that we don't know about.
     #[error("Error constructing extrinsic parameters: Unknown signed extension '{0}'")]
     UnknownSignedExtension(String),
-    /// Some custom error.
+    #[error("Cannot find extension's '{0}' type id '{1} in the metadata")]
+    MissingTypeId(String, u32),
+    #[error("Provided a different signed extension for '{0}', the metadata expect '{1}'")]
+    ExpectedAnotherExtension(String, String),
+    #[error("The inner type of the signed extension '{0}' is not present in the metadata")]
+    MissingInnerSignedExtension(String),
+    #[error("The signed extension's '{0}' type id '{1}' does not have a name in the metadata")]
+    ExpectedNamedTypeId(String, u32),
+    /// Some custom error.s
     #[error("Error constructing extrinsic parameters: {0}")]
     Custom(CustomError),
 }

--- a/subxt/src/config/mod.rs
+++ b/subxt/src/config/mod.rs
@@ -18,6 +18,7 @@ pub mod substrate;
 use codec::{Decode, Encode};
 use core::fmt::Debug;
 use scale_decode::DecodeAsType;
+use scale_encode::EncodeAsType;
 use serde::{de::DeserializeOwned, Serialize};
 
 pub use default_extrinsic_params::{DefaultExtrinsicParams, DefaultExtrinsicParamsBuilder};
@@ -54,7 +55,7 @@ pub trait Config: Sized + Send + Sync + 'static {
     type ExtrinsicParams: ExtrinsicParams<Self>;
 
     /// This is used to identify an asset in the `ChargeAssetTxPayment` signed extension.
-    type AssetId: Debug + Encode + DecodeAsType;
+    type AssetId: Debug + Clone + Encode + DecodeAsType + EncodeAsType;
 }
 
 /// given some [`Config`], this return the other params needed for its `ExtrinsicParams`.

--- a/subxt/src/config/signed_extensions.rs
+++ b/subxt/src/config/signed_extensions.rs
@@ -518,10 +518,7 @@ where
         client: Client,
         other_params: Self::OtherParams,
     ) -> Result<Self, Self::Error> {
-        let other_params = match other_params.0 {
-            Some(other_params) => other_params,
-            None => <S as ExtrinsicParams<T>>::OtherParams::default(),
-        };
+        let other_params = other_params.0.unwrap_or_default();
 
         let metadata = client.metadata();
         let encoding_data = SkipCheckIfFeelessEncodingData::new(metadata, Self::NAME, S::NAME)?;

--- a/subxt/src/config/signed_extensions.rs
+++ b/subxt/src/config/signed_extensions.rs
@@ -33,7 +33,7 @@ pub trait SignedExtension<T: Config>: ExtrinsicParams<T> {
 }
 
 /// The [`CheckSpecVersion`] signed extension.
-#[derive(Debug)]
+#[derive(Clone, Debug, EncodeAsType, DecodeAsType)]
 pub struct CheckSpecVersion(u32);
 
 impl<T: Config> ExtrinsicParams<T> for CheckSpecVersion {
@@ -61,7 +61,7 @@ impl<T: Config> SignedExtension<T> for CheckSpecVersion {
 }
 
 /// The [`CheckNonce`] signed extension.
-#[derive(Debug)]
+#[derive(Clone, Debug, EncodeAsType, DecodeAsType)]
 pub struct CheckNonce(Compact<u64>);
 
 impl<T: Config> ExtrinsicParams<T> for CheckNonce {
@@ -89,7 +89,7 @@ impl<T: Config> SignedExtension<T> for CheckNonce {
 }
 
 /// The [`CheckTxVersion`] signed extension.
-#[derive(Debug)]
+#[derive(Clone, Debug, EncodeAsType, DecodeAsType)]
 pub struct CheckTxVersion(u32);
 
 impl<T: Config> ExtrinsicParams<T> for CheckTxVersion {
@@ -117,6 +117,9 @@ impl<T: Config> SignedExtension<T> for CheckTxVersion {
 }
 
 /// The [`CheckGenesis`] signed extension.
+#[derive(Clone, EncodeAsType, DecodeAsType)]
+#[decode_as_type(trait_bounds = "T::Hash: DecodeAsType")]
+#[encode_as_type(trait_bounds = "T::Hash: EncodeAsType")]
 pub struct CheckGenesis<T: Config>(T::Hash);
 
 impl<T: Config> std::fmt::Debug for CheckGenesis<T> {
@@ -150,12 +153,16 @@ impl<T: Config> SignedExtension<T> for CheckGenesis<T> {
 }
 
 /// The [`CheckMortality`] signed extension.
+#[derive(Clone, EncodeAsType, DecodeAsType)]
+#[decode_as_type(trait_bounds = "T::Hash: DecodeAsType")]
+#[encode_as_type(trait_bounds = "T::Hash: EncodeAsType")]
 pub struct CheckMortality<T: Config> {
     era: Era,
     checkpoint: T::Hash,
 }
 
 /// Parameters to configure the [`CheckMortality`] signed extension.
+#[derive(Clone, Debug)]
 pub struct CheckMortalityParams<T: Config> {
     era: Era,
     checkpoint: Option<T::Hash>,
@@ -230,7 +237,7 @@ impl<T: Config> SignedExtension<T> for CheckMortality<T> {
 }
 
 /// The [`ChargeAssetTxPayment`] signed extension.
-#[derive(Debug, DecodeAsType, EncodeAsType, Clone)]
+#[derive(Clone, Debug, DecodeAsType, EncodeAsType)]
 #[decode_as_type(trait_bounds = "T::AssetId: DecodeAsType")]
 #[encode_as_type(trait_bounds = "T::AssetId: EncodeAsType")]
 pub struct ChargeAssetTxPayment<T: Config> {
@@ -251,6 +258,7 @@ impl<T: Config> ChargeAssetTxPayment<T> {
 }
 
 /// Parameters to configure the [`ChargeAssetTxPayment`] signed extension.
+#[derive(Debug)]
 pub struct ChargeAssetTxPaymentParams<T: Config> {
     tip: u128,
     asset_id: Option<T::AssetId>,
@@ -260,7 +268,7 @@ pub struct ChargeAssetTxPaymentParams<T: Config> {
 impl<T: Config> Clone for ChargeAssetTxPaymentParams<T> {
     fn clone(&self) -> Self {
         Self {
-            tip: self.tip.clone(),
+            tip: self.tip,
             asset_id: self.asset_id.clone(),
         }
     }
@@ -327,7 +335,7 @@ impl<T: Config> SignedExtension<T> for ChargeAssetTxPayment<T> {
 }
 
 /// The [`ChargeTransactionPayment`] signed extension.
-#[derive(Debug, DecodeAsType, EncodeAsType)]
+#[derive(Clone, Debug, DecodeAsType, EncodeAsType)]
 pub struct ChargeTransactionPayment {
     tip: Compact<u128>,
 }
@@ -463,8 +471,9 @@ impl SkipCheckIfFeelessEncodingData {
 }
 
 /// The [`SkipCheckIfFeeless`] signed extension.
-#[derive(Debug, DecodeAsType)]
+#[derive(Debug, DecodeAsType, EncodeAsType)]
 #[decode_as_type(trait_bounds = "S: DecodeAsType")]
+#[encode_as_type(trait_bounds = "S: EncodeAsType")]
 pub struct SkipCheckIfFeeless<T, S>
 where
     T: Config,
@@ -477,8 +486,10 @@ where
     // [`ExtrinsicParams`] (ie, when subxt submits extrinsics). However, it is not
     // populated when decoding signed extensions from the node.
     #[decode_as_type(skip)]
+    #[encode_as_type(skip)]
     encoding_data: Option<SkipCheckIfFeelessEncodingData>,
     #[decode_as_type(skip)]
+    #[encode_as_type(skip)]
     _phantom: PhantomData<T>,
 }
 
@@ -555,6 +566,16 @@ pub struct SkipCheckIfFeelessParams<T, S>(Option<<S as ExtrinsicParams<T>>::Othe
 where
     T: Config,
     S: SignedExtension<T>;
+
+impl<T, S> std::fmt::Debug for SkipCheckIfFeelessParams<T, S>
+where
+    T: Config,
+    S: SignedExtension<T>,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("SkipCheckIfFeelessParams").finish()
+    }
+}
 
 impl<T: Config, S: SignedExtension<T>> Default for SkipCheckIfFeelessParams<T, S>
 where

--- a/subxt/src/config/signed_extensions.rs
+++ b/subxt/src/config/signed_extensions.rs
@@ -370,6 +370,32 @@ impl<T: Config> SignedExtension<T> for ChargeTransactionPayment {
     type Decoded = Self;
 }
 
+/// The [`SkipCheckIfFeeless`] signed extension.
+#[derive(Debug, DecodeAsType)]
+pub struct SkipCheckIfFeeless;
+
+impl<T: Config> ExtrinsicParams<T> for SkipCheckIfFeeless {
+    type OtherParams = ();
+    type Error = std::convert::Infallible;
+
+    fn new<Client: OfflineClientT<T>>(
+        _nonce: u64,
+        _client: Client,
+        _other_params: Self::OtherParams,
+    ) -> Result<Self, Self::Error> {
+        Ok(SkipCheckIfFeeless)
+    }
+}
+
+impl ExtrinsicParamsEncoder for SkipCheckIfFeeless {
+    fn encode_extra_to(&self, _v: &mut Vec<u8>) {}
+}
+
+impl<T: Config> SignedExtension<T> for SkipCheckIfFeeless {
+    const NAME: &'static str = "SkipCheckIfFeeless";
+    type Decoded = Self;
+}
+
 /// This accepts a tuple of [`SignedExtension`]s, and will dynamically make use of whichever
 /// ones are actually required for the chain in the correct order, ignoring the rest. This
 /// is a sensible default, and allows for a single configuration to work across multiple chains.

--- a/subxt/src/utils/era.rs
+++ b/subxt/src/utils/era.rs
@@ -3,11 +3,21 @@
 // see LICENSE for license details.
 
 use scale_decode::DecodeAsType;
+use scale_encode::EncodeAsType;
 
 // Dev note: This and related bits taken from `sp_runtime::generic::Era`
 /// An era to describe the longevity of a transaction.
 #[derive(
-    PartialEq, Default, Eq, Clone, Copy, Debug, serde::Serialize, serde::Deserialize, DecodeAsType,
+    PartialEq,
+    Default,
+    Eq,
+    Clone,
+    Copy,
+    Debug,
+    serde::Serialize,
+    serde::Deserialize,
+    DecodeAsType,
+    EncodeAsType,
 )]
 pub enum Era {
     /// The transaction is valid forever. The genesis hash must be present in the signed content.

--- a/testing/integration-tests/src/full_client/blocks/mod.rs
+++ b/testing/integration-tests/src/full_client/blocks/mod.rs
@@ -5,7 +5,9 @@
 use crate::{test_context, utils::node_runtime};
 use codec::{Compact, Encode};
 use futures::StreamExt;
-use subxt::config::signed_extensions::{ChargeAssetTxPayment, CheckMortality, CheckNonce};
+use subxt::config::signed_extensions::{
+    ChargeAssetTxPayment, CheckMortality, CheckNonce, SkipCheckIfFeeless,
+};
 use subxt::config::DefaultExtrinsicParamsBuilder;
 use subxt::config::SubstrateConfig;
 use subxt::utils::Era;
@@ -276,13 +278,15 @@ async fn decode_signed_extensions_from_blocks() {
 
     let transaction1 = submit_transfer_extrinsic_and_get_it_back!(1234);
     let extensions1 = transaction1.signed_extensions().unwrap();
+
     let nonce1 = extensions1.nonce().unwrap();
     let nonce1_static = extensions1.find::<CheckNonce>().unwrap().unwrap().0;
     let tip1 = extensions1.tip().unwrap();
     let tip1_static: u128 = extensions1
-        .find::<ChargeAssetTxPayment<SubstrateConfig>>()
+        .find::<SkipCheckIfFeeless<SubstrateConfig, ChargeAssetTxPayment<SubstrateConfig>>>()
         .unwrap()
         .unwrap()
+        .inner_signed_extension()
         .tip();
 
     let transaction2 = submit_transfer_extrinsic_and_get_it_back!(5678);
@@ -291,9 +295,10 @@ async fn decode_signed_extensions_from_blocks() {
     let nonce2_static = extensions2.find::<CheckNonce>().unwrap().unwrap().0;
     let tip2 = extensions2.tip().unwrap();
     let tip2_static: u128 = extensions2
-        .find::<ChargeAssetTxPayment<SubstrateConfig>>()
+        .find::<SkipCheckIfFeeless<SubstrateConfig, ChargeAssetTxPayment<SubstrateConfig>>>()
         .unwrap()
         .unwrap()
+        .inner_signed_extension()
         .tip();
 
     assert_eq!(nonce1, 0);
@@ -313,7 +318,7 @@ async fn decode_signed_extensions_from_blocks() {
         "CheckMortality",
         "CheckNonce",
         "CheckWeight",
-        "ChargeAssetTxPayment",
+        "SkipCheckIfFeeless",
     ];
 
     assert_eq!(extensions1.iter().count(), expected_signed_extensions.len());


### PR DESCRIPTION
This PR adds the `SkipCheckIfFeeless` to the signed extensions of subxt.

The extension was introduced in substrate to skip calculating feels if the extrinsics are feeless.

From [substrate](https://github.com/paritytech/polkadot-sdk/blob/05ddbf57a154f350e0015d3264543bcda09153cf/substrate/frame/transaction-payment/skip-feeless-payment/src/lib.rs#L80), the `SkipCheckIfFeeless` is simply a wrapper over another signed extension.

```rust
/// A [`SignedExtension`] that skips the wrapped extension if the dispatchable is feeless.
#[derive(Encode, Decode, Clone, Eq, PartialEq, TypeInfo)]
#[scale_info(skip_type_params(T))]
pub struct SkipCheckIfFeeless<T: Config, S: SignedExtension>(pub S, sp_std::marker::PhantomData<T>);

```

This extension will forward for encoding whatever extension it wraps.
The extension has implications for the `pre_dispatch` method where the inner extension is conditionally disabled depending on whether the transaction is feeless or not. As well for the `post_dispatch` to generate an event specific to the feeless extrinsics named `FeeSkipped`.


From the subxt perspective, we need to implement our `SignedExtension` trait for the `SkipCheckIfFeeless`. Doing so will propagate the extension name that is correlated for decoding purposes and it fixes errors such as:

```bash
 Error: ExtrinsicParams(UnknownSignedExtension("SkipCheckIfFeeless"))
 ```


Closes https://github.com/paritytech/subxt/issues/1262