### PR TITLE
ci: Ensure order of execution for CI steps

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,6 +22,30 @@ env:
   WASM_BINDGEN_TEST_TIMEOUT: 60
 
 jobs:
+  fmt:
+    name: Cargo fmt
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Install Rust nightly toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2.7.3
+
+      - name: Cargo fmt
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: fmt
+          args: --all -- --check
+
   check:
     name: Cargo check
     runs-on: ubuntu-latest
@@ -47,6 +71,59 @@ jobs:
         with:
           crate: cargo-hack
           version: 0.5
+  clippy:
+    name: Cargo clippy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Use substrate-node binary
+        uses: ./.github/workflows/actions/use-substrate
+
+      - name: Install Rust stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          components: clippy
+          override: true
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2.7.3
+
+      - name: Run clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --all-targets -- -D warnings
+  machete:
+    name: "Check unused dependencies"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Use substrate-node binary
+        uses: ./.github/workflows/actions/use-substrate
+
+      - name: Install Rust stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2.7.3
+
+      - name: Install cargo-machete
+        run: cargo install cargo-machete
+
+      - name: Check unused dependencies
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: machete
 
       # A basic check over all targets together. This may lead to features being combined etc,
       # and doesn't test combinations of different features.
@@ -83,6 +160,7 @@ jobs:
   wasm_check:
     name: Cargo check (WASM)
     runs-on: ubuntu-latest
+    needs: check
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -102,30 +180,6 @@ jobs:
       - name: Cargo check WASM examples
         run: |
           cargo check --manifest-path examples/wasm-example/Cargo.toml --target wasm32-unknown-unknown
-
-  fmt:
-    name: Cargo fmt
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4
-
-      - name: Install Rust nightly toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          components: rustfmt
-
-      - name: Rust Cache
-        uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2.7.3
-
-      - name: Cargo fmt
-        uses: actions-rs/cargo@v1.0.3
-        with:
-          command: fmt
-          args: --all -- --check
 
   docs:
     name: Check documentation and run doc tests
@@ -294,57 +348,3 @@ jobs:
           wasm-pack test --headless --firefox
           wasm-pack test --headless --chrome
         working-directory: signer/wasm-tests
-
-  clippy:
-    name: Cargo clippy
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4
-
-      - name: Use substrate-node binary
-        uses: ./.github/workflows/actions/use-substrate
-
-      - name: Install Rust stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          components: clippy
-          override: true
-
-      - name: Rust Cache
-        uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2.7.3
-
-      - name: Run clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-targets -- -D warnings
-  machete:
-    name: "Check unused dependencies"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4
-
-      - name: Use substrate-node binary
-        uses: ./.github/workflows/actions/use-substrate
-
-      - name: Install Rust stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      - name: Rust Cache
-        uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2.7.3
-
-      - name: Install cargo-machete
-        run: cargo install cargo-machete
-
-      - name: Check unused dependencies
-        uses: actions-rs/cargo@v1.0.3
-        with:
-          command: machete

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -101,6 +101,38 @@ jobs:
           crate: cargo-hack
           version: 0.5
 
+      # A basic check over all targets together. This may lead to features being combined etc,
+      # and doesn't test combinations of different features.
+      - name: Cargo check all targets.
+        run: cargo check --all-targets
+
+      # Next, check subxt features.
+      # - `native` feature must always be enabled
+      # - `web` feature is always ignored.
+      # - This means, don't check --no-default-features and don't try enabling --all-features; both will fail
+      - name: Cargo hack; check each subxt feature
+        run: cargo hack -p subxt --each-feature check --exclude-no-default-features --exclude-all-features --exclude-features web --features native
+
+      # Subxt-signer has the "subxt" features enabled in the "check all targets" test. Run it on its own to
+      # check it without. We can't enable subxt or web features here, so no cargo hack.
+      - name: Cargo check subxt-signer
+        run: |
+          cargo check -p subxt-signer
+          cargo check -p subxt-signer --no-default-features --features sr25519,native
+          cargo check -p subxt-signer --no-default-features --features ecdsa,native
+
+      # We can't enable web features here, so no cargo hack.
+      - name: Cargo check subxt-lightclient
+        run: cargo check -p subxt-lightclient
+
+      # Next, check each other package in isolation.
+      - name: Cargo hack; check each feature/crate on its own
+        run: cargo hack --exclude subxt --exclude subxt-signer --exclude subxt-lightclient --exclude-all-features --each-feature check --workspace
+
+      # Check the parachain-example code, which isn't a part of the workspace so is otherwise ignored.
+      - name: Cargo check parachain-example
+        run: cargo check --manifest-path examples/parachain-example/Cargo.toml
+
   wasm_check:
     name: Cargo check (WASM)
     runs-on: ubuntu-latest
@@ -153,38 +185,6 @@ jobs:
         uses: actions-rs/cargo@v1.0.3
         with:
           command: machete
-
-      # A basic check over all targets together. This may lead to features being combined etc,
-      # and doesn't test combinations of different features.
-      - name: Cargo check all targets.
-        run: cargo check --all-targets
-
-      # Next, check subxt features.
-      # - `native` feature must always be enabled
-      # - `web` feature is always ignored.
-      # - This means, don't check --no-default-features and don't try enabling --all-features; both will fail
-      - name: Cargo hack; check each subxt feature
-        run: cargo hack -p subxt --each-feature check --exclude-no-default-features --exclude-all-features --exclude-features web --features native
-
-      # Subxt-signer has the "subxt" features enabled in the "check all targets" test. Run it on its own to
-      # check it without. We can't enable subxt or web features here, so no cargo hack.
-      - name: Cargo check subxt-signer
-        run: |
-          cargo check -p subxt-signer
-          cargo check -p subxt-signer --no-default-features --features sr25519,native
-          cargo check -p subxt-signer --no-default-features --features ecdsa,native
-
-      # We can't enable web features here, so no cargo hack.
-      - name: Cargo check subxt-lightclient
-        run: cargo check -p subxt-lightclient
-
-      # Next, check each other package in isolation.
-      - name: Cargo hack; check each feature/crate on its own
-        run: cargo hack --exclude subxt --exclude subxt-signer --exclude subxt-lightclient --exclude-all-features --each-feature check --workspace
-
-      # Check the parachain-example code, which isn't a part of the workspace so is otherwise ignored.
-      - name: Cargo check parachain-example
-        run: cargo check --manifest-path examples/parachain-example/Cargo.toml
 
   docs:
     name: Check documentation and run doc tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,34 +46,10 @@ jobs:
           command: fmt
           args: --all -- --check
 
-  check:
-    name: Cargo check
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4
-
-      - name: Use substrate-node binary
-        uses: ./.github/workflows/actions/use-substrate
-
-      - name: Install Rust stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      - name: Rust Cache
-        uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2.7.3
-
-      - name: Install cargo-hack
-        uses: baptiste0928/cargo-install@v2
-        with:
-          crate: cargo-hack
-          version: 0.5
   clippy:
     name: Cargo clippy
     runs-on: ubuntu-latest
+    needs: fmt
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -97,9 +73,62 @@ jobs:
         with:
           command: clippy
           args: --all-targets -- -D warnings
+
+  check:
+    name: Cargo check
+    runs-on: ubuntu-latest
+    needs: [fmt, clippy]
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Use substrate-node binary
+        uses: ./.github/workflows/actions/use-substrate
+
+      - name: Install Rust stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2.7.3
+
+      - name: Install cargo-hack
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: cargo-hack
+          version: 0.5
+
+  wasm_check:
+    name: Cargo check (WASM)
+    runs-on: ubuntu-latest
+    needs: [fmt, clippy]
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Install Rust stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: wasm32-unknown-unknown
+          override: true
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2.7.3
+
+      # Check WASM examples, which aren't a part of the workspace and so are otherwise missed:
+      - name: Cargo check WASM examples
+        run: |
+          cargo check --manifest-path examples/wasm-example/Cargo.toml --target wasm32-unknown-unknown
+
   machete:
     name: "Check unused dependencies"
     runs-on: ubuntu-latest
+    needs: [check, wasm_check]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -157,33 +186,10 @@ jobs:
       - name: Cargo check parachain-example
         run: cargo check --manifest-path examples/parachain-example/Cargo.toml
 
-  wasm_check:
-    name: Cargo check (WASM)
-    runs-on: ubuntu-latest
-    needs: check
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4
-
-      - name: Install Rust stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          target: wasm32-unknown-unknown
-          override: true
-
-      - name: Rust Cache
-        uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2.7.3
-
-      # Check WASM examples, which aren't a part of the workspace and so are otherwise missed:
-      - name: Cargo check WASM examples
-        run: |
-          cargo check --manifest-path examples/wasm-example/Cargo.toml --target wasm32-unknown-unknown
-
   docs:
     name: Check documentation and run doc tests
     runs-on: ubuntu-latest
+    needs: [check, wasm_check]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -213,6 +219,7 @@ jobs:
   tests:
     name: "Test (Native)"
     runs-on: ubuntu-latest-16-cores
+    needs: [machete, docs]
     timeout-minutes: 30
     steps:
       - name: Checkout sources
@@ -243,6 +250,7 @@ jobs:
   unstable_backend_tests:
     name: "Test (Unstable Backend)"
     runs-on: ubuntu-latest-16-cores
+    needs: [machete, docs]
     timeout-minutes: 30
     steps:
       - name: Checkout sources
@@ -273,6 +281,7 @@ jobs:
   light_client_tests:
     name: "Test (Light Client)"
     runs-on: ubuntu-latest
+    needs: [machete, docs]
     timeout-minutes: 15
     steps:
       - name: Checkout sources
@@ -300,6 +309,7 @@ jobs:
   wasm_tests:
     name: Test (WASM)
     runs-on: ubuntu-latest
+    needs: [machete, docs]
     timeout-minutes: 30
     env:
       # Set timeout for wasm tests to be much bigger than the default 20 secs.


### PR DESCRIPTION
This uses the [needs](https://docs.github.com/en/actions/using-jobs/using-jobs-in-a-workflow) step to enforce jobs to run sequentially.


Data extracted from https://github.com/paritytech/subxt/actions/runs/7558071243/job/20578738077 (however I believe some checks are already cached):
```bash
Rust / Cargo fmt (push) Successful in 12s
Rust / Check unused dependencies (push) Successful in 17s
Rust / Cargo check (WASM) (push) Successful in 1m
Rust / Cargo clippy (push) Successful in 3m
Rust / Cargo check (push) Successful in 5m
Rust / Check documentation and run doc tests (push) Successful in 5m
Rust / Test (Native) (push) Successful in 9m
Rust / Test (Light Client) (push) Successful in 6m
Rust / Test (WASM) (push) Successful in 6m
```

This PR ensures the following steps are running in order:
- fmt 
- clippy
- check || wasm_check
- machete || docs
- all other tests


