### PR TITLE
Improve SignedExtension matching logic and remove SkipCheckIfFeeless bits

### DIFF
--- a/subxt/examples/setup_config_custom.rs
+++ b/subxt/examples/setup_config_custom.rs
@@ -1,6 +1,6 @@
 use codec::Encode;
 use subxt::client::OfflineClientT;
-use subxt::config::{Config, ExtrinsicParams, ExtrinsicParamsEncoder};
+use subxt::config::{Config, ExtrinsicParams, ExtrinsicParamsEncoder, ExtrinsicParamsError};
 use subxt_signer::sr25519::dev;
 
 #[subxt::subxt(
@@ -66,14 +66,13 @@ impl CustomExtrinsicParamsBuilder {
 // Describe how to fetch and then encode the params:
 impl<T: Config> ExtrinsicParams<T> for CustomExtrinsicParams<T> {
     type OtherParams = CustomExtrinsicParamsBuilder;
-    type Error = std::convert::Infallible;
 
     // Gather together all of the params we will need to encode:
     fn new<Client: OfflineClientT<T>>(
         _nonce: u64,
         client: Client,
         other_params: Self::OtherParams,
-    ) -> Result<Self, Self::Error> {
+    ) -> Result<Self, ExtrinsicParamsError> {
         Ok(Self {
             genesis_hash: client.genesis_hash(),
             tip: other_params.tip,

--- a/subxt/examples/setup_config_signed_extension.rs
+++ b/subxt/examples/setup_config_signed_extension.rs
@@ -50,12 +50,8 @@ pub struct CustomSignedExtension;
 // up in the chain metadata in order to know when and if to use it.
 impl<T: Config> signed_extensions::SignedExtension<T> for CustomSignedExtension {
     type Decoded = ();
-    fn matches(
-        identifier: &str,
-        _type_id: u32,
-        _types: &PortableRegistry,
-    ) -> Result<bool, ExtrinsicParamsError> {
-        Ok(identifier == "CustomSignedExtension")
+    fn matches(identifier: &str, _type_id: u32, _types: &PortableRegistry) -> bool {
+        identifier == "CustomSignedExtension"
     }
 }
 

--- a/subxt/src/blocks/extrinsic_types.rs
+++ b/subxt/src/blocks/extrinsic_types.rs
@@ -739,7 +739,7 @@ impl<'a, T: Config> ExtrinsicSignedExtension<'a, T> {
     /// Returns `Ok(None)` if the data we have doesn't match the Signed Extension we're asking to
     /// decode with.
     pub fn as_signed_extension<S: SignedExtension<T>>(&self) -> Result<Option<S::Decoded>, Error> {
-        if !S::matches(self.identifier, self.ty_id, self.metadata.types())? {
+        if !S::matches(self.identifier, self.ty_id, self.metadata.types()) {
             return Ok(None);
         }
         self.as_type::<S::Decoded>().map(Some)

--- a/subxt/src/blocks/extrinsic_types.rs
+++ b/subxt/src/blocks/extrinsic_types.rs
@@ -672,7 +672,7 @@ impl<'a, T: Config> ExtrinsicSignedExtensions<'a, T> {
                 // No error, but no match either; next!
                 Ok(None) => continue,
                 // Error? return it
-                Err(e) => return Err(e.into()),
+                Err(e) => return Err(e),
             }
         }
         Ok(None)

--- a/subxt/src/blocks/extrinsic_types.rs
+++ b/subxt/src/blocks/extrinsic_types.rs
@@ -672,7 +672,7 @@ impl<'a, T: Config> ExtrinsicSignedExtensions<'a, T> {
                 // No error, but no match either; next!
                 Ok(None) => continue,
                 // Error? return it
-                Err(e) => return Err(e),
+                Err(e) => return Err(e.into()),
             }
         }
         Ok(None)

--- a/subxt/src/blocks/extrinsic_types.rs
+++ b/subxt/src/blocks/extrinsic_types.rs
@@ -665,7 +665,9 @@ impl<'a, T: Config> ExtrinsicSignedExtensions<'a, T> {
     /// If the Signed Extension is found but decoding failed `Err(_)` is returned.
     pub fn find<S: SignedExtension<T>>(&self) -> Result<Option<S::Decoded>, Error> {
         for ext in self.iter() {
-            let Ok(ext) = ext else { continue };
+            // If we encounter an error while iterating, we won't get any more results
+            // back, so just return that error as we won't find the signed ext anyway.
+            let ext = ext?;
             match ext.as_signed_extension::<S>() {
                 // We found a match; return it:
                 Ok(Some(e)) => return Ok(Some(e)),

--- a/subxt/src/config/default_extrinsic_params.rs
+++ b/subxt/src/config/default_extrinsic_params.rs
@@ -17,7 +17,6 @@ pub type DefaultExtrinsicParams<T> = signed_extensions::AnyOf<
         signed_extensions::CheckMortality<T>,
         signed_extensions::ChargeAssetTxPayment<T>,
         signed_extensions::ChargeTransactionPayment,
-        signed_extensions::SkipCheckIfFeeless<T, signed_extensions::ChargeAssetTxPayment<T>>,
     ),
 >;
 
@@ -132,9 +131,6 @@ impl<T: Config> DefaultExtrinsicParamsBuilder<T> {
         let charge_transaction_params =
             signed_extensions::ChargeTransactionPaymentParams::tip(self.tip);
 
-        let skip_check_params =
-            signed_extensions::SkipCheckIfFeelessParams::from(charge_asset_tx_params.clone());
-
         (
             (),
             (),
@@ -143,7 +139,6 @@ impl<T: Config> DefaultExtrinsicParamsBuilder<T> {
             check_mortality_params,
             charge_asset_tx_params,
             charge_transaction_params,
-            skip_check_params,
         )
     }
 }

--- a/subxt/src/config/signed_extensions.rs
+++ b/subxt/src/config/signed_extensions.rs
@@ -30,10 +30,6 @@ pub trait SignedExtension<T: Config>: ExtrinsicParams<T> {
     /// This should return true if the signed extension matches the details given.
     /// Often, this will involve just checking that the identifier given matches that of the
     /// extension in question.
-    ///
-    /// The first match that returns true will be the entry that this signed extension
-    /// is used to encode values for. This takes `&mut self`, allowing the extension to
-    /// cache values if it likes when it finds the type it'll be encoding for.
     fn matches(identifier: &str, _type_id: u32, _types: &PortableRegistry) -> bool;
 }
 

--- a/subxt/src/config/signed_extensions.rs
+++ b/subxt/src/config/signed_extensions.rs
@@ -34,11 +34,7 @@ pub trait SignedExtension<T: Config>: ExtrinsicParams<T> {
     /// The first match that returns true will be the entry that this signed extension
     /// is used to encode values for. This takes `&mut self`, allowing the extension to
     /// cache values if it likes when it finds the type it'll be encoding for.
-    fn matches(
-        identifier: &str,
-        _type_id: u32,
-        _types: &PortableRegistry,
-    ) -> Result<bool, ExtrinsicParamsError>;
+    fn matches(identifier: &str, _type_id: u32, _types: &PortableRegistry) -> bool;
 }
 
 /// The [`CheckSpecVersion`] signed extension.
@@ -64,12 +60,8 @@ impl ExtrinsicParamsEncoder for CheckSpecVersion {
 
 impl<T: Config> SignedExtension<T> for CheckSpecVersion {
     type Decoded = ();
-    fn matches(
-        identifier: &str,
-        _type_id: u32,
-        _types: &PortableRegistry,
-    ) -> Result<bool, ExtrinsicParamsError> {
-        Ok(identifier == "CheckSpecVersion")
+    fn matches(identifier: &str, _type_id: u32, _types: &PortableRegistry) -> bool {
+        identifier == "CheckSpecVersion"
     }
 }
 
@@ -96,12 +88,8 @@ impl ExtrinsicParamsEncoder for CheckNonce {
 
 impl<T: Config> SignedExtension<T> for CheckNonce {
     type Decoded = u64;
-    fn matches(
-        identifier: &str,
-        _type_id: u32,
-        _types: &PortableRegistry,
-    ) -> Result<bool, ExtrinsicParamsError> {
-        Ok(identifier == "CheckNonce")
+    fn matches(identifier: &str, _type_id: u32, _types: &PortableRegistry) -> bool {
+        identifier == "CheckNonce"
     }
 }
 
@@ -128,12 +116,8 @@ impl ExtrinsicParamsEncoder for CheckTxVersion {
 
 impl<T: Config> SignedExtension<T> for CheckTxVersion {
     type Decoded = ();
-    fn matches(
-        identifier: &str,
-        _type_id: u32,
-        _types: &PortableRegistry,
-    ) -> Result<bool, ExtrinsicParamsError> {
-        Ok(identifier == "CheckTxVersion")
+    fn matches(identifier: &str, _type_id: u32, _types: &PortableRegistry) -> bool {
+        identifier == "CheckTxVersion"
     }
 }
 
@@ -160,12 +144,8 @@ impl<T: Config> ExtrinsicParamsEncoder for CheckGenesis<T> {
 
 impl<T: Config> SignedExtension<T> for CheckGenesis<T> {
     type Decoded = ();
-    fn matches(
-        identifier: &str,
-        _type_id: u32,
-        _types: &PortableRegistry,
-    ) -> Result<bool, ExtrinsicParamsError> {
-        Ok(identifier == "CheckGenesis")
+    fn matches(identifier: &str, _type_id: u32, _types: &PortableRegistry) -> bool {
+        identifier == "CheckGenesis"
     }
 }
 
@@ -236,12 +216,8 @@ impl<T: Config> ExtrinsicParamsEncoder for CheckMortality<T> {
 
 impl<T: Config> SignedExtension<T> for CheckMortality<T> {
     type Decoded = Era;
-    fn matches(
-        identifier: &str,
-        _type_id: u32,
-        _types: &PortableRegistry,
-    ) -> Result<bool, ExtrinsicParamsError> {
-        Ok(identifier == "CheckMortality")
+    fn matches(identifier: &str, _type_id: u32, _types: &PortableRegistry) -> bool {
+        identifier == "CheckMortality"
     }
 }
 
@@ -328,12 +304,8 @@ impl<T: Config> ExtrinsicParamsEncoder for ChargeAssetTxPayment<T> {
 
 impl<T: Config> SignedExtension<T> for ChargeAssetTxPayment<T> {
     type Decoded = Self;
-    fn matches(
-        identifier: &str,
-        _type_id: u32,
-        _types: &PortableRegistry,
-    ) -> Result<bool, ExtrinsicParamsError> {
-        Ok(identifier == "ChargeAssetTxPayment")
+    fn matches(identifier: &str, _type_id: u32, _types: &PortableRegistry) -> bool {
+        identifier == "ChargeAssetTxPayment"
     }
 }
 
@@ -389,12 +361,8 @@ impl ExtrinsicParamsEncoder for ChargeTransactionPayment {
 
 impl<T: Config> SignedExtension<T> for ChargeTransactionPayment {
     type Decoded = Self;
-    fn matches(
-        identifier: &str,
-        _type_id: u32,
-        _types: &PortableRegistry,
-    ) -> Result<bool, ExtrinsicParamsError> {
-        Ok(identifier == "ChargeTransactionPayment")
+    fn matches(identifier: &str, _type_id: u32, _types: &PortableRegistry) -> bool {
+        identifier == "ChargeTransactionPayment"
     }
 }
 
@@ -436,7 +404,7 @@ macro_rules! impl_tuples {
                             continue
                         }
                         // Break and record as soon as we find a match:
-                        if $ident::matches(e.identifier(), e.extra_ty(), types)? {
+                        if $ident::matches(e.identifier(), e.extra_ty(), types) {
                             let ext = $ident::new(nonce, client.clone(), other_params.$index)?;
                             let boxed_ext: Box<dyn ExtrinsicParamsEncoder> = Box::new(ext);
                             exts_by_index.insert(idx, boxed_ext);

--- a/subxt/src/config/signed_extensions.rs
+++ b/subxt/src/config/signed_extensions.rs
@@ -9,12 +9,12 @@
 
 use super::extrinsic_params::{ExtrinsicParams, ExtrinsicParamsEncoder, ExtrinsicParamsError};
 use crate::utils::Era;
-use crate::{client::OfflineClientT, Config, Metadata};
+use crate::{client::OfflineClientT, Config};
 use codec::{Compact, Encode};
 use core::fmt::Debug;
 use scale_decode::DecodeAsType;
 use scale_encode::EncodeAsType;
-use std::marker::PhantomData;
+use scale_info::PortableRegistry;
 
 use std::collections::HashMap;
 
@@ -22,14 +22,23 @@ use std::collections::HashMap;
 /// same as [`ExtrinsicParams`] in describing how to encode the extra and
 /// additional data.
 pub trait SignedExtension<T: Config>: ExtrinsicParams<T> {
-    /// The name of the signed extension. This is used to associate it
-    /// with the signed extensions that the node is making use of.
-    const NAME: &'static str;
-
     /// The type representing the `extra` bytes of a signed extension.
     /// Decoding from this type should be symmetrical to the respective
     /// `ExtrinsicParamsEncoder::encode_extra_to()` implementation of this signed extension.
     type Decoded: DecodeAsType;
+
+    /// This should return true if the signed extension matches the details given.
+    /// Often, this will involve just checking that the identifier given matches that of the
+    /// extension in question.
+    ///
+    /// The first match that returns true will be the entry that this signed extension
+    /// is used to encode values for. This takes `&mut self`, allowing the extension to
+    /// cache values if it likes when it finds the type it'll be encoding for.
+    fn matches(
+        identifier: &str,
+        type_id: u32,
+        types: &PortableRegistry,
+    ) -> Result<bool, ExtrinsicParamsError>;
 }
 
 /// The [`CheckSpecVersion`] signed extension.
@@ -38,13 +47,12 @@ pub struct CheckSpecVersion(u32);
 
 impl<T: Config> ExtrinsicParams<T> for CheckSpecVersion {
     type OtherParams = ();
-    type Error = std::convert::Infallible;
 
     fn new<Client: OfflineClientT<T>>(
         _nonce: u64,
         client: Client,
         _other_params: Self::OtherParams,
-    ) -> Result<Self, Self::Error> {
+    ) -> Result<Self, ExtrinsicParamsError> {
         Ok(CheckSpecVersion(client.runtime_version().spec_version))
     }
 }
@@ -56,8 +64,14 @@ impl ExtrinsicParamsEncoder for CheckSpecVersion {
 }
 
 impl<T: Config> SignedExtension<T> for CheckSpecVersion {
-    const NAME: &'static str = "CheckSpecVersion";
     type Decoded = ();
+    fn matches(
+        _identifier: &str,
+        type_id: u32,
+        types: &PortableRegistry,
+    ) -> Result<bool, ExtrinsicParamsError> {
+        type_id_matches_ext_name(type_id, types, "CheckSpecVersion")
+    }
 }
 
 /// The [`CheckNonce`] signed extension.
@@ -66,13 +80,12 @@ pub struct CheckNonce(Compact<u64>);
 
 impl<T: Config> ExtrinsicParams<T> for CheckNonce {
     type OtherParams = ();
-    type Error = std::convert::Infallible;
 
     fn new<Client: OfflineClientT<T>>(
         nonce: u64,
         _client: Client,
         _other_params: Self::OtherParams,
-    ) -> Result<Self, Self::Error> {
+    ) -> Result<Self, ExtrinsicParamsError> {
         Ok(CheckNonce(Compact(nonce)))
     }
 }
@@ -84,8 +97,14 @@ impl ExtrinsicParamsEncoder for CheckNonce {
 }
 
 impl<T: Config> SignedExtension<T> for CheckNonce {
-    const NAME: &'static str = "CheckNonce";
-    type Decoded = Compact<u64>;
+    type Decoded = u64;
+    fn matches(
+        _identifier: &str,
+        type_id: u32,
+        types: &PortableRegistry,
+    ) -> Result<bool, ExtrinsicParamsError> {
+        type_id_matches_ext_name(type_id, types, "CheckNonce")
+    }
 }
 
 /// The [`CheckTxVersion`] signed extension.
@@ -94,13 +113,12 @@ pub struct CheckTxVersion(u32);
 
 impl<T: Config> ExtrinsicParams<T> for CheckTxVersion {
     type OtherParams = ();
-    type Error = std::convert::Infallible;
 
     fn new<Client: OfflineClientT<T>>(
         _nonce: u64,
         client: Client,
         _other_params: Self::OtherParams,
-    ) -> Result<Self, Self::Error> {
+    ) -> Result<Self, ExtrinsicParamsError> {
         Ok(CheckTxVersion(client.runtime_version().transaction_version))
     }
 }
@@ -112,8 +130,14 @@ impl ExtrinsicParamsEncoder for CheckTxVersion {
 }
 
 impl<T: Config> SignedExtension<T> for CheckTxVersion {
-    const NAME: &'static str = "CheckTxVersion";
     type Decoded = ();
+    fn matches(
+        _identifier: &str,
+        type_id: u32,
+        types: &PortableRegistry,
+    ) -> Result<bool, ExtrinsicParamsError> {
+        type_id_matches_ext_name(type_id, types, "CheckTxVersion")
+    }
 }
 
 /// The [`CheckGenesis`] signed extension.
@@ -130,13 +154,12 @@ impl<T: Config> std::fmt::Debug for CheckGenesis<T> {
 
 impl<T: Config> ExtrinsicParams<T> for CheckGenesis<T> {
     type OtherParams = ();
-    type Error = std::convert::Infallible;
 
     fn new<Client: OfflineClientT<T>>(
         _nonce: u64,
         client: Client,
         _other_params: Self::OtherParams,
-    ) -> Result<Self, Self::Error> {
+    ) -> Result<Self, ExtrinsicParamsError> {
         Ok(CheckGenesis(client.genesis_hash()))
     }
 }
@@ -148,8 +171,14 @@ impl<T: Config> ExtrinsicParamsEncoder for CheckGenesis<T> {
 }
 
 impl<T: Config> SignedExtension<T> for CheckGenesis<T> {
-    const NAME: &'static str = "CheckGenesis";
     type Decoded = ();
+    fn matches(
+        _identifier: &str,
+        type_id: u32,
+        types: &PortableRegistry,
+    ) -> Result<bool, ExtrinsicParamsError> {
+        type_id_matches_ext_name(type_id, types, "CheckGenesis")
+    }
 }
 
 /// The [`CheckMortality`] signed extension.
@@ -208,13 +237,12 @@ impl<T: Config> std::fmt::Debug for CheckMortality<T> {
 
 impl<T: Config> ExtrinsicParams<T> for CheckMortality<T> {
     type OtherParams = CheckMortalityParams<T>;
-    type Error = std::convert::Infallible;
 
     fn new<Client: OfflineClientT<T>>(
         _nonce: u64,
         client: Client,
         other_params: Self::OtherParams,
-    ) -> Result<Self, Self::Error> {
+    ) -> Result<Self, ExtrinsicParamsError> {
         Ok(CheckMortality {
             era: other_params.era,
             checkpoint: other_params.checkpoint.unwrap_or(client.genesis_hash()),
@@ -227,19 +255,24 @@ impl<T: Config> ExtrinsicParamsEncoder for CheckMortality<T> {
         self.era.encode_to(v);
     }
     fn encode_additional_to(&self, v: &mut Vec<u8>) {
-        self.checkpoint.encode_to(v)
+        self.checkpoint.encode_to(v);
     }
 }
 
 impl<T: Config> SignedExtension<T> for CheckMortality<T> {
-    const NAME: &'static str = "CheckMortality";
     type Decoded = Era;
+    fn matches(
+        _identifier: &str,
+        type_id: u32,
+        types: &PortableRegistry,
+    ) -> Result<bool, ExtrinsicParamsError> {
+        type_id_matches_ext_name(type_id, types, "CheckMortality")
+    }
 }
 
 /// The [`ChargeAssetTxPayment`] signed extension.
-#[derive(Clone, Debug, DecodeAsType, EncodeAsType)]
+#[derive(Clone, Debug, DecodeAsType)]
 #[decode_as_type(trait_bounds = "T::AssetId: DecodeAsType")]
-#[encode_as_type(trait_bounds = "T::AssetId: EncodeAsType")]
 pub struct ChargeAssetTxPayment<T: Config> {
     tip: Compact<u128>,
     asset_id: Option<T::AssetId>,
@@ -309,13 +342,12 @@ impl<T: Config> ChargeAssetTxPaymentParams<T> {
 
 impl<T: Config> ExtrinsicParams<T> for ChargeAssetTxPayment<T> {
     type OtherParams = ChargeAssetTxPaymentParams<T>;
-    type Error = std::convert::Infallible;
 
     fn new<Client: OfflineClientT<T>>(
         _nonce: u64,
         _client: Client,
         other_params: Self::OtherParams,
-    ) -> Result<Self, Self::Error> {
+    ) -> Result<Self, ExtrinsicParamsError> {
         Ok(ChargeAssetTxPayment {
             tip: Compact(other_params.tip),
             asset_id: other_params.asset_id,
@@ -330,12 +362,18 @@ impl<T: Config> ExtrinsicParamsEncoder for ChargeAssetTxPayment<T> {
 }
 
 impl<T: Config> SignedExtension<T> for ChargeAssetTxPayment<T> {
-    const NAME: &'static str = "ChargeAssetTxPayment";
     type Decoded = Self;
+    fn matches(
+        _identifier: &str,
+        type_id: u32,
+        types: &PortableRegistry,
+    ) -> Result<bool, ExtrinsicParamsError> {
+        type_id_matches_ext_name(type_id, types, "ChargeAssetTxPayment")
+    }
 }
 
 /// The [`ChargeTransactionPayment`] signed extension.
-#[derive(Clone, Debug, DecodeAsType, EncodeAsType)]
+#[derive(Clone, Debug, DecodeAsType)]
 pub struct ChargeTransactionPayment {
     tip: Compact<u128>,
 }
@@ -366,13 +404,12 @@ impl ChargeTransactionPaymentParams {
 
 impl<T: Config> ExtrinsicParams<T> for ChargeTransactionPayment {
     type OtherParams = ChargeTransactionPaymentParams;
-    type Error = std::convert::Infallible;
 
     fn new<Client: OfflineClientT<T>>(
         _nonce: u64,
         _client: Client,
         other_params: Self::OtherParams,
-    ) -> Result<Self, Self::Error> {
+    ) -> Result<Self, ExtrinsicParamsError> {
         Ok(ChargeTransactionPayment {
             tip: Compact(other_params.tip),
         })
@@ -386,212 +423,13 @@ impl ExtrinsicParamsEncoder for ChargeTransactionPayment {
 }
 
 impl<T: Config> SignedExtension<T> for ChargeTransactionPayment {
-    const NAME: &'static str = "ChargeTransactionPayment";
     type Decoded = Self;
-}
-
-/// Information needed to encode the [`SkipCheckIfFeeless`] signed extension.
-#[derive(Debug)]
-struct SkipCheckIfFeelessEncodingData {
-    metadata: Metadata,
-    type_id: u32,
-}
-
-impl SkipCheckIfFeelessEncodingData {
-    /// Construct [`SkipCheckIfFeelessEncodingData`].
-    fn new(
-        metadata: Metadata,
-        extension: &str,
-        inner_extension: &str,
-    ) -> Result<Self, ExtrinsicParamsError> {
-        let skip_check_type_id = metadata
-            .extrinsic()
-            .signed_extensions()
-            .iter()
-            .find_map(|ext| {
-                if ext.identifier() == extension {
-                    Some(ext.extra_ty())
-                } else {
-                    None
-                }
-            });
-        let Some(skip_check_type_id) = skip_check_type_id else {
-            return Err(ExtrinsicParamsError::UnknownSignedExtension(
-                inner_extension.to_owned(),
-            ));
-        };
-
-        // Ensure that the `SkipCheckIfFeeless` type has the same inner signed extension as provided.
-        let Some(skip_check_ty) = metadata.types().resolve(skip_check_type_id) else {
-            return Err(ExtrinsicParamsError::MissingTypeId(
-                inner_extension.to_owned(),
-                skip_check_type_id,
-            ));
-        };
-
-        // The substrate's `SkipCheckIfFeeless` contains 2 types: the inner signed extension and a phantom data.
-        // Phantom data does not have a type associated, so we need to find the inner signed extension.
-        let Some(inner_type_id) = skip_check_ty
-            .type_params
-            .iter()
-            .find_map(|param| param.ty.map(|ty| ty.id))
-        else {
-            return Err(ExtrinsicParamsError::MissingInnerSignedExtension(
-                inner_extension.to_owned(),
-            ));
-        };
-
-        // Get the inner type of the `SkipCheckIfFeeless` extension to check if the naming matches the provided parameters.
-        let Some(inner_extension_ty) = metadata.types().resolve(inner_type_id) else {
-            return Err(ExtrinsicParamsError::MissingTypeId(
-                inner_extension.to_owned(),
-                inner_type_id,
-            ));
-        };
-
-        let Some(inner_extension_name) = inner_extension_ty.path.segments.last() else {
-            return Err(ExtrinsicParamsError::ExpectedNamedTypeId(
-                inner_extension.to_owned(),
-                inner_type_id,
-            ));
-        };
-
-        if inner_extension_name != inner_extension {
-            return Err(ExtrinsicParamsError::ExpectedAnotherExtension(
-                inner_extension.to_owned(),
-                inner_extension_name.to_owned(),
-            ));
-        }
-
-        Ok(SkipCheckIfFeelessEncodingData {
-            metadata,
-            type_id: inner_type_id,
-        })
-    }
-}
-
-/// The [`SkipCheckIfFeeless`] signed extension.
-#[derive(Debug, DecodeAsType, EncodeAsType)]
-#[decode_as_type(trait_bounds = "S: DecodeAsType")]
-#[encode_as_type(trait_bounds = "S: EncodeAsType")]
-pub struct SkipCheckIfFeeless<T, S>
-where
-    T: Config,
-    S: SignedExtension<T> + DecodeAsType + EncodeAsType,
-{
-    inner: S,
-    // Dev note: This is `Option` because `#[derive(DecodeAsType)]` requires the
-    // `Default` bound on skipped parameters.
-    // This field is populated when the [`SkipCheckIfFeeless`] is constructed from
-    // [`ExtrinsicParams`] (ie, when subxt submits extrinsics). However, it is not
-    // populated when decoding signed extensions from the node.
-    #[decode_as_type(skip)]
-    #[encode_as_type(skip)]
-    encoding_data: Option<SkipCheckIfFeelessEncodingData>,
-    #[decode_as_type(skip)]
-    #[encode_as_type(skip)]
-    _phantom: PhantomData<T>,
-}
-
-impl<T, S> SkipCheckIfFeeless<T, S>
-where
-    T: Config,
-    S: SignedExtension<T> + DecodeAsType + EncodeAsType,
-{
-    /// The inner signed extension.
-    pub fn inner_signed_extension(&self) -> &S {
-        &self.inner
-    }
-}
-
-impl<T, S> ExtrinsicParams<T> for SkipCheckIfFeeless<T, S>
-where
-    T: Config,
-    S: SignedExtension<T> + DecodeAsType + EncodeAsType,
-    <S as ExtrinsicParams<T>>::OtherParams: Default,
-{
-    type OtherParams = SkipCheckIfFeelessParams<T, S>;
-    type Error = ExtrinsicParamsError;
-
-    fn new<Client: OfflineClientT<T>>(
-        nonce: u64,
-        client: Client,
-        other_params: Self::OtherParams,
-    ) -> Result<Self, Self::Error> {
-        let other_params = other_params.0.unwrap_or_default();
-
-        let metadata = client.metadata();
-        let encoding_data = SkipCheckIfFeelessEncodingData::new(metadata, Self::NAME, S::NAME)?;
-        let inner_extension = S::new(nonce, client, other_params).map_err(Into::into)?;
-
-        Ok(SkipCheckIfFeeless {
-            inner: inner_extension,
-            encoding_data: Some(encoding_data),
-            _phantom: PhantomData,
-        })
-    }
-}
-
-impl<T, S> ExtrinsicParamsEncoder for SkipCheckIfFeeless<T, S>
-where
-    T: Config,
-    S: SignedExtension<T> + DecodeAsType + EncodeAsType,
-{
-    fn encode_extra_to(&self, v: &mut Vec<u8>) {
-        if let Some(encoding_data) = &self.encoding_data {
-            let _ = self.inner.encode_as_type_to(
-                encoding_data.type_id,
-                encoding_data.metadata.types(),
-                v,
-            );
-        }
-    }
-}
-
-impl<T, S> SignedExtension<T> for SkipCheckIfFeeless<T, S>
-where
-    T: Config,
-    S: SignedExtension<T> + DecodeAsType + EncodeAsType,
-    <S as ExtrinsicParams<T>>::OtherParams: Default,
-{
-    const NAME: &'static str = "SkipCheckIfFeeless";
-    type Decoded = Self;
-}
-
-/// Parameters to configure the [`SkipCheckIfFeeless`] signed extension.
-pub struct SkipCheckIfFeelessParams<T, S>(Option<<S as ExtrinsicParams<T>>::OtherParams>)
-where
-    T: Config,
-    S: SignedExtension<T>;
-
-impl<T, S> std::fmt::Debug for SkipCheckIfFeelessParams<T, S>
-where
-    T: Config,
-    S: SignedExtension<T>,
-{
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("SkipCheckIfFeelessParams").finish()
-    }
-}
-
-impl<T: Config, S: SignedExtension<T>> Default for SkipCheckIfFeelessParams<T, S>
-where
-    T: Config,
-    S: SignedExtension<T>,
-{
-    fn default() -> Self {
-        SkipCheckIfFeelessParams(None)
-    }
-}
-
-impl<T, S> SkipCheckIfFeelessParams<T, S>
-where
-    T: Config,
-    S: SignedExtension<T>,
-{
-    /// Skip the check if the transaction is feeless.
-    pub fn from(extrinsic_params: <S as ExtrinsicParams<T>>::OtherParams) -> Self {
-        SkipCheckIfFeelessParams(Some(extrinsic_params))
+    fn matches(
+        _identifier: &str,
+        type_id: u32,
+        types: &PortableRegistry,
+    ) -> Result<bool, ExtrinsicParamsError> {
+        type_id_matches_ext_name(type_id, types, "ChargeTransactionPayment")
     }
 }
 
@@ -614,37 +452,45 @@ macro_rules! impl_tuples {
             $($ident: SignedExtension<T>,)+
         {
             type OtherParams = ($($ident::OtherParams,)+);
-            type Error = ExtrinsicParamsError;
 
             fn new<Client: OfflineClientT<T>>(
                 nonce: u64,
                 client: Client,
                 other_params: Self::OtherParams,
-            ) -> Result<Self, Self::Error> {
-                // First, push encoders to map as we are given them:
-                let mut map = HashMap::new();
-                $({
-                    let e: Box<dyn ExtrinsicParamsEncoder>
-                        = Box::new($ident::new(nonce, client.clone(), other_params.$index).map_err(Into::into)?);
-                    map.insert($ident::NAME, e);
-                })+
-
-                // Next, based on metadata, push to vec in the order the node needs:
-                let mut params = Vec::new();
+            ) -> Result<Self, ExtrinsicParamsError> {
                 let metadata = client.metadata();
                 let types = metadata.types();
-                for ext in metadata.extrinsic().signed_extensions() {
-                    if let Some(ext) = map.remove(ext.identifier()) {
-                        params.push(ext)
-                    } else {
-                        if is_type_empty(ext.extra_ty(), types) && is_type_empty(ext.additional_ty(), types) {
-                            // If we don't know about the signed extension, _but_ it appears to require zero bytes
-                            // to encode its extra and additional data, then we can safely ignore it as it makes
-                            // no difference either way.
-                            continue;
+
+                // For each signed extension in the tuple, find the matching index in the metadata, if
+                // there is one, and add it to a map with that index as the key.
+                let mut exts_by_index = HashMap::new();
+                $({
+                    for (idx, e) in metadata.extrinsic().signed_extensions().iter().enumerate() {
+                        // Skip over any exts that have a match already:
+                        if exts_by_index.contains_key(&idx) {
+                            continue
                         }
-                        return Err(ExtrinsicParamsError::UnknownSignedExtension(ext.identifier().to_owned()));
+                        // Break and record as soon as we find a match:
+                        if $ident::matches(e.identifier(), e.extra_ty(), types)? {
+                            let ext = $ident::new(nonce, client.clone(), other_params.$index)?;
+                            let boxed_ext: Box<dyn ExtrinsicParamsEncoder> = Box::new(ext);
+                            exts_by_index.insert(idx, boxed_ext);
+                            break
+                        }
                     }
+                })+
+
+                // Next, turn these into an ordered vec, erroring if we haven't matched on any exts yet.
+                let mut params = Vec::new();
+                for (idx, e) in metadata.extrinsic().signed_extensions().iter().enumerate() {
+                    let Some(ext) = exts_by_index.remove(&idx) else {
+                        if is_type_empty(e.extra_ty(), types) {
+                            continue
+                        } else {
+                            return Err(ExtrinsicParamsError::UnknownSignedExtension(e.identifier().to_owned()));
+                        }
+                    };
+                    params.push(ext);
                 }
 
                 Ok(AnyOf {
@@ -717,5 +563,41 @@ fn is_type_empty(type_id: u32, types: &scale_info::PortableRegistry) -> bool {
         | TypeDef::Sequence(_)
         | TypeDef::Compact(_)
         | TypeDef::Primitive(_) => false,
+    }
+}
+
+/// Resolve a type ID and check that its path equals the extension name provided.
+/// As an exception; if the name of the extension is the transparent "SkipCheckIfFeeless"
+/// signed extension, then we look at the inner type of that to determine whether it's a match.
+fn type_id_matches_ext_name(
+    type_id: u32,
+    types: &PortableRegistry,
+    ext_name: &'static str,
+) -> Result<bool, ExtrinsicParamsError> {
+    let Some(ty) = types.resolve(type_id) else {
+        return Err(ExtrinsicParamsError::MissingTypeId {
+            type_id,
+            context: ext_name,
+        });
+    };
+    let Some(name) = ty.path.segments.last() else {
+        return Ok(false);
+    };
+    if name == "SkipCheckIfFeeless" {
+        // SkipCheckIfFeeless is a transparent wrapper that can be applied around any signed extension.
+        // It should have 2 generic types: the inner signed extension and a phantom data type. Phantom data does
+        // not have a type associated, so we find the type that does to find the inner signed extension.
+        // If this doesn't pan out, don't error, just don't match.
+        let Some(inner_type_id) = ty
+            .type_params
+            .iter()
+            .find_map(|param| param.ty.map(|ty| ty.id))
+        else {
+            return Ok(false);
+        };
+
+        type_id_matches_ext_name(inner_type_id, types, ext_name)
+    } else {
+        Ok(name == ext_name)
     }
 }

--- a/subxt/src/config/signed_extensions.rs
+++ b/subxt/src/config/signed_extensions.rs
@@ -12,8 +12,8 @@ use crate::utils::Era;
 use crate::{client::OfflineClientT, Config};
 use codec::{Compact, Encode};
 use core::fmt::Debug;
+use derivative::Derivative;
 use scale_decode::DecodeAsType;
-use scale_encode::EncodeAsType;
 use scale_info::PortableRegistry;
 
 use std::collections::HashMap;
@@ -42,7 +42,6 @@ pub trait SignedExtension<T: Config>: ExtrinsicParams<T> {
 }
 
 /// The [`CheckSpecVersion`] signed extension.
-#[derive(Clone, Debug, EncodeAsType, DecodeAsType)]
 pub struct CheckSpecVersion(u32);
 
 impl<T: Config> ExtrinsicParams<T> for CheckSpecVersion {
@@ -75,7 +74,6 @@ impl<T: Config> SignedExtension<T> for CheckSpecVersion {
 }
 
 /// The [`CheckNonce`] signed extension.
-#[derive(Clone, Debug, EncodeAsType, DecodeAsType)]
 pub struct CheckNonce(Compact<u64>);
 
 impl<T: Config> ExtrinsicParams<T> for CheckNonce {
@@ -108,7 +106,6 @@ impl<T: Config> SignedExtension<T> for CheckNonce {
 }
 
 /// The [`CheckTxVersion`] signed extension.
-#[derive(Clone, Debug, EncodeAsType, DecodeAsType)]
 pub struct CheckTxVersion(u32);
 
 impl<T: Config> ExtrinsicParams<T> for CheckTxVersion {
@@ -141,16 +138,7 @@ impl<T: Config> SignedExtension<T> for CheckTxVersion {
 }
 
 /// The [`CheckGenesis`] signed extension.
-#[derive(Clone, EncodeAsType, DecodeAsType)]
-#[decode_as_type(trait_bounds = "T::Hash: DecodeAsType")]
-#[encode_as_type(trait_bounds = "T::Hash: EncodeAsType")]
 pub struct CheckGenesis<T: Config>(T::Hash);
-
-impl<T: Config> std::fmt::Debug for CheckGenesis<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("CheckGenesis").field(&self.0).finish()
-    }
-}
 
 impl<T: Config> ExtrinsicParams<T> for CheckGenesis<T> {
     type OtherParams = ();
@@ -182,16 +170,12 @@ impl<T: Config> SignedExtension<T> for CheckGenesis<T> {
 }
 
 /// The [`CheckMortality`] signed extension.
-#[derive(Clone, EncodeAsType, DecodeAsType)]
-#[decode_as_type(trait_bounds = "T::Hash: DecodeAsType")]
-#[encode_as_type(trait_bounds = "T::Hash: EncodeAsType")]
 pub struct CheckMortality<T: Config> {
     era: Era,
     checkpoint: T::Hash,
 }
 
 /// Parameters to configure the [`CheckMortality`] signed extension.
-#[derive(Clone, Debug)]
 pub struct CheckMortalityParams<T: Config> {
     era: Era,
     checkpoint: Option<T::Hash>,
@@ -223,15 +207,6 @@ impl<T: Config> CheckMortalityParams<T> {
             era: Era::Immortal,
             checkpoint: None,
         }
-    }
-}
-
-impl<T: Config> std::fmt::Debug for CheckMortality<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("CheckMortality")
-            .field("era", &self.era)
-            .field("checkpoint", &self.checkpoint)
-            .finish()
     }
 }
 
@@ -271,7 +246,8 @@ impl<T: Config> SignedExtension<T> for CheckMortality<T> {
 }
 
 /// The [`ChargeAssetTxPayment`] signed extension.
-#[derive(Clone, Debug, DecodeAsType)]
+#[derive(Derivative, DecodeAsType)]
+#[derivative(Clone(bound = "T::AssetId: Clone"), Debug(bound = "T::AssetId: Debug"))]
 #[decode_as_type(trait_bounds = "T::AssetId: DecodeAsType")]
 pub struct ChargeAssetTxPayment<T: Config> {
     tip: Compact<u128>,
@@ -291,20 +267,9 @@ impl<T: Config> ChargeAssetTxPayment<T> {
 }
 
 /// Parameters to configure the [`ChargeAssetTxPayment`] signed extension.
-#[derive(Debug)]
 pub struct ChargeAssetTxPaymentParams<T: Config> {
     tip: u128,
     asset_id: Option<T::AssetId>,
-}
-
-// Dev note: `#[derive(Clone)]` implies `T: Clone` instead of `T::AssetId: Clone`.
-impl<T: Config> Clone for ChargeAssetTxPaymentParams<T> {
-    fn clone(&self) -> Self {
-        Self {
-            tip: self.tip,
-            asset_id: self.asset_id.clone(),
-        }
-    }
 }
 
 impl<T: Config> Default for ChargeAssetTxPaymentParams<T> {

--- a/subxt/src/tx/tx_client.rs
+++ b/subxt/src/tx/tx_client.rs
@@ -124,8 +124,7 @@ impl<T: Config, C: OfflineClientT<T>> TxClient<T, C> {
             account_nonce,
             self.client.clone(),
             other_params,
-        )
-        .map_err(Into::into)?;
+        )?;
 
         // Return these details, ready to construct a signed extrinsic from.
         Ok(PartialExtrinsic {

--- a/testing/integration-tests/src/full_client/blocks/mod.rs
+++ b/testing/integration-tests/src/full_client/blocks/mod.rs
@@ -277,9 +277,9 @@ async fn decode_signed_extensions_from_blocks() {
     let transaction1 = submit_transfer_extrinsic_and_get_it_back!(1234);
     let extensions1 = transaction1.signed_extensions().unwrap();
 
-    let nonce1 = extensions1.nonce().unwrap().unwrap();
+    let nonce1 = extensions1.nonce().unwrap();
     let nonce1_static = extensions1.find::<CheckNonce>().unwrap().unwrap();
-    let tip1 = extensions1.tip().unwrap().unwrap();
+    let tip1 = extensions1.tip().unwrap();
     let tip1_static: u128 = extensions1
         .find::<ChargeAssetTxPayment<SubstrateConfig>>()
         .unwrap()

--- a/testing/integration-tests/src/full_client/blocks/mod.rs
+++ b/testing/integration-tests/src/full_client/blocks/mod.rs
@@ -5,9 +5,7 @@
 use crate::{test_context, utils::node_runtime};
 use codec::{Compact, Encode};
 use futures::StreamExt;
-use subxt::config::signed_extensions::{
-    ChargeAssetTxPayment, CheckMortality, CheckNonce,
-};
+use subxt::config::signed_extensions::{ChargeAssetTxPayment, CheckMortality, CheckNonce};
 use subxt::config::DefaultExtrinsicParamsBuilder;
 use subxt::config::SubstrateConfig;
 use subxt::utils::Era;
@@ -279,9 +277,9 @@ async fn decode_signed_extensions_from_blocks() {
     let transaction1 = submit_transfer_extrinsic_and_get_it_back!(1234);
     let extensions1 = transaction1.signed_extensions().unwrap();
 
-    let nonce1 = extensions1.nonce().unwrap();
+    let nonce1 = extensions1.nonce().unwrap().unwrap();
     let nonce1_static = extensions1.find::<CheckNonce>().unwrap().unwrap();
-    let tip1 = extensions1.tip().unwrap();
+    let tip1 = extensions1.tip().unwrap().unwrap();
     let tip1_static: u128 = extensions1
         .find::<ChargeAssetTxPayment<SubstrateConfig>>()
         .unwrap()
@@ -316,7 +314,7 @@ async fn decode_signed_extensions_from_blocks() {
         "CheckMortality",
         "CheckNonce",
         "CheckWeight",
-        "SkipCheckIfFeeless",
+        "ChargeAssetTxPayment",
     ];
 
     assert_eq!(extensions1.iter().count(), expected_signed_extensions.len());

--- a/testing/integration-tests/src/full_client/blocks/mod.rs
+++ b/testing/integration-tests/src/full_client/blocks/mod.rs
@@ -6,7 +6,7 @@ use crate::{test_context, utils::node_runtime};
 use codec::{Compact, Encode};
 use futures::StreamExt;
 use subxt::config::signed_extensions::{
-    ChargeAssetTxPayment, CheckMortality, CheckNonce, SkipCheckIfFeeless,
+    ChargeAssetTxPayment, CheckMortality, CheckNonce,
 };
 use subxt::config::DefaultExtrinsicParamsBuilder;
 use subxt::config::SubstrateConfig;
@@ -280,25 +280,23 @@ async fn decode_signed_extensions_from_blocks() {
     let extensions1 = transaction1.signed_extensions().unwrap();
 
     let nonce1 = extensions1.nonce().unwrap();
-    let nonce1_static = extensions1.find::<CheckNonce>().unwrap().unwrap().0;
+    let nonce1_static = extensions1.find::<CheckNonce>().unwrap().unwrap();
     let tip1 = extensions1.tip().unwrap();
     let tip1_static: u128 = extensions1
-        .find::<SkipCheckIfFeeless<SubstrateConfig, ChargeAssetTxPayment<SubstrateConfig>>>()
+        .find::<ChargeAssetTxPayment<SubstrateConfig>>()
         .unwrap()
         .unwrap()
-        .inner_signed_extension()
         .tip();
 
     let transaction2 = submit_transfer_extrinsic_and_get_it_back!(5678);
     let extensions2 = transaction2.signed_extensions().unwrap();
     let nonce2 = extensions2.nonce().unwrap();
-    let nonce2_static = extensions2.find::<CheckNonce>().unwrap().unwrap().0;
+    let nonce2_static = extensions2.find::<CheckNonce>().unwrap().unwrap();
     let tip2 = extensions2.tip().unwrap();
     let tip2_static: u128 = extensions2
-        .find::<SkipCheckIfFeeless<SubstrateConfig, ChargeAssetTxPayment<SubstrateConfig>>>()
+        .find::<ChargeAssetTxPayment<SubstrateConfig>>()
         .unwrap()
         .unwrap()
-        .inner_signed_extension()
         .tip();
 
     assert_eq!(nonce1, 0);


### PR DESCRIPTION
Closes #1280.

- `SkipCheckIfFeeless` is now transparent to the outside world in the latest polkadot-sdk, so remove logic specific to that.
- But, remove `SignedExtension::IDENTIFIER` and replace with `SignedExtension::matches(..)` function which is able to do much more custom/intelligent matching to work out which of our signed extensions to use at which point (in part, just in case we have more complex things to do later, and in part just to provide the flexibility now for anybody that wants it).
- Tidy some bounds (Debug/Clone only for the signed exts the user might handle ie the ones that are Decode targets) and no need for `EncodeAsType`/`DecodeAsType` on most of the exts now.
- Just return `ExtrinsicParamsError` rather than `type Error: Into<ExtrinsicParamsError>`.