### PR TITLE
fix: don't unpin blocks that may show up again

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -159,7 +159,7 @@ jobs:
     tests:
         name: "Test (Native)"
         runs-on: ubuntu-latest-16-cores
-        timeout-minutes: 45
+        timeout-minutes: 30
         steps:
             - name: Checkout sources
               uses: actions/checkout@v4
@@ -189,7 +189,7 @@ jobs:
     unstable_backend_tests:
         name: "Test (Unstable Backend)"
         runs-on: ubuntu-latest-16-cores
-        timeout-minutes: 45
+        timeout-minutes: 30
         steps:
             - name: Checkout sources
               uses: actions/checkout@v4
@@ -219,7 +219,7 @@ jobs:
     light_client_tests:
         name: "Test (Light Client)"
         runs-on: ubuntu-latest-16-cores
-        timeout-minutes: 45
+        timeout-minutes: 30
         steps:
             - name: Checkout sources
               uses: actions/checkout@v4
@@ -246,7 +246,7 @@ jobs:
     wasm_tests:
         name: Test (WASM)
         runs-on: ubuntu-latest
-        timeout-minutes: 45
+        timeout-minutes: 30
         env:
             # Set timeout for wasm tests to be much bigger than the default 20 secs.
             WASM_BINDGEN_TEST_TIMEOUT: 300

--- a/subxt/src/backend/unstable/follow_stream.rs
+++ b/subxt/src/backend/unstable/follow_stream.rs
@@ -249,9 +249,9 @@ pub(super) mod test_utils {
     }
 
     /// A new block event
-    pub fn ev_new_block(parent: u64, n: u64) -> FollowEvent<H256> {
+    pub fn ev_new_block(parent_n: u64, n: u64) -> FollowEvent<H256> {
         FollowEvent::NewBlock(NewBlock {
-            parent_block_hash: H256::from_low_u64_le(parent),
+            parent_block_hash: H256::from_low_u64_le(parent_n),
             block_hash: H256::from_low_u64_le(n),
             new_runtime: None,
         })
@@ -266,12 +266,15 @@ pub(super) mod test_utils {
 
     /// A finalized event
     pub fn ev_finalized(
-        ns: impl IntoIterator<Item = u64>,
-        pruned: impl IntoIterator<Item = u64>,
+        finalized_ns: impl IntoIterator<Item = u64>,
+        pruned_ns: impl IntoIterator<Item = u64>,
     ) -> FollowEvent<H256> {
         FollowEvent::Finalized(Finalized {
-            finalized_block_hashes: ns.into_iter().map(H256::from_low_u64_le).collect(),
-            pruned_block_hashes: pruned.into_iter().map(H256::from_low_u64_le).collect(),
+            finalized_block_hashes: finalized_ns
+                .into_iter()
+                .map(H256::from_low_u64_le)
+                .collect(),
+            pruned_block_hashes: pruned_ns.into_iter().map(H256::from_low_u64_le).collect(),
         })
     }
 }

--- a/subxt/src/backend/unstable/follow_stream.rs
+++ b/subxt/src/backend/unstable/follow_stream.rs
@@ -265,10 +265,13 @@ pub(super) mod test_utils {
     }
 
     /// A finalized event
-    pub fn ev_finalized(ns: impl IntoIterator<Item = u64>) -> FollowEvent<H256> {
+    pub fn ev_finalized(
+        ns: impl IntoIterator<Item = u64>,
+        pruned: impl IntoIterator<Item = u64>,
+    ) -> FollowEvent<H256> {
         FollowEvent::Finalized(Finalized {
             finalized_block_hashes: ns.into_iter().map(H256::from_low_u64_le).collect(),
-            pruned_block_hashes: vec![],
+            pruned_block_hashes: pruned.into_iter().map(H256::from_low_u64_le).collect(),
         })
     }
 }

--- a/subxt/src/backend/unstable/follow_stream_driver.rs
+++ b/subxt/src/backend/unstable/follow_stream_driver.rs
@@ -424,7 +424,7 @@ mod test {
                     Ok(ev_initialized(0)),
                     Ok(ev_new_block(0, 1)),
                     Ok(ev_best_block(1)),
-                    Ok(ev_finalized([1])),
+                    Ok(ev_finalized([1], [])),
                     Err(Error::Other("ended".to_owned())),
                 ]
             },
@@ -465,7 +465,7 @@ mod test {
                     Ok(ev_initialized(0)),
                     Ok(ev_new_block(0, 1)),
                     Ok(ev_best_block(1)),
-                    Ok(ev_finalized([1])),
+                    Ok(ev_finalized([1], [])),
                     Ok(ev_new_block(1, 2)),
                     Ok(ev_new_block(2, 3)),
                     Err(Error::Other("ended".to_owned())),
@@ -517,7 +517,7 @@ mod test {
                     Ok(ev_best_block(1)),
                     Ok(ev_new_block(1, 2)),
                     Ok(ev_new_block(2, 3)),
-                    Ok(ev_finalized([1])),
+                    Ok(ev_finalized([1], [])),
                     Err(Error::Other("ended".to_owned())),
                 ]
             },

--- a/subxt/src/backend/unstable/follow_stream_unpin.rs
+++ b/subxt/src/backend/unstable/follow_stream_unpin.rs
@@ -315,7 +315,7 @@ impl<Hash: BlockHash> FollowStreamUnpin<Hash> {
         entry.block_ref.clone()
     }
 
-    /// Unpin any blocks that are either too old, or have the unpin flag set and are in the list of pruned hashes.
+    /// Unpin any blocks that are either too old, or have the unpin flag set and are old enough.
     fn unpin_blocks(&mut self, waker: &Waker) {
         let unpin_flags = std::mem::take(&mut *self.unpin_flags.lock().unwrap());
         let rel_block_num = self.rel_block_num;

--- a/subxt/src/backend/unstable/follow_stream_unpin.rs
+++ b/subxt/src/backend/unstable/follow_stream_unpin.rs
@@ -159,7 +159,7 @@ impl<Hash: BlockHash> Stream for FollowStreamUnpin<Hash> {
                             // but if they don't, we just increment the num from the last finalized block
                             // we saw, which should be accurate.
                             //
-                            // `pin_final_block_at` indicates that the block will not show up in future events
+                            // `pin_unpinnable_block_at` indicates that the block will not show up in future events
                             // (They will show up as a parent block, but we don't care about that right now).
                             let rel_block_num = this.rel_block_num + idx + 1;
                             this.pin_unpinnable_block_at(rel_block_num, hash)
@@ -176,7 +176,7 @@ impl<Hash: BlockHash> Stream for FollowStreamUnpin<Hash> {
                         .map(|hash| {
                             // We should know about these, too, and if not we set their age to last_finalized + 1.
                             //
-                            // `pin_final_block_at` indicates that the block will not show up in future events.
+                            // `pin_unpinnable_block_at` indicates that the block will not show up in future events.
                             let rel_block_num = this.rel_block_num + 1;
                             this.pin_unpinnable_block_at(rel_block_num, hash)
                         })
@@ -303,8 +303,8 @@ impl<Hash: BlockHash> FollowStreamUnpin<Hash> {
             .pinned
             .entry(hash)
             // If there's already an entry, then clear any unpin_flags and update the
-            // pruned status (a pruned block can never become unpruned again, but vice versa
-            // is possible).
+            // can_be_unpinned status (this can become true but cannot become false again
+            // once true).
             .and_modify(|entry| {
                 entry.can_be_unpinned = entry.can_be_unpinned || can_be_unpinned;
                 self.unpin_flags.lock().unwrap().remove(&hash);

--- a/subxt/src/backend/unstable/follow_stream_unpin.rs
+++ b/subxt/src/backend/unstable/follow_stream_unpin.rs
@@ -109,7 +109,8 @@ impl<Hash: BlockHash> Stream for FollowStreamUnpin<Hash> {
                 FollowStreamMsg::Event(FollowEvent::Initialized(details)) => {
                     // The first finalized block gets the starting block_num.
                     let rel_block_num = this.rel_block_num;
-                    let block_ref = this.pin_block_at(rel_block_num, details.finalized_block_hash);
+                    let block_ref =
+                        this.pin_block_at(rel_block_num, details.finalized_block_hash, false);
 
                     FollowStreamMsg::Event(FollowEvent::Initialized(Initialized {
                         finalized_block_hash: block_ref,
@@ -126,9 +127,10 @@ impl<Hash: BlockHash> Stream for FollowStreamUnpin<Hash> {
                         .map(|p| p.rel_block_num)
                         .unwrap_or(this.rel_block_num);
 
-                    let block_ref = this.pin_block_at(parent_rel_block_num + 1, details.block_hash);
+                    let block_ref =
+                        this.pin_block_at(parent_rel_block_num + 1, details.block_hash, false);
                     let parent_block_ref =
-                        this.pin_block_at(parent_rel_block_num, details.parent_block_hash);
+                        this.pin_block_at(parent_rel_block_num, details.parent_block_hash, false);
 
                     FollowStreamMsg::Event(FollowEvent::NewBlock(NewBlock {
                         block_hash: block_ref,
@@ -140,7 +142,8 @@ impl<Hash: BlockHash> Stream for FollowStreamUnpin<Hash> {
                     // We expect this block to already exist, so it'll keep its existing block_num,
                     // but worst case it'll just get the current finalized block_num + 1.
                     let rel_block_num = this.rel_block_num + 1;
-                    let block_ref = this.pin_block_at(rel_block_num, details.best_block_hash);
+                    let block_ref =
+                        this.pin_block_at(rel_block_num, details.best_block_hash, false);
 
                     FollowStreamMsg::Event(FollowEvent::BestBlockChanged(BestBlockChanged {
                         best_block_hash: block_ref,
@@ -156,7 +159,7 @@ impl<Hash: BlockHash> Stream for FollowStreamUnpin<Hash> {
                             // but if they don't, we just increment the num from the last finalized block
                             // we saw, which should be accurate.
                             let rel_block_num = this.rel_block_num + idx + 1;
-                            this.pin_block_at(rel_block_num, hash)
+                            this.pin_block_at(rel_block_num, hash, false)
                         })
                         .collect();
 
@@ -170,17 +173,15 @@ impl<Hash: BlockHash> Stream for FollowStreamUnpin<Hash> {
                         .map(|hash| {
                             // We should know about these, too, and if not we set their age to last_finalized + 1
                             let rel_block_num = this.rel_block_num + 1;
-                            this.pin_block_at(rel_block_num, hash)
+                            this.pin_block_at(rel_block_num, hash, true)
                         })
                         .collect();
-
-                    let pruned_hashes = pruned_block_refs.iter().map(|block| block.hash());
 
                     // At this point, we also check to see which blocks we should submit unpin events
                     // for. When we see a block hash as finalized, we know that it won't be reported again
                     // (except as a parent hash of a new block), so we can safely make an unpin call for it
                     // without worrying about the hash being returned again despite the block not being pinned.
-                    this.unpin_blocks(pruned_hashes, cx.waker());
+                    this.unpin_blocks(cx.waker());
 
                     FollowStreamMsg::Event(FollowEvent::Finalized(Finalized {
                         finalized_block_hashes: finalized_block_refs,
@@ -272,12 +273,18 @@ impl<Hash: BlockHash> FollowStreamUnpin<Hash> {
     /// Pin a block, or return the reference to an already-pinned block. If the block has been registered to
     /// be unpinned, we'll clear those flags, so that it won't be unpinned. If the unpin request has already
     /// been sent though, then the block will be unpinned.
-    fn pin_block_at(&mut self, rel_block_num: usize, hash: Hash) -> BlockRef<Hash> {
+    fn pin_block_at(
+        &mut self,
+        rel_block_num: usize,
+        hash: Hash,
+        should_unpin: bool,
+    ) -> BlockRef<Hash> {
         let entry = self
             .pinned
             .entry(hash)
             // Only if there's already an entry do we need to clear any unpin flags set against it.
-            .and_modify(|_| {
+            .and_modify(|entry| {
+                entry.block_ref.should_unpin = should_unpin;
                 self.unpin_flags.lock().unwrap().remove(&hash);
             })
             // If there's not an entry already, make one and return it.
@@ -288,6 +295,7 @@ impl<Hash: BlockHash> FollowStreamUnpin<Hash> {
                         hash,
                         unpin_flags: self.unpin_flags.clone(),
                     }),
+                    should_unpin,
                 },
             });
 
@@ -295,7 +303,7 @@ impl<Hash: BlockHash> FollowStreamUnpin<Hash> {
     }
 
     /// Unpin any blocks that are either too old, or have the unpin flag set and are in the list of pruned hashes.
-    fn unpin_blocks(&mut self, pruned_hashes: impl IntoIterator<Item = Hash>, waker: &Waker) {
+    fn unpin_blocks(&mut self, waker: &Waker) {
         let unpin_flags = std::mem::take(&mut *self.unpin_flags.lock().unwrap());
         let rel_block_num = self.rel_block_num;
 
@@ -307,15 +315,11 @@ impl<Hash: BlockHash> FollowStreamUnpin<Hash> {
 
         let mut blocks_to_unpin = vec![];
         for (hash, details) in &self.pinned {
-            if rel_block_num.saturating_sub(details.rel_block_num) >= self.max_block_life {
+            if rel_block_num.saturating_sub(details.rel_block_num) >= self.max_block_life
+                || unpin_flags.contains(&hash)
+            {
                 // The block is too old, or it's been flagged to be unpinned (no refs to it left)
                 blocks_to_unpin.push(*hash);
-            }
-        }
-
-        for hash in pruned_hashes {
-            if unpin_flags.contains(&hash) {
-                blocks_to_unpin.push(hash);
             }
         }
 
@@ -355,6 +359,7 @@ struct PinnedDetails<Hash: BlockHash> {
 #[derive(Debug, Clone)]
 pub struct BlockRef<Hash: BlockHash> {
     inner: Arc<BlockRefInner<Hash>>,
+    should_unpin: bool,
 }
 
 #[derive(Debug)]
@@ -373,6 +378,7 @@ impl<Hash: BlockHash> BlockRef<Hash> {
                 hash,
                 unpin_flags: Default::default(),
             }),
+            should_unpin: false,
         }
     }
 
@@ -400,7 +406,7 @@ impl<Hash: BlockHash> Drop for BlockRef<Hash> {
         // only "external" one left and we should ask to unpin it now. if it's
         // the only ref remaining, it means that it's already been unpinned, so
         // nothing to do here anyway.
-        if Arc::strong_count(&self.inner) == 2 {
+        if self.should_unpin && Arc::strong_count(&self.inner) == 2 {
             if let Ok(mut unpin_flags) = self.inner.unpin_flags.lock() {
                 unpin_flags.insert(self.inner.hash);
             }
@@ -520,11 +526,11 @@ mod test {
             || {
                 [
                     Ok(ev_initialized(0)),
-                    Ok(ev_finalized([1])),
-                    Ok(ev_finalized([2])),
-                    Ok(ev_finalized([3])),
-                    Ok(ev_finalized([4])),
-                    Ok(ev_finalized([5])),
+                    Ok(ev_finalized([1], [])),
+                    Ok(ev_finalized([2], [])),
+                    Ok(ev_finalized([3], [])),
+                    Ok(ev_finalized([4], [])),
+                    Ok(ev_finalized([5], [])),
                     Err(Error::Other("ended".to_owned())),
                 ]
             },
@@ -569,8 +575,10 @@ mod test {
             || {
                 [
                     Ok(ev_initialized(0)),
-                    Ok(ev_finalized([1])),
-                    Ok(ev_finalized([2])),
+                    Ok(ev_new_block(0, 1)),
+                    Ok(ev_new_block(1, 2)),
+                    Ok(ev_finalized([1], [])),
+                    Ok(ev_finalized([2], [])),
                     Err(Error::Other("ended".to_owned())),
                 ]
             },
@@ -579,8 +587,13 @@ mod test {
 
         let _r = follow_unpin.next().await.unwrap().unwrap();
         let _i0 = follow_unpin.next().await.unwrap().unwrap();
-        let f1 = follow_unpin.next().await.unwrap().unwrap();
 
+        let n1 = follow_unpin.next().await.unwrap().unwrap();
+        drop(n1);
+        let n2 = follow_unpin.next().await.unwrap().unwrap();
+        drop(n2);
+
+        let f1 = follow_unpin.next().await.unwrap().unwrap();
         // We don't care about block 1 any more; drop it. unpinning happens when the max_life is exceeded.
         drop(f1);
 
@@ -593,6 +606,51 @@ mod test {
     }
 
     #[tokio::test]
+    async fn pruned_blocks_should_get_unpinned() {
+        let (mut follow_unpin, unpin_rx) = test_unpin_stream_getter(
+            || {
+                [
+                    Ok(ev_initialized(0)),
+                    Ok(ev_new_block(0, 1)),
+                    Ok(ev_new_block(1, 2)),
+                    Ok(ev_new_block(1, 3)),
+                    Ok(ev_finalized([1], [3])),
+                    Ok(ev_finalized([2], [])),
+                    Err(Error::Other("ended".to_owned())),
+                ]
+            },
+            10,
+        );
+
+        let _r = follow_unpin.next().await.unwrap().unwrap();
+        let _i0 = follow_unpin.next().await.unwrap().unwrap();
+
+        let n1 = follow_unpin.next().await.unwrap().unwrap();
+        drop(n1);
+        let n2 = follow_unpin.next().await.unwrap().unwrap();
+        drop(n2);
+        let n3 = follow_unpin.next().await.unwrap().unwrap();
+        drop(n3);
+
+        let f1 = follow_unpin.next().await.unwrap().unwrap();
+        drop(f1);
+        let f2 = follow_unpin.next().await.unwrap().unwrap();
+        drop(f2);
+
+        let (hash, _) = unpin_rx
+            .try_recv()
+            .expect("unpin call should have happened");
+        assert_eq!(hash, H256::from_low_u64_le(3));
+
+        // Confirm that 0 and 2 are still pinned and that 1 isnt.
+        assert!(follow_unpin.is_pinned(&H256::from_low_u64_le(0)));
+        assert!(follow_unpin.is_pinned(&H256::from_low_u64_le(1)));
+        assert!(follow_unpin.is_pinned(&H256::from_low_u64_le(2)));
+        // Block 3 was pruned, so should be unpinned by the second finalized event.
+        assert!(!follow_unpin.is_pinned(&H256::from_low_u64_le(3)));
+    }
+
+    #[tokio::test]
     async fn never_unpin_new_block_before_finalized() {
         // Ensure that if we drop a new block; the pinning is still active until the block is finalized.
         let (mut follow_unpin, unpin_rx) = test_unpin_stream_getter(
@@ -602,9 +660,9 @@ mod test {
                     Ok(ev_new_block(0, 1)),
                     Ok(ev_new_block(1, 2)),
                     Ok(ev_best_block(1)),
-                    Ok(ev_finalized([1])),
-                    Ok(ev_finalized([2])),
-                    Ok(ev_finalized([3])),
+                    Ok(ev_finalized([1], [])),
+                    Ok(ev_finalized([2], [])),
+                    Ok(ev_finalized([3], [])),
                     Err(Error::Other("ended".to_owned())),
                 ]
             },

--- a/subxt/src/backend/unstable/follow_stream_unpin.rs
+++ b/subxt/src/backend/unstable/follow_stream_unpin.rs
@@ -168,14 +168,13 @@ impl<Hash: BlockHash> Stream for FollowStreamUnpin<Hash> {
                         .pruned_block_hashes
                         .into_iter()
                         .map(|hash| {
-                            // Make note of any pinned blocks as having been pruned by the backend, so that
-                            // we know we can unpin them now once dropped.
+                            // If we've pinned any of these pruned blocks, then make a note in our pinned block
+                            // details that they have been pruned (and thus will never show up again).
                             this.pinned
                                 .entry(hash)
                                 .and_modify(|entry| entry.has_been_pruned = true);
 
-                            // We should know about these, too, and if not we set their age to last_finalized + 1
-                            // Set the unpinning policy to `OnDrop` to unpin the block when the last ref is dropped.
+                            // We should know about these, too, and if not we set their age to last_finalized + 1.
                             let rel_block_num = this.rel_block_num + 1;
                             this.pin_block_at(rel_block_num, hash)
                         })

--- a/subxt/src/backend/unstable/follow_stream_unpin.rs
+++ b/subxt/src/backend/unstable/follow_stream_unpin.rs
@@ -329,7 +329,7 @@ impl<Hash: BlockHash> FollowStreamUnpin<Hash> {
         let mut blocks_to_unpin = vec![];
         for (hash, details) in &self.pinned {
             if rel_block_num.saturating_sub(details.rel_block_num) >= self.max_block_life
-                || unpin_flags.contains(&hash)
+                || unpin_flags.contains(hash)
             {
                 // The block is too old, or it's been flagged to be unpinned (no refs to it left)
                 blocks_to_unpin.push(*hash);

--- a/subxt/src/backend/unstable/follow_stream_unpin.rs
+++ b/subxt/src/backend/unstable/follow_stream_unpin.rs
@@ -110,7 +110,7 @@ impl<Hash: BlockHash> Stream for FollowStreamUnpin<Hash> {
                     // The first finalized block gets the starting block_num.
                     let rel_block_num = this.rel_block_num;
                     // Pin this block, but note that it can be unpinned any time since it won't show up again (except
-                    // as a parten block, which we are ignoring at the moment).
+                    // as a parent block, which we are ignoring at the moment).
                     let block_ref =
                         this.pin_unpinnable_block_at(rel_block_num, details.finalized_block_hash);
 
@@ -381,9 +381,10 @@ struct PinnedDetails<Hash: BlockHash> {
     /// Because we store one here until it's unpinned, the live count
     /// will only drop to 1 when no external refs are left.
     block_ref: BlockRef<Hash>,
-    /// Has this block showed up in the list of pruned blocks in a
-    /// finalized event from the backend? If so, it means that the
-    /// block will never show up in another event again.
+    /// Has this block showed up in the list of pruned blocks, or has it
+    /// been finalized? In this case, it can now been pinned as it won't
+    /// show up again in future events (except as a "parent block" of some
+    /// new block, which we're currently ignoring).
     can_be_unpinned: bool,
 }
 

--- a/subxt/src/backend/unstable/follow_stream_unpin.rs
+++ b/subxt/src/backend/unstable/follow_stream_unpin.rs
@@ -111,7 +111,8 @@ impl<Hash: BlockHash> Stream for FollowStreamUnpin<Hash> {
                     let rel_block_num = this.rel_block_num;
                     // Pin this block, but note that it can be unpinned any time since it won't show up again (except
                     // as a parten block, which we are ignoring at the moment).
-                    let block_ref = this.pin_unpinnable_block_at(rel_block_num, details.finalized_block_hash);
+                    let block_ref =
+                        this.pin_unpinnable_block_at(rel_block_num, details.finalized_block_hash);
 
                     FollowStreamMsg::Event(FollowEvent::Initialized(Initialized {
                         finalized_block_hash: block_ref,
@@ -292,7 +293,12 @@ impl<Hash: BlockHash> FollowStreamUnpin<Hash> {
         self.pin_block_at_setting_unpinnable_flag(rel_block_num, hash, true)
     }
 
-    fn pin_block_at_setting_unpinnable_flag(&mut self, rel_block_num: usize, hash: Hash, can_be_unpinned: bool) -> BlockRef<Hash> {
+    fn pin_block_at_setting_unpinnable_flag(
+        &mut self,
+        rel_block_num: usize,
+        hash: Hash,
+        can_be_unpinned: bool,
+    ) -> BlockRef<Hash> {
         let entry = self
             .pinned
             .entry(hash)
@@ -574,7 +580,6 @@ mod test {
         assert!(!follow_unpin.is_pinned(&H256::from_low_u64_le(0)));
     }
 
-
     #[tokio::test]
     async fn unpins_old_blocks() {
         let (mut follow_unpin, unpin_rx) = test_unpin_stream_getter(
@@ -743,11 +748,14 @@ mod test {
             let (h2, _) = unpin_rx
                 .try_recv()
                 .expect("unpin call should have happened");
-            let mut both = [h1,h2];
+            let mut both = [h1, h2];
             both.sort();
             both
         };
-        assert_eq!(dropped,[H256::from_low_u64_le(2), H256::from_low_u64_le(3)]);
+        assert_eq!(
+            dropped,
+            [H256::from_low_u64_le(2), H256::from_low_u64_le(3)]
+        );
     }
 
     #[tokio::test]

--- a/subxt/src/backend/unstable/follow_stream_unpin.rs
+++ b/subxt/src/backend/unstable/follow_stream_unpin.rs
@@ -481,7 +481,7 @@ pub(super) mod test_utils {
         unpin_rx: &UnpinRx<Hash>,
         items: impl IntoIterator<Item = Hash>,
     ) {
-        let expected_hashes = HashSet::<Hash>::from_iter(items.into_iter());
+        let expected_hashes = HashSet::<Hash>::from_iter(items);
         for i in 0..expected_hashes.len() {
             let Ok((hash, _)) = unpin_rx.try_recv() else {
                 panic!("Another unpin event is expected, but failed to pull item {i} from channel");

--- a/subxt/src/backend/unstable/mod.rs
+++ b/subxt/src/backend/unstable/mod.rs
@@ -471,7 +471,6 @@ impl<T: Config + Send + Sync + 'static> Backend<T> for UnstableBackend<T> {
                 if let Poll::Ready(Some(seen_block)) = seen_blocks_sub.poll_next_unpin(cx) {
                     match seen_block {
                         FollowEvent::NewBlock(ev) => {
-    println!("New block seen: {:?}", ev.block_hash.hash());
                             // Optimization: once we have a `finalized_hash`, we only care about finalized
                             // block refs now and can avoid bothering to save new blocks.
                             if finalized_hash.is_none() {
@@ -481,7 +480,6 @@ impl<T: Config + Send + Sync + 'static> Backend<T> for UnstableBackend<T> {
                         }
                         FollowEvent::Finalized(ev) => {
                             for block_ref in ev.finalized_block_hashes {
-    println!("Finalized block seen: {:?}", block_ref.hash());
                                 seen_blocks.insert(
                                     block_ref.hash(),
                                     (SeenBlockMarker::Finalized, block_ref),
@@ -496,10 +494,8 @@ impl<T: Config + Send + Sync + 'static> Backend<T> for UnstableBackend<T> {
                 // If we have a finalized hash, we are done looking for tx events and we are just waiting
                 // for a pinned block with a matching hash (which must appear eventually given it's finalized).
                 if let Some(hash) = &finalized_hash {
-    println!("Looking for finalized hash {hash:?}");
                     if let Some((SeenBlockMarker::Finalized, block_ref)) = seen_blocks.remove(hash)
                     {
-    println!("Found finalized hash!");
                         // Found it! Hand back the event with a pinned block. We're done.
                         done = true;
                         let ev = TransactionStatus::InFinalizedBlock {
@@ -524,7 +520,6 @@ impl<T: Config + Send + Sync + 'static> Backend<T> for UnstableBackend<T> {
                     Poll::Ready(Some(Err(e))) => return Poll::Ready(Some(Err(e))),
                     Poll::Ready(Some(Ok(ev))) => ev,
                 };
-    println!("TX Event seen: {ev:?}");
                 // When we get one, map it to the correct format (or for finalized ev, wait for the pinned block):
                 let ev = match ev {
                     rpc_methods::TransactionStatus::Finalized { block } => {

--- a/subxt/src/backend/unstable/mod.rs
+++ b/subxt/src/backend/unstable/mod.rs
@@ -474,8 +474,10 @@ impl<T: Config + Send + Sync + 'static> Backend<T> for UnstableBackend<T> {
                             // Optimization: once we have a `finalized_hash`, we only care about finalized
                             // block refs now and can avoid bothering to save new blocks.
                             if finalized_hash.is_none() {
-                                seen_blocks
-                                    .insert(ev.block_hash.hash(), (SeenBlockMarker::New, ev.block_hash));
+                                seen_blocks.insert(
+                                    ev.block_hash.hash(),
+                                    (SeenBlockMarker::New, ev.block_hash),
+                                );
                             }
                         }
                         FollowEvent::Finalized(ev) => {
@@ -485,7 +487,7 @@ impl<T: Config + Send + Sync + 'static> Backend<T> for UnstableBackend<T> {
                                     (SeenBlockMarker::Finalized, block_ref),
                                 );
                             }
-                        },
+                        }
                         _ => {}
                     }
                     continue;


### PR DESCRIPTION
This builds on #1367.

The intention behind the original unpin logic is that blocks that will never show up again in any future event can now be safely unpinned. The logic was flawed though; we'd unpin _all_ flagged blocks when a finalized event comes in, even if some of those may later appear in another finalized event.

The intention behind this fix is to track of which of our pinned blocks have been pruned by the backend, and only _actually_ unpin those blocks for real, leaving other blocks pinned until they eventually are pruned by the backend too.