### PR TITLE
Remove `ensure_unique_type_paths` function from `subxt_metadata`, use it from `scale-typegen` instead.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3577,22 +3577,19 @@ dependencies = [
 
 [[package]]
 name = "scale-typegen"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6108609f017741c78d35967c7afe4aeaa3999b848282581041428e10d23b63"
+version = "0.3.0"
 dependencies = [
  "proc-macro2",
  "quote",
  "scale-info",
+ "smallvec",
  "syn 2.0.48",
  "thiserror",
 ]
 
 [[package]]
 name = "scale-typegen-description"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479f0b8b0d75cce8d284ace5a9b7f5a12c523c94387c710835695e8b194a17bb"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "peekmore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,8 +106,8 @@ url = "2.5.0"
 wabt = "0.10.0"
 wasm-bindgen-test = "0.3.24"
 which = "5.0.0"
-scale-typegen-description = "0.2.0"
-scale-typegen = "0.2.0"
+scale-typegen-description = {path = "../scale-typegen/description"}    #  "0.3.0"
+scale-typegen = {path = "../scale-typegen/typegen"} 
 strip-ansi-escapes = "0.2.0"
 
 # Light client support:

--- a/codegen/src/api/mod.rs
+++ b/codegen/src/api/mod.rs
@@ -44,7 +44,7 @@ impl RuntimeGenerator {
     ///
     /// Supported versions: v14 and v15.
     pub fn new(mut metadata: Metadata) -> Self {
-        metadata.ensure_unique_type_paths();
+        scale_typegen::utils::ensure_unique_type_paths(metadata.types_mut());
         RuntimeGenerator { metadata }
     }
 


### PR DESCRIPTION
We have a `ensure_unique_type_paths` function in `scale-typegen` that is a bit more advanced than the one we currently have in `subxt-metadata`. This more simple function will cause typegen failures in the light of this [PR in scale-typegen](https://github.com/paritytech/scale-typegen/pull/16). But because it is only used in the `subxt-codegen::RuntimeGenerator` it is easy to switch it out to the function from `scale-typegen`. 

I tested the compatibility locally with scale typegens [newest version of the function](https://github.com/paritytech/scale-typegen/pull/16). Once this lands, I will update the `scale-typegen` deps here.

