### PR TITLE
storage: Fix partial key storage iteration 

### DIFF
--- a/subxt/src/storage/storage_address.rs
+++ b/subxt/src/storage/storage_address.rs
@@ -172,6 +172,12 @@ where
                     .resolve(*key_ty)
                     .ok_or(MetadataError::TypeNotFound(*key_ty))?;
 
+                // If the provided keys are empty, the storage address must be
+                // equal to the storage root address.
+                if self.storage_entry_keys.is_empty() {
+                    return Ok(());
+                }
+
                 // If the key is a tuple, we encode each value to the corresponding tuple type.
                 // If the key is not a tuple, encode a single value to the key type.
                 let type_ids = match &ty.type_def {

--- a/subxt/src/storage/storage_address.rs
+++ b/subxt/src/storage/storage_address.rs
@@ -190,7 +190,7 @@ where
                     }
                     hash_bytes(&input, &hashers[0], bytes);
                     Ok(())
-                } else if hashers.len() == type_ids.len() {
+                } else if hashers.len() >= type_ids.len() {
                     let iter = self.storage_entry_keys.iter().zip(type_ids).zip(hashers);
                     // A hasher per field; encode and hash each field independently.
                     for ((key, type_id), hasher) in iter {
@@ -200,7 +200,7 @@ where
                     }
                     Ok(())
                 } else {
-                    // Mismatch; wrong number of hashers/fields.
+                    // Provided more fields than hashers.
                     Err(StorageAddressError::WrongNumberOfHashers {
                         hashers: hashers.len(),
                         fields: type_ids.len(),

--- a/subxt/src/storage/storage_address.rs
+++ b/subxt/src/storage/storage_address.rs
@@ -181,6 +181,15 @@ where
                     _other => either::Either::Right(std::iter::once(*key_ty)),
                 };
 
+                if type_ids.len() < self.storage_entry_keys.len() {
+                    // Provided more keys than fields.
+                    return Err(StorageAddressError::WrongNumberOfKeys {
+                        expected: type_ids.len(),
+                        actual: self.storage_entry_keys.len(),
+                    }
+                    .into());
+                }
+
                 if hashers.len() == 1 {
                     // One hasher; hash a tuple of all SCALE encoded bytes with the one hash function.
                     let mut input = Vec::new();

--- a/subxt/src/storage/storage_address.rs
+++ b/subxt/src/storage/storage_address.rs
@@ -181,14 +181,6 @@ where
                     _other => either::Either::Right(std::iter::once(*key_ty)),
                 };
 
-                if type_ids.len() != self.storage_entry_keys.len() {
-                    return Err(StorageAddressError::WrongNumberOfKeys {
-                        expected: type_ids.len(),
-                        actual: self.storage_entry_keys.len(),
-                    }
-                    .into());
-                }
-
                 if hashers.len() == 1 {
                     // One hasher; hash a tuple of all SCALE encoded bytes with the one hash function.
                     let mut input = Vec::new();

--- a/subxt/src/storage/storage_type.rs
+++ b/subxt/src/storage/storage_type.rs
@@ -228,12 +228,12 @@ where
             // in the iterator.
             let return_type_id = return_type_from_storage_entry_type(entry.entry_type());
 
-            // The root pallet/entry bytes for this storage entry:
-            let address_root_bytes = super::utils::storage_address_bytes(&address, &metadata)?;
+            // The address bytes of this entry:
+            let address_bytes = super::utils::storage_address_bytes(&address, &metadata)?;
 
             let s = client
                 .backend()
-                .storage_fetch_descendant_values(address_root_bytes, block_ref.hash())
+                .storage_fetch_descendant_values(address_bytes, block_ref.hash())
                 .await?
                 .map(move |kv| {
                     let kv = match kv {

--- a/subxt/src/storage/storage_type.rs
+++ b/subxt/src/storage/storage_type.rs
@@ -229,7 +229,7 @@ where
             let return_type_id = return_type_from_storage_entry_type(entry.entry_type());
 
             // The root pallet/entry bytes for this storage entry:
-            let address_root_bytes = super::utils::storage_address_root_bytes(&address);
+            let address_root_bytes = super::utils::storage_address_bytes(&address, &metadata)?;
 
             let s = client
                 .backend()

--- a/testing/integration-tests/src/full_client/client/mod.rs
+++ b/testing/integration-tests/src/full_client/client/mod.rs
@@ -45,6 +45,9 @@ async fn storage_iter() {
     let api = ctx.client();
 
     let addr = node_runtime::storage().system().account_iter();
+    let addr_bytes = api.storage().address_bytes(&addr).unwrap();
+    assert_eq!(addr_bytes, addr.to_root_bytes());
+
     let len = api
         .storage()
         .at_latest()


### PR DESCRIPTION
This PR fixes the partial key storage iteration.

The storage key constructed by partial inputs was converted to the root storage key entry.
This meant that any partial input parameters provided to the key were completely ignored; and resulted in a wrongful behavior of iterating over all storage entries, rather than just the ones starting with the partial key.

To mitigate this behavior, the address bytes take into account the provided parameter inputs.
This loosens the expectations of `utils::storage_address_bytes`, which now only returns errors if the provided input types exceed the number of types from the metadata. Before this PR, the function expected an identical match in terms of the number of inputs.


### Testing Done

- Manual testing with the metadata from "wss://rpc.relay.blockchain.enjin.io:443"
- Added an unit test that creates two assets, and checks that partial iterations result in the expected number of items


Closes: https://github.com/paritytech/subxt/issues/1251
