### PR TITLE
add `rpc_client` to Backend trait

### DIFF
--- a/subxt/src/backend/legacy/mod.rs
+++ b/subxt/src/backend/legacy/mod.rs
@@ -9,8 +9,8 @@ pub mod rpc_methods;
 
 use self::rpc_methods::TransactionStatus as RpcTransactionStatus;
 use crate::backend::{
-    rpc::RpcClient, Backend, BlockRef, RuntimeVersion, StorageResponse, StreamOf, StreamOfResults,
-    TransactionStatus,
+    rpc::RpcClient, Backend, BlockRef, RpcClientT, RuntimeVersion, StorageResponse, StreamOf,
+    StreamOfResults, TransactionStatus,
 };
 use crate::{config::Header, Config, Error};
 use async_trait::async_trait;
@@ -41,6 +41,10 @@ impl<T: Config> super::sealed::Sealed for LegacyBackend<T> {}
 
 #[async_trait]
 impl<T: Config + Send + Sync + 'static> Backend<T> for LegacyBackend<T> {
+    fn rpc_client(&self) -> &dyn RpcClientT {
+        &*self.methods.client
+    }
+
     async fn storage_fetch_values(
         &self,
         keys: Vec<Vec<u8>>,

--- a/subxt/src/backend/legacy/mod.rs
+++ b/subxt/src/backend/legacy/mod.rs
@@ -42,7 +42,7 @@ impl<T: Config> super::sealed::Sealed for LegacyBackend<T> {}
 #[async_trait]
 impl<T: Config + Send + Sync + 'static> Backend<T> for LegacyBackend<T> {
     fn rpc_client(&self) -> &dyn RpcClientT {
-        &*self.methods.client
+        &*self.methods.rpc_client()
     }
 
     async fn storage_fetch_values(

--- a/subxt/src/backend/legacy/rpc_methods.rs
+++ b/subxt/src/backend/legacy/rpc_methods.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Derivative)]
 #[derivative(Clone(bound = ""), Debug(bound = ""))]
 pub struct LegacyRpcMethods<T> {
-    pub(crate) client: RpcClient,
+    client: RpcClient,
     _marker: std::marker::PhantomData<T>,
 }
 
@@ -30,6 +30,12 @@ impl<T: Config> LegacyRpcMethods<T> {
             _marker: std::marker::PhantomData,
         }
     }
+
+    /// Return the internal [`RpcClient`].
+    pub fn rpc_client(&self) -> &RpcClient {
+        &self.client
+    }
+
 
     /// Fetch the raw bytes for a given storage key
     pub async fn state_get_storage(

--- a/subxt/src/backend/legacy/rpc_methods.rs
+++ b/subxt/src/backend/legacy/rpc_methods.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Derivative)]
 #[derivative(Clone(bound = ""), Debug(bound = ""))]
 pub struct LegacyRpcMethods<T> {
-    client: RpcClient,
+    pub(crate) client: RpcClient,
     _marker: std::marker::PhantomData<T>,
 }
 

--- a/subxt/src/backend/mod.rs
+++ b/subxt/src/backend/mod.rs
@@ -10,6 +10,7 @@ pub mod legacy;
 pub mod rpc;
 pub mod unstable;
 
+use crate::backend::rpc::RpcClientT;
 use crate::error::Error;
 use crate::metadata::Metadata;
 use crate::Config;
@@ -29,6 +30,9 @@ pub(crate) mod sealed {
 /// a backend. Its goal is to be as minimal as possible.
 #[async_trait]
 pub trait Backend<T: Config>: sealed::Sealed + Send + Sync + 'static {
+    /// Return the underline rpc client of backend.
+    fn rpc_client(&self) -> &dyn RpcClientT;
+
     /// Fetch values from storage.
     async fn storage_fetch_values(
         &self,

--- a/subxt/src/backend/mod.rs
+++ b/subxt/src/backend/mod.rs
@@ -30,7 +30,7 @@ pub(crate) mod sealed {
 /// a backend. Its goal is to be as minimal as possible.
 #[async_trait]
 pub trait Backend<T: Config>: sealed::Sealed + Send + Sync + 'static {
-    /// Return the underline rpc client of backend.
+    /// Return the rpc client of backend.
     fn rpc_client(&self) -> &dyn RpcClientT;
 
     /// Fetch values from storage.

--- a/subxt/src/backend/unstable/mod.rs
+++ b/subxt/src/backend/unstable/mod.rs
@@ -22,8 +22,8 @@ use self::rpc_methods::{
     FollowEvent, MethodResponse, RuntimeEvent, StorageQuery, StorageQueryType, StorageResultType,
 };
 use crate::backend::{
-    rpc::RpcClient, Backend, BlockRef, BlockRefT, RuntimeVersion, StorageResponse, StreamOf,
-    StreamOfResults, TransactionStatus,
+    rpc::RpcClient, Backend, BlockRef, BlockRefT, RpcClientT, RuntimeVersion, StorageResponse,
+    StreamOf, StreamOfResults, TransactionStatus,
 };
 use crate::config::BlockHash;
 use crate::error::{Error, RpcError};
@@ -186,6 +186,10 @@ impl<T: Config> super::sealed::Sealed for UnstableBackend<T> {}
 
 #[async_trait]
 impl<T: Config + Send + Sync + 'static> Backend<T> for UnstableBackend<T> {
+    fn rpc_client(&self) -> &dyn RpcClientT {
+        &*self.methods.client
+    }
+
     async fn storage_fetch_values(
         &self,
         keys: Vec<Vec<u8>>,

--- a/subxt/src/backend/unstable/mod.rs
+++ b/subxt/src/backend/unstable/mod.rs
@@ -187,7 +187,7 @@ impl<T: Config> super::sealed::Sealed for UnstableBackend<T> {}
 #[async_trait]
 impl<T: Config + Send + Sync + 'static> Backend<T> for UnstableBackend<T> {
     fn rpc_client(&self) -> &dyn RpcClientT {
-        &*self.methods.client
+        &*self.methods.rpc_client()
     }
 
     async fn storage_fetch_values(

--- a/subxt/src/backend/unstable/rpc_methods.rs
+++ b/subxt/src/backend/unstable/rpc_methods.rs
@@ -21,7 +21,7 @@ use std::task::Poll;
 #[derive(Derivative)]
 #[derivative(Clone(bound = ""), Debug(bound = ""))]
 pub struct UnstableRpcMethods<T> {
-    pub(crate) client: RpcClient,
+    client: RpcClient,
     _marker: std::marker::PhantomData<T>,
 }
 
@@ -32,6 +32,11 @@ impl<T: Config> UnstableRpcMethods<T> {
             client,
             _marker: std::marker::PhantomData,
         }
+    }
+
+    /// Return the internal [`RpcClient`].
+    pub fn rpc_client(&self) -> &RpcClient {
+        &self.client
     }
 
     /// Subscribe to `chainHead_unstable_follow` to obtain all reported blocks by the chain.

--- a/subxt/src/backend/unstable/rpc_methods.rs
+++ b/subxt/src/backend/unstable/rpc_methods.rs
@@ -21,7 +21,7 @@ use std::task::Poll;
 #[derive(Derivative)]
 #[derivative(Clone(bound = ""), Debug(bound = ""))]
 pub struct UnstableRpcMethods<T> {
-    client: RpcClient,
+    pub(crate) client: RpcClient,
     _marker: std::marker::PhantomData<T>,
 }
 


### PR DESCRIPTION
User maybe need to add custom jsonrpc request so the internal rpc client need to be accessed.

Or maybe just return `RpcClient` is enough?