### PR TITLE
Make storage_page_size for the LegacyBackend configurable

### DIFF
--- a/subxt/src/backend/legacy/mod.rs
+++ b/subxt/src/backend/legacy/mod.rs
@@ -22,18 +22,56 @@ use std::task::{Context, Poll};
 // Expose the RPC methods.
 pub use rpc_methods::LegacyRpcMethods;
 
+/// Configure and build an [`LegacyBackend`].
+pub struct LegacyBackendBuilder<T> {
+    storage_page_size: u32,
+    _marker: std::marker::PhantomData<T>,
+}
+
+impl<T: Config> Default for LegacyBackendBuilder<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T: Config> LegacyBackendBuilder<T> {
+    /// Create a new [`LegacyBackendBuilder`].
+    pub fn new() -> Self {
+        Self {
+            storage_page_size: 64,
+            _marker: std::marker::PhantomData,
+        }
+    }
+
+    /// Iterating over storage entries using the [`LegacyBackend`] requires
+    /// fetching entries in batches. This configures the number of entries that
+    /// we'll try to obtain in each batch (default: 64).
+    pub fn storage_page_size(mut self, storage_page_size: u32) -> Self {
+        self.storage_page_size = storage_page_size;
+        self
+    }
+
+    /// Given an [`RpcClient`] to use to make requests, this returns a [`LegacyBackend`],
+    /// which implements the [`Backend`] trait.
+    pub fn build(self, client: RpcClient) -> LegacyBackend<T> {
+        LegacyBackend {
+            storage_page_size: self.storage_page_size,
+            methods: LegacyRpcMethods::new(client),
+        }
+    }
+}
+
 /// The legacy backend.
 #[derive(Debug, Clone)]
 pub struct LegacyBackend<T> {
+    storage_page_size: u32,
     methods: LegacyRpcMethods<T>,
 }
 
 impl<T: Config> LegacyBackend<T> {
-    /// Instantiate a new backend which uses the legacy API methods.
-    pub fn new(client: RpcClient) -> Self {
-        Self {
-            methods: LegacyRpcMethods::new(client),
-        }
+    /// Configure and construct an [`LegacyBackend`].
+    pub fn builder() -> LegacyBackendBuilder<T> {
+        LegacyBackendBuilder::new()
     }
 }
 
@@ -74,6 +112,7 @@ impl<T: Config + Send + Sync + 'static> Backend<T> for LegacyBackend<T> {
         let keys = StorageFetchDescendantKeysStream {
             at,
             key,
+            storage_page_size: self.storage_page_size,
             methods: self.methods.clone(),
             done: Default::default(),
             keys_fut: Default::default(),
@@ -104,6 +143,7 @@ impl<T: Config + Send + Sync + 'static> Backend<T> for LegacyBackend<T> {
         let keys_stream = StorageFetchDescendantKeysStream {
             at,
             key,
+            storage_page_size: self.storage_page_size,
             methods: self.methods.clone(),
             done: Default::default(),
             keys_fut: Default::default(),
@@ -332,9 +372,6 @@ where
     })
 }
 
-/// How many keys/values to fetch at once.
-const STORAGE_PAGE_SIZE: u32 = 32;
-
 /// This provides a stream of values given some prefix `key`. It
 /// internally manages pagination and such.
 #[allow(clippy::type_complexity)]
@@ -342,6 +379,8 @@ pub struct StorageFetchDescendantKeysStream<T: Config> {
     methods: LegacyRpcMethods<T>,
     key: Vec<u8>,
     at: T::Hash,
+    // How many entries to ask for each time.
+    storage_page_size: u32,
     // What key do we start paginating from? None = from the beginning.
     pagination_start_key: Option<Vec<u8>>,
     // Keys, future and cached:
@@ -392,12 +431,13 @@ impl<T: Config> Stream for StorageFetchDescendantKeysStream<T> {
             let methods = this.methods.clone();
             let key = this.key.clone();
             let at = this.at;
+            let storage_page_size = this.storage_page_size;
             let pagination_start_key = this.pagination_start_key.take();
             let keys_fut = async move {
                 methods
                     .state_get_keys_paged(
                         &key,
-                        STORAGE_PAGE_SIZE,
+                        storage_page_size,
                         pagination_start_key.as_deref(),
                         Some(at),
                     )

--- a/subxt/src/client/online_client.rs
+++ b/subxt/src/client/online_client.rs
@@ -76,7 +76,7 @@ impl<T: Config> OnlineClient<T> {
     /// Allows insecure URLs without SSL encryption, e.g. (http:// and ws:// URLs).
     pub async fn from_insecure_url(url: impl AsRef<str>) -> Result<OnlineClient<T>, Error> {
         let client = RpcClient::from_insecure_url(url).await?;
-        let backend = LegacyBackend::new(client);
+        let backend = LegacyBackend::builder().build(client);
         OnlineClient::from_backend(Arc::new(backend)).await
     }
 }
@@ -85,7 +85,7 @@ impl<T: Config> OnlineClient<T> {
     /// Construct a new [`OnlineClient`] by providing an [`RpcClient`] to drive the connection.
     /// This will use the current default [`Backend`], which may change in future releases.
     pub async fn from_rpc_client(rpc_client: RpcClient) -> Result<OnlineClient<T>, Error> {
-        let backend = Arc::new(LegacyBackend::new(rpc_client));
+        let backend = Arc::new(LegacyBackend::builder().build(rpc_client));
         OnlineClient::from_backend(backend).await
     }
 
@@ -108,7 +108,7 @@ impl<T: Config> OnlineClient<T> {
         metadata: impl Into<Metadata>,
         rpc_client: RpcClient,
     ) -> Result<OnlineClient<T>, Error> {
-        let backend = Arc::new(LegacyBackend::new(rpc_client));
+        let backend = Arc::new(LegacyBackend::builder().build(rpc_client));
         OnlineClient::from_backend_with(genesis_hash, runtime_version, metadata, backend)
     }
 

--- a/testing/integration-tests/src/utils/node_proc.rs
+++ b/testing/integration-tests/src/utils/node_proc.rs
@@ -201,7 +201,7 @@ async fn build_rpc_client(ws_url: &str) -> Result<rpc::RpcClient, String> {
 async fn build_legacy_client<T: Config>(
     rpc_client: rpc::RpcClient,
 ) -> Result<OnlineClient<T>, String> {
-    let backend = legacy::LegacyBackend::new(rpc_client);
+    let backend = legacy::LegacyBackend::builder().build(rpc_client);
     let client = OnlineClient::from_backend(Arc::new(backend))
         .await
         .map_err(|e| format!("Cannot construct OnlineClient from backend: {e}"))?;


### PR DESCRIPTION
Closes #1454 by allowing the user to configure the number of storage entries returned when iterating using the `LegacyBackend`. To make use of this you'll have to manually instantiate a backend etc, ie something like this:

```rust
// Connect to node:
let rpc_client = subxt::backend::rpc::RpcClient::from_insecure_url("ws://localhost:9944").await?;

// Use this connection to make calls using our legacy backend:
let backend = LegacyBackend::builder()
    .storage_page_size(1024)
    .build(rpc_client);

// Use the legacy backend to drive our Subxt client:
let client = OnlineClient::<PolkadotConfig>::from_backend(Arc::new(backend)).await?;
```

I added a builder just to mirror the `UnstableBackend` interface more closely, and to be a place where potentially we can expose more configuration if need be. It's definitely not ideal that you only have one global page size setting per client, but it's also a bit of a stop gap until we migrate to the new backend which streams storage entries and thus has no such configuration.