### PR TITLE
subxt: Derive `std::cmp` traits for subxt payloads and addresses

### DIFF
--- a/subxt/src/backend/mod.rs
+++ b/subxt/src/backend/mod.rs
@@ -184,6 +184,7 @@ impl<H: PartialEq> PartialEq for BlockRef<H> {
 }
 impl<H: Eq> Eq for BlockRef<H> {}
 
+// Manual implementation to work aroud https://github.com/mcarton/rust-derivative/issues/115.
 impl<H: PartialOrd> PartialOrd for BlockRef<H> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         self.hash.partial_cmp(&other.hash)

--- a/subxt/src/backend/mod.rs
+++ b/subxt/src/backend/mod.rs
@@ -184,7 +184,7 @@ impl<H: PartialEq> PartialEq for BlockRef<H> {
 }
 impl<H: Eq> Eq for BlockRef<H> {}
 
-// Manual implementation to work aroud https://github.com/mcarton/rust-derivative/issues/115.
+// Manual implementation to work around https://github.com/mcarton/rust-derivative/issues/115.
 impl<H: PartialOrd> PartialOrd for BlockRef<H> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         self.hash.partial_cmp(&other.hash)

--- a/subxt/src/constants/constant_address.rs
+++ b/subxt/src/constants/constant_address.rs
@@ -42,7 +42,7 @@ pub struct Address<ReturnTy> {
     _marker: std::marker::PhantomData<ReturnTy>,
 }
 
-// Manual implementation to work aroud https://github.com/mcarton/rust-derivative/issues/115.
+// Manual implementation to work around https://github.com/mcarton/rust-derivative/issues/115.
 impl<ReturnTy> PartialOrd for Address<ReturnTy> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))

--- a/subxt/src/constants/constant_address.rs
+++ b/subxt/src/constants/constant_address.rs
@@ -33,14 +33,19 @@ pub trait ConstantAddress {
     Debug(bound = ""),
     Eq(bound = ""),
     Ord(bound = ""),
-    PartialEq(bound = ""),
-    PartialOrd(bound = "")
+    PartialEq(bound = "")
 )]
 pub struct Address<ReturnTy> {
     pallet_name: Cow<'static, str>,
     constant_name: Cow<'static, str>,
     constant_hash: Option<[u8; 32]>,
     _marker: std::marker::PhantomData<ReturnTy>,
+}
+
+impl<ReturnTy> PartialOrd for Address<ReturnTy> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
 }
 
 /// The type of address typically used to return dynamic constant values.

--- a/subxt/src/constants/constant_address.rs
+++ b/subxt/src/constants/constant_address.rs
@@ -28,7 +28,14 @@ pub trait ConstantAddress {
 
 /// This represents the address of a constant.
 #[derive(Derivative)]
-#[derivative(Clone(bound = ""), Debug(bound = ""))]
+#[derivative(
+    Clone(bound = ""),
+    Debug(bound = ""),
+    Eq(bound = ""),
+    Ord(bound = ""),
+    PartialEq(bound = ""),
+    PartialOrd(bound = "")
+)]
 pub struct Address<ReturnTy> {
     pallet_name: Cow<'static, str>,
     constant_name: Cow<'static, str>,

--- a/subxt/src/constants/constant_address.rs
+++ b/subxt/src/constants/constant_address.rs
@@ -42,6 +42,7 @@ pub struct Address<ReturnTy> {
     _marker: std::marker::PhantomData<ReturnTy>,
 }
 
+// Manual implementation to work aroud https://github.com/mcarton/rust-derivative/issues/115.
 impl<ReturnTy> PartialOrd for Address<ReturnTy> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))

--- a/subxt/src/custom_values/custom_value_address.rs
+++ b/subxt/src/custom_values/custom_value_address.rs
@@ -38,7 +38,14 @@ pub struct Yes;
 
 /// A static address to a custom value.
 #[derive(Derivative)]
-#[derivative(Clone(bound = ""), Debug(bound = ""))]
+#[derivative(
+    Clone(bound = ""),
+    Debug(bound = ""),
+    Eq(bound = ""),
+    Ord(bound = ""),
+    PartialEq(bound = ""),
+    PartialOrd(bound = "")
+)]
 pub struct StaticAddress<ReturnTy, IsDecodable> {
     name: &'static str,
     hash: Option<[u8; 32]>,

--- a/subxt/src/custom_values/custom_value_address.rs
+++ b/subxt/src/custom_values/custom_value_address.rs
@@ -43,13 +43,18 @@ pub struct Yes;
     Debug(bound = ""),
     Eq(bound = ""),
     Ord(bound = ""),
-    PartialEq(bound = ""),
-    PartialOrd(bound = "")
+    PartialEq(bound = "")
 )]
 pub struct StaticAddress<ReturnTy, IsDecodable> {
     name: &'static str,
     hash: Option<[u8; 32]>,
     phantom: PhantomData<(ReturnTy, IsDecodable)>,
+}
+
+impl<ReturnTy, IsDecodable> PartialOrd for StaticAddress<ReturnTy, IsDecodable> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
 }
 
 impl<ReturnTy, IsDecodable> StaticAddress<ReturnTy, IsDecodable> {

--- a/subxt/src/runtime_api/runtime_payload.rs
+++ b/subxt/src/runtime_api/runtime_payload.rs
@@ -69,7 +69,11 @@ pub trait RuntimeApiPayload {
 #[derive(Derivative)]
 #[derivative(
     Clone(bound = "ArgsData: Clone"),
-    Debug(bound = "ArgsData: std::fmt::Debug")
+    Debug(bound = "ArgsData: std::fmt::Debug"),
+    Eq(bound = "ArgsData: std::cmp::Eq"),
+    Ord(bound = "ArgsData: std::cmp::Ord"),
+    PartialEq(bound = "ArgsData: std::cmp::PartialEq"),
+    PartialOrd(bound = "ArgsData: std::cmp::PartialOrd")
 )]
 pub struct Payload<ArgsData, ReturnTy> {
     trait_name: Cow<'static, str>,

--- a/subxt/src/storage/storage_address.rs
+++ b/subxt/src/storage/storage_address.rs
@@ -55,7 +55,11 @@ pub struct Yes;
 #[derive(Derivative)]
 #[derivative(
     Clone(bound = "StorageKey: Clone"),
-    Debug(bound = "StorageKey: std::fmt::Debug")
+    Debug(bound = "StorageKey: std::fmt::Debug"),
+    Eq(bound = "StorageKey: std::cmp::Eq"),
+    Ord(bound = "StorageKey: std::cmp::Ord"),
+    PartialEq(bound = "StorageKey: std::cmp::PartialEq"),
+    PartialOrd(bound = "StorageKey: std::cmp::PartialOrd")
 )]
 pub struct Address<StorageKey, ReturnTy, Fetchable, Defaultable, Iterable> {
     pallet_name: Cow<'static, str>,

--- a/subxt/src/tx/tx_payload.rs
+++ b/subxt/src/tx/tx_payload.rs
@@ -11,6 +11,7 @@ use crate::{
     metadata::Metadata,
 };
 use codec::Encode;
+use derivative::Derivative;
 use scale_encode::EncodeAsFields;
 use scale_value::{Composite, ValueDef, Variant};
 use std::{borrow::Cow, sync::Arc};
@@ -48,7 +49,15 @@ pub struct ValidationDetails<'a> {
 }
 
 /// A transaction payload containing some generic `CallData`.
-#[derive(Clone, Debug)]
+#[derive(Derivative)]
+#[derivative(
+    Clone(bound = "CallData: Clone"),
+    Debug(bound = "CallData: std::fmt::Debug"),
+    Eq(bound = "CallData: std::cmp::Eq"),
+    Ord(bound = "CallData: std::cmp::Ord"),
+    PartialEq(bound = "CallData: std::cmp::PartialEq"),
+    PartialOrd(bound = "CallData: std::cmp::PartialOrd")
+)]
 pub struct Payload<CallData> {
     pallet_name: Cow<'static, str>,
     call_name: Cow<'static, str>,


### PR DESCRIPTION
This PR implements multiple std::cmp traits for either subxt payloads to addresses:
- Eq
- Ord
- PartialEq
- PartialOrd

The traits are only implemented if the generic parameter of those objects implements the said traits.

This offers users the flexibility to use the subxt payloads in combination with `custom_derives` for the subxt macro. This makes the subxt more flexible (eg users could compare multiple `tx::Payload<X>` when `X: PartialEq`).

Closes https://github.com/paritytech/subxt/issues/1422