### PR TITLE
backend(fix): Remove only finalized blocks from the event window

### DIFF
--- a/subxt/src/backend/unstable/follow_stream_driver.rs
+++ b/subxt/src/backend/unstable/follow_stream_driver.rs
@@ -274,8 +274,12 @@ impl<Hash: BlockHash> Shared<Hash> {
                     }
                 }
 
-                // The blocks reported by the finalized event should not be reported again
-                // by the initialized event. The pruned blocks are not of interest.
+                // The last finalized block will be reported as Initialized by our driver,
+                // therefore there is no need to report NewBlock and BestBlock events for it.
+                // If the Finalized event reported multiple finalized hashes, we only care about
+                // the state at the head of the chain, therefore it is correct to remove those as well.
+                // Idem for the pruned hashes; they will never be reported again and we remove
+                // them from the window of events.
                 let to_remove: HashSet<Hash> = finalized_ev
                     .finalized_block_hashes
                     .iter()


### PR DESCRIPTION
This PR ensures that the window of events we feed to every new subscription contains the appropriate `NewBlock` and `BestBlock` events.

Before this PR, the `block_events_from_last_finalized` window of events was cleared out on every `Finalized` event.
However, this approach could miss reporting `NewBlocks` that will later become `Finalized`. Therefore, the unstable driver could report a block as `Finalized` and never report it as `NewBlock` first.

Considering the following edge case:

```bash

      0x1 -----> 0x2 -----> 0x3 -----> 0x4

T0    init       new         new       new
T1               fin                 
```

- T0: The chainHead subscription is started, 0x1 0x2 0x3 0x4 are announced
  - 0x1 is the `Initialized` event
  - `block_events_from_last_finalized` contains: 0x2 0x3 0x4 as `NewBlocks`
- T1: 0x2 is reported as `Finalized` 
  - Before this PR the `block_events_from_last_finalized` is cleared our entirely

If a new subscription is started after T1; it will receive an `Initialized` event with the 0x2 block. However, it will never receive `0x3` and `0x4` as `NewBlocks`.  After around 6 seconds, the `0x3` is reported in a `Finalized` event. This breaks the expectations of the rpc-v2 spec.

To mitigate this behavior, the window of events is not entirely cleaned out. Instead, only blocks reported as `Finalized` or pruned are removed from the window.
The last finalized block will be reported as `Initialized` by our driver, therefore there is no need to report `NewBlock` and `BestBlock` events for it.  If the `Finalized` event reported multiple finalized hashes, we only care about the state at the head of the chain, therefore it is correct to remove those as well. Idem for the pruned hashes; they will never be reported again and we remove them from the window of events.


### Testing Done
- This has been discovered by https://github.com/paritytech/subxt/pull/1318
- For more details see [this comment](https://github.com/paritytech/subxt/pull/1318#issuecomment-1884792300)
- The `decode_signed_extensions_from_blocks` with the `panic` patch is passing after this PR
- Added an unit test to ensure we don't clear out events of interest

