### PR TITLE
disable cargo doc for `subxt-cli`

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -13,8 +13,9 @@ homepage.workspace = true
 description = "Command line utilities for working with subxt codegen"
 
 [[bin]]
-name = "subxt-cli"
+name = "subxt"
 path = "src/main.rs"
+doc = false
 
 [lints]
 workspace = true

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -13,7 +13,7 @@ homepage.workspace = true
 description = "Command line utilities for working with subxt codegen"
 
 [[bin]]
-name = "subxt"
+name = "subxt-cli"
 path = "src/main.rs"
 
 [lints]


### PR DESCRIPTION
Currently we are sometimes running into https://github.com/rust-lang/cargo/issues/6313 because `subxt crate` and the binary name for `subxt-cli` causes a file-name collision when running `cargo doc`.

This PR disables `doc` for subxt-cli crate which is not that useful anyway. The CLI `--help` should be sufficient

Fixes the following warning from the cargo doc:

```bash
warning: output filename collision.
The bin target `subxt` in package `subxt-cli v0.34.0 (/home/niklasad1/Github/subxt/cli)` has the same output filename as the lib target `subxt` in package `subxt v0.34.0 (/home/niklasad1/Github/subxt/subxt)`.
Colliding filename is: /home/niklasad1/Github/subxt/target/doc/subxt/index.html
The targets should have unique names.
This is a known bug where multiple crates with the same name use
the same path; see <https://github.com/rust-lang/cargo/issues/6313>.
```