### PR TITLE
[Fix] Auto-generated PR: delete polkadot binaries from working directory.

### DIFF
--- a/.github/workflows/actions/use-nodes/action.yml
+++ b/.github/workflows/actions/use-nodes/action.yml
@@ -33,7 +33,8 @@ runs:
         ./substrate-node --version
         ./polkadot --version
         mkdir -p ~/.local/bin
-        cp ./substrate-node ~/.local/bin
-        cp ./polkadot ~/.local/bin
-        cp ./polkadot-execute-worker ~/.local/bin
-        cp ./polkadot-prepare-worker ~/.local/bin
+        mv ./substrate-node ~/.local/bin
+        mv ./polkadot ~/.local/bin
+        mv ./polkadot-execute-worker ~/.local/bin
+        mv ./polkadot-prepare-worker ~/.local/bin
+        rm ./polkadot.tar.gz

--- a/.github/workflows/update-artifacts.yml
+++ b/.github/workflows/update-artifacts.yml
@@ -41,10 +41,6 @@ jobs:
       - name: Fetch Artifacts
         run: cargo run --bin artifacts
 
-      - name: Delete substrate and polkadot binaries
-        run: |
-          rm ./substrate-node ./polkadot ./polkadot.tar.gz ./polkadot-execute-worker ./polkadot-prepare-worker
-
       - uses: actions/create-github-app-token@v1
         id: app-token
         with:

--- a/.github/workflows/update-artifacts.yml
+++ b/.github/workflows/update-artifacts.yml
@@ -41,8 +41,9 @@ jobs:
       - name: Fetch Artifacts
         run: cargo run --bin artifacts
 
-      - name: Delete substrate node binary
-        run: rm ./substrate-node
+      - name: Delete substrate and polkadot binaries
+        run: |
+          rm ./substrate-node ./polkadot ./polkadot.tar.gz ./polkadot-execute-worker ./polkadot-prepare-worker
 
       - uses: actions/create-github-app-token@v1
         id: app-token


### PR DESCRIPTION
This PR fixes the issue notices by [Niklas in this PR](https://github.com/paritytech/subxt/pull/1430#discussion_r1489440678). We can remove the nodes binaries and the the archive from the working directory in directly in the use-nodes action. 

