### PR TITLE
workflow: Fix building substate

### DIFF
--- a/.github/workflows/build-substrate.yml
+++ b/.github/workflows/build-substrate.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Install WASM toolchain
         run: rustup target add wasm32-unknown-unknown
 
+      - name: Install WASM toolchain
+        run: rustup component add rust-src
+
       - name: Rust Cache
         uses: Swatinem/rust-cache@3cf7f8cc28d1b4e7d01e3783be10a97d55d483c8 # v2.7.1
 


### PR DESCRIPTION
This Installs the required `rustup` component for building substrate.

The latest workflows were failing with the following error:

```bash
Error: failed to run custom build command for `kitchensink-runtime v3.0.0-dev (/home/runner/work/subxt/subxt/substrate/bin/node/runtime)`
Caused by:
  process didn't exit successfully: `/home/runner/work/subxt/subxt/target/release/build/kitchensink-runtime-61e4944c4d68a9c3/build-script-build` (exit status: 1)
  --- stderr
  Cannot compile the WASM runtime: no standard library sources found!
  You can install them with `rustup component add rust-src` if you're using `rustup`.
```