### PR TITLE
ci: Reduce the light client timeout to 15 minutes

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -218,7 +218,7 @@ jobs:
 
   light_client_tests:
     name: "Test (Light Client)"
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - name: Checkout sources

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -219,7 +219,7 @@ jobs:
   light_client_tests:
     name: "Test (Light Client)"
     runs-on: ubuntu-latest-16-cores
-    timeout-minutes: 30
+    timeout-minutes: 15
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4


### PR DESCRIPTION
The light-client CI time is reduced from 30 minutes to 15 minutes.

This is part of an initiative to reduce the CI minutes consumed by subxt (related to: https://github.com/paritytech/subxt/issues/1366).

The light-client has been recently patched by: https://github.com/paritytech/subxt/pull/1372. Without this fix, the light-client tests would fail to sync to the head of the chain, consuming all minutes (30) until the timeout was hit.

The following datapoints show the light-client only needs around 5 minutes:
- https://github.com/paritytech/subxt/actions/runs/7555940911/job/20571947269
- https://github.com/paritytech/subxt/actions/runs/7554871260/job/20568625374
- https://github.com/paritytech/subxt/actions/runs/7540594780/job/20525526129

To stay on the safe side and not have the test fail due to CI overloading, 15 minutes should be enough time.