### PR TITLE
CI: Add timeouts to test jobs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -246,7 +246,7 @@ jobs:
     wasm_tests:
         name: Test (WASM)
         runs-on: ubuntu-latest
-        timeout-minutes: 25
+        timeout-minutes: 45
         env:
             # Set timeout for wasm tests to be much bigger than the default 20 secs.
             WASM_BINDGEN_TEST_TIMEOUT: 300

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -219,7 +219,7 @@ jobs:
     light_client_tests:
         name: "Test (Light Client)"
         runs-on: ubuntu-latest-16-cores
-        timeout-minutes: 25
+        timeout-minutes: 45
         steps:
             - name: Checkout sources
               uses: actions/checkout@v4

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -159,7 +159,7 @@ jobs:
     tests:
         name: "Test (Native)"
         runs-on: ubuntu-latest-16-cores
-        timeout-minutes: 25
+        timeout-minutes: 45
         steps:
             - name: Checkout sources
               uses: actions/checkout@v4
@@ -189,7 +189,7 @@ jobs:
     unstable_backend_tests:
         name: "Test (Unstable Backend)"
         runs-on: ubuntu-latest-16-cores
-        timeout-minutes: 25
+        timeout-minutes: 45
         steps:
             - name: Checkout sources
               uses: actions/checkout@v4

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -159,6 +159,7 @@ jobs:
     tests:
         name: "Test (Native)"
         runs-on: ubuntu-latest-16-cores
+        timeout-minutes: 25
         steps:
             - name: Checkout sources
               uses: actions/checkout@v4
@@ -188,6 +189,7 @@ jobs:
     unstable_backend_tests:
         name: "Test (Unstable Backend)"
         runs-on: ubuntu-latest-16-cores
+        timeout-minutes: 25
         steps:
             - name: Checkout sources
               uses: actions/checkout@v4
@@ -244,6 +246,7 @@ jobs:
     wasm_tests:
         name: Test (WASM)
         runs-on: ubuntu-latest
+        timeout-minutes: 25
         env:
             # Set timeout for wasm tests to be much bigger than the default 20 secs.
             WASM_BINDGEN_TEST_TIMEOUT: 300


### PR DESCRIPTION
This pr add timeouts to the test jobs to limit GHA minutes wasteful utilisation. As we can see from this report https://github.com/paritytech/ci_cd/issues/553#issuecomment-1868812436 `subxt` managed to beat "all time record" in paid GHA minutes consumption last month.