### PR TITLE
lightclient: Fix wasm socket closure called after being dropped

### DIFF
--- a/lightclient/src/platform/wasm_socket.rs
+++ b/lightclient/src/platform/wasm_socket.rs
@@ -230,7 +230,7 @@ impl Drop for WasmSocket {
     fn drop(&mut self) {
         let inner = self.inner.lock().expect("Mutex is poised; qed");
 
-        if inner.state == ConnectionState::Opened {
+        if inner.state == ConnectionState::Opened || inner.state == ConnectionState::Connecting {
             let _ = self.socket.close();
         }
     }

--- a/lightclient/src/platform/wasm_socket.rs
+++ b/lightclient/src/platform/wasm_socket.rs
@@ -242,9 +242,7 @@ impl AsyncWrite for WasmSocket {
 
 impl Drop for WasmSocket {
     fn drop(&mut self) {
-        if self.socket.ready_state() == web_sys::WebSocket::OPEN
-            || self.socket.ready_state() == web_sys::WebSocket::CONNECTING
-        {
+        if self.socket.ready_state() != web_sys::WebSocket::CLOSING {
             let _ = self.socket.close();
         }
 

--- a/lightclient/src/platform/wasm_socket.rs
+++ b/lightclient/src/platform/wasm_socket.rs
@@ -171,6 +171,10 @@ impl AsyncRead for WasmSocket {
         let mut inner = self.inner.lock().expect("Mutex is poised; qed");
         inner.waker = Some(cx.waker().clone());
 
+        if self.socket.ready_state() == web_sys::WebSocket::Connecting {
+            return Poll::Pending;
+        }
+
         match inner.state {
             ConnectionState::Error => {
                 Poll::Ready(Err(io::Error::new(io::ErrorKind::Other, "Socket error")))

--- a/lightclient/src/platform/wasm_socket.rs
+++ b/lightclient/src/platform/wasm_socket.rs
@@ -253,9 +253,7 @@ impl AsyncWrite for WasmSocket {
 
 impl Drop for WasmSocket {
     fn drop(&mut self) {
-        let inner = self.inner.lock().expect("Mutex is poised; qed");
-
-        if inner.state == ConnectionState::Opened || inner.state == ConnectionState::Connecting {
+        if self.socket.ready_state() == web_sys::WebSocket::OPEN {
             let _ = self.socket.close();
         }
     }

--- a/lightclient/src/platform/wasm_socket.rs
+++ b/lightclient/src/platform/wasm_socket.rs
@@ -55,15 +55,8 @@ struct InnerWasmSocket {
     state: ConnectionState,
     /// Data buffer for the socket.
     data: VecDeque<u8>,
-
-    /// Waker from `poll_read` when the socket is not connected yet.
-    open_waker: Option<Waker>,
-    /// Waker from `poll_read`.
-    read_waker: Option<Waker>,
-    /// Waker from `poll_write` and `poll_flush`.
-    write_waker: Option<Waker>,
-    /// Waker from `poll_close`.
-    close_waker: Option<Waker>,
+    /// Waker from `poll_read` / `poll_write`.
+    waker: Option<Waker>,
 }
 
 /// Registered callbacks of the [`WasmSocket`].
@@ -93,10 +86,7 @@ impl WasmSocket {
         let inner = Arc::new(Mutex::new(InnerWasmSocket {
             state: ConnectionState::Connecting,
             data: VecDeque::with_capacity(16384),
-            open_waker: None,
-            read_waker: None,
-            write_waker: None,
-            close_waker: None,
+            waker: None,
         }));
 
         let open_callback = Closure::once_into_js({
@@ -105,7 +95,7 @@ impl WasmSocket {
                 let mut inner = inner.lock().expect("Mutex is poised; qed");
                 inner.state = ConnectionState::Opened;
 
-                if let Some(waker) = inner.open_waker.take() {
+                if let Some(waker) = inner.waker.take() {
                     waker.wake();
                 }
             }
@@ -123,7 +113,7 @@ impl WasmSocket {
                 let bytes = js_sys::Uint8Array::new(&buffer).to_vec();
                 inner.data.extend(bytes.into_iter());
 
-                if let Some(waker) = inner.read_waker.take() {
+                if let Some(waker) = inner.waker.take() {
                     waker.wake();
                 }
             }
@@ -136,6 +126,10 @@ impl WasmSocket {
                 // Callback does not provide useful information, signal it back to the stream.
                 let mut inner = inner.lock().expect("Mutex is poised; qed");
                 inner.state = ConnectionState::Error;
+
+                if let Some(waker) = inner.waker.take() {
+                    waker.wake();
+                }
             }
         });
         socket.set_onerror(Some(error_callback.as_ref().unchecked_ref()));
@@ -146,7 +140,7 @@ impl WasmSocket {
                 let mut inner = inner.lock().expect("Mutex is poised; qed");
                 inner.state = ConnectionState::Closed;
 
-                if let Some(waker) = inner.close_waker.take() {
+                if let Some(waker) = inner.waker.take() {
                     waker.wake();
                 }
             }
@@ -175,17 +169,8 @@ impl AsyncRead for WasmSocket {
         buf: &mut [u8],
     ) -> Poll<Result<usize, io::Error>> {
         let mut inner = self.inner.lock().expect("Mutex is poised; qed");
+        inner.waker = Some(cx.waker().clone());
 
-        // Check if the socket is ready for reading.
-        let state = self.socket.ready_state();
-        if state == web_sys::WebSocket::CLOSED || state == web_sys::WebSocket::CLOSING {
-            return Poll::Ready(Err(io::ErrorKind::BrokenPipe.into()));
-        } else if state == web_sys::WebSocket::CONNECTING {
-            inner.open_waker = Some(cx.waker().clone());
-            return Poll::Pending;
-        }
-
-        inner.read_waker = Some(cx.waker().clone());
         match inner.state {
             ConnectionState::Error => {
                 Poll::Ready(Err(io::Error::new(io::ErrorKind::Other, "Socket error")))
@@ -214,7 +199,7 @@ impl AsyncWrite for WasmSocket {
         buf: &[u8],
     ) -> Poll<Result<usize, io::Error>> {
         let mut inner = self.inner.lock().expect("Mutex is poised; qed");
-        inner.write_waker = Some(cx.waker().clone());
+        inner.waker = Some(cx.waker().clone());
 
         match inner.state {
             ConnectionState::Error => {
@@ -236,18 +221,8 @@ impl AsyncWrite for WasmSocket {
         Poll::Ready(Ok(()))
     }
 
-    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
-        if self.socket.ready_state() == web_sys::WebSocket::CLOSED {
-            return Poll::Ready(Ok(()));
-        }
-
-        if self.socket.ready_state() != web_sys::WebSocket::CLOSING {
-            let _ = self.socket.close();
-        }
-
-        let mut inner = self.inner.lock().expect("Mutex is poised; qed");
-        inner.close_waker = Some(cx.waker().clone());
-        Poll::Pending
+    fn poll_close(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        Poll::Ready(Ok(()))
     }
 }
 

--- a/testing/wasm-lightclient-tests/tests/wasm.rs
+++ b/testing/wasm-lightclient-tests/tests/wasm.rs
@@ -32,6 +32,8 @@ wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 #[wasm_bindgen_test]
 async fn light_client_works() {
+    console_error_panic_hook::set_once();
+
     let api: LightClient<PolkadotConfig> = LightClientBuilder::new()
         .build_from_url("wss://rpc.polkadot.io:443")
         .await


### PR DESCRIPTION
The errors reported by the wasm related to `Error closure invoked recursively or destroyed already` could happen whenever a `Closure` object is used after being dropped.

This PR makes the assumption that the JS realm socket created by `web_sys::WebSocket` is able to access the references of the registered `Closure` callbacks, even after the Rust object has been dropped due to the socket not being closed properly.

https://github.com/paritytech/subxt/blob/f3eb4cdf350eb1f83b5ec478be93321631adad9a/lightclient/src/platform/wasm_socket.rs#L103


This PR makes the following adjustments to fix and improve the code:
- The main fix is to use `Closure::once_into_js` for closures that can are called only once
  - This primitive will deallocate the memory of the closure after the call happens (eg. on_close, on_error, on_open callbacks are called once (https://developer.mozilla.org/en-US/docs/Web/API/WebSocket#events)
  - The on_close and on_open are evident, however for the on_error the documentation implies it is called only once
  > [error](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/error_event)
    Fired when a connection with a WebSocket has been closed because of an error, such as when some data couldn't be sent. Also available via the onerror property.

- poll_read verifies if the connected is not opened yet, then it saves the waker and returns `Poll::Pending`
- poll_close now closes the socket
- Socket is closed from `Drop` only if its internal state is open

Closes: https://github.com/paritytech/subxt/issues/1288
