### PR TITLE
Prep to release 0.35

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,7 +111,6 @@ For a full list of changes, please see the following:
 - Handle errors when fetching storage keys from Unstablebackend ([#1440](https://github.com/paritytech/subxt/pull/1440))
 - Swap type aliases around to be semantically correct ([#1441](https://github.com/paritytech/subxt/pull/1441))
 
-
 ## [0.34.0] - 2024-01-23
 
 This release introduces a bunch of features that make subxt easier to use. Let's look at a few of them.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -333,7 +333,7 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "artifacts"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "substrate-runner",
 ]
@@ -1758,7 +1758,7 @@ dependencies = [
 
 [[package]]
 name = "generate-custom-metadata"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "frame-metadata 16.0.0",
  "parity-scale-codec",
@@ -2244,7 +2244,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "assert_matches",
  "frame-metadata 16.0.0",
@@ -4502,7 +4502,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-runner"
-version = "0.34.0"
+version = "0.35.0"
 
 [[package]]
 name = "subtle"
@@ -4512,7 +4512,7 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "subxt"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -4556,7 +4556,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-cli"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "clap 4.5.2",
  "color-eyre",
@@ -4585,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-codegen"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "frame-metadata 16.0.0",
  "getrandom",
@@ -4605,7 +4605,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-lightclient"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4630,7 +4630,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "darling 0.20.8",
  "parity-scale-codec",
@@ -4643,7 +4643,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-metadata"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "assert_matches",
  "bitvec",
@@ -4658,7 +4658,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-signer"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "bip39",
  "cfg-if",
@@ -4725,7 +4725,7 @@ dependencies = [
 
 [[package]]
 name = "test-runtime"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "hex",
  "impl-serde",
@@ -5154,7 +5154,7 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "ui-tests"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "frame-metadata 16.0.0",
  "generate-custom-metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ resolver = "2"
 [workspace.package]
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
-version = "0.34.0"
+version = "0.35.0"
 rust-version = "1.74.0"
 license = "Apache-2.0 OR GPL-3.0"
 repository = "https://github.com/paritytech/subxt"
@@ -135,12 +135,12 @@ sp-runtime = "31.0.0"
 sp-keyring = "31.0.0"
 
 # Subxt workspace crates:
-subxt = { version = "0.34.0", path = "subxt", default-features = false }
-subxt-macro = { version = "0.34.0", path = "macro" }
-subxt-metadata = { version = "0.34.0", path = "metadata", default-features = false }
-subxt-codegen = { version = "0.34.0", path = "codegen" }
-subxt-signer = { version = "0.34.0", path = "signer", default-features = false }
-subxt-lightclient = { version = "0.34.0", path = "lightclient", default-features = false }
+subxt = { version = "0.35.0", path = "subxt", default-features = false }
+subxt-macro = { version = "0.35.0", path = "macro" }
+subxt-metadata = { version = "0.35.0", path = "metadata", default-features = false }
+subxt-codegen = { version = "0.35.0", path = "codegen" }
+subxt-signer = { version = "0.35.0", path = "signer", default-features = false }
+subxt-lightclient = { version = "0.35.0", path = "lightclient", default-features = false }
 test-runtime = { path = "testing/test-runtime" }
 substrate-runner = { path = "testing/substrate-runner" }
 

--- a/examples/parachain-example/Cargo.lock
+++ b/examples/parachain-example/Cargo.lock
@@ -2551,7 +2551,7 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "subxt"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "base58",
@@ -2585,7 +2585,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-codegen"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "frame-metadata 16.0.0",
  "heck",
@@ -2604,7 +2604,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-lightclient"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "futures",
  "futures-util",
@@ -2619,7 +2619,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "darling 0.20.3",
  "parity-scale-codec",
@@ -2632,7 +2632,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-metadata"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "frame-metadata 16.0.0",
  "parity-scale-codec",
@@ -2643,7 +2643,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-signer"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "bip39",
  "hex",

--- a/examples/wasm-example/Cargo.lock
+++ b/examples/wasm-example/Cargo.lock
@@ -2499,7 +2499,7 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "subxt"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "base58",
@@ -2533,7 +2533,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-codegen"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "frame-metadata 16.0.0",
  "getrandom",
@@ -2553,7 +2553,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-lightclient"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "futures",
  "futures-timer",
@@ -2578,7 +2578,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "darling",
  "parity-scale-codec",
@@ -2591,7 +2591,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-metadata"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "derive_more",
  "frame-metadata 16.0.0",

--- a/signer/src/crypto/mod.rs
+++ b/signer/src/crypto/mod.rs
@@ -6,8 +6,13 @@
 
 mod derive_junction;
 mod secret_uri;
+
+// No need for the cfg other than to avoid an unused_imports lint warning.
+#[cfg(any(feature = "sr25519", feature = "ecdsa"))]
 mod seed_from_entropy;
 
 pub use derive_junction::DeriveJunction;
 pub use secret_uri::{SecretUri, SecretUriError, DEV_PHRASE};
+
+#[cfg(any(feature = "sr25519", feature = "ecdsa"))]
 pub use seed_from_entropy::seed_from_entropy;

--- a/testing/integration-tests/Cargo.toml
+++ b/testing/integration-tests/Cargo.toml
@@ -34,7 +34,7 @@ scale-info = { workspace = true, features = ["bit-vec"] }
 sp-core = { workspace = true }
 syn = { workspace = true }
 subxt = { workspace = true, features = ["unstable-metadata", "native", "jsonrpsee", "substrate-compat"] }
-subxt-signer = { workspace = true }
+subxt-signer = { workspace = true, features = ["default"] }
 subxt-codegen = { workspace = true }
 subxt-metadata = { workspace = true }
 test-runtime = { workspace = true }

--- a/testing/no-std-tests/Cargo.lock
+++ b/testing/no-std-tests/Cargo.lock
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-metadata"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "derive_more",
  "frame-metadata",
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-signer"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "bip39",
  "cfg-if",

--- a/testing/wasm-lightclient-tests/Cargo.lock
+++ b/testing/wasm-lightclient-tests/Cargo.lock
@@ -2311,7 +2311,7 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "subxt"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "base58",
@@ -2345,7 +2345,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-codegen"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "frame-metadata 16.0.0",
  "getrandom",
@@ -2365,7 +2365,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-lightclient"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "futures",
  "futures-timer",
@@ -2390,7 +2390,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "darling 0.20.8",
  "parity-scale-codec",
@@ -2403,7 +2403,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-metadata"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "derive_more",
  "frame-metadata 16.0.0",


### PR DESCRIPTION
## [0.35.0] - 2024-03-21

This release contains several fixes, adds `no_std` support to a couple of crates (`subxt-signer` and `subxt-metadata`) and introduces a few quality of life improvements, which I'll quickly cover:

### Reworked light client ([#1475](https://github.com/paritytech/subxt/pull/1475))

This PR reworks the light client interface. The "basic" usage of connecting to a parachain now looks like this:

```rust
#[subxt::subxt(runtime_metadata_path = "../artifacts/polkadot_metadata_small.scale")]
pub mod polkadot {}

use subxt::lightclient::LightClient;

// Instantiate a light client with the Polkadot relay chain given its chain spec.
let (lightclient, polkadot_rpc) = LightClient::relay_chain(POLKADOT_SPEC)?;
// Connect the light client to some parachain by giving a chain spec for it.
let asset_hub_rpc = lightclient.parachain(ASSET_HUB_SPEC)?;

// Now, we can create Subxt clients from these Smoldot backed RPC clients:
let polkadot_api = OnlineClient::<PolkadotConfig>::from_rpc_client(polkadot_rpc).await?;
let asset_hub_api = OnlineClient::<PolkadotConfig>::from_rpc_client(asset_hub_rpc).await?;
```

This interface mirrors the requirement that we must connect to a relay chain before we can connect to a parachain. It also moves the light client specific logic into an `RpcClientT` implementation, rather than exposing it as a `subxt::client::LightClient`.

### Typed Storage Keys ([#1419](https://github.com/paritytech/subxt/pull/1419))

This PR changes the storage interface so that, where possible, we now also decode the storage keys as well as the values when iterating over storage entries:

```rust
#[subxt::subxt(runtime_metadata_path = "../artifacts/polkadot_metadata_small.scale")]
pub mod polkadot {}

// Create a new API client, configured to talk to Polkadot nodes.
let api = OnlineClient::<PolkadotConfig>::new().await?;

// Build a storage query to iterate over account information.
let storage_query = polkadot::storage().system().account_iter();

// Get back an iterator of results (here, we are fetching 10 items at
// a time from the node, but we always iterate over one at a time).
let mut results = api.storage().at_latest().await?.iter(storage_query).await?;

while let Some(Ok(kv)) = results.next().await {
    // We used to get a tuple of key bytes + value. Now we get back a
    // `kv` struct containing the bytes and value as well as the actual
    // decoded keys:
    println!("Decoded key(s): {:?}", kv.keys);
    println!("Key bytes: 0x{}", hex::encode(&kv.key_bytes));
    println!("Value: {:?}", kv.value);
}
```

When using the static interface, keys come back as a tuple of values corresponding to the different hashers used in constructing the key. When using a dynamic interface, keys will be encoded/decoded from the type given so long as it implements `subxt::storage::StorageKey`, eg `Vec<scale_value::Value>`.

### Extrinsic Params Refinement ([#1439](https://github.com/paritytech/subxt/pull/1439))

Prior to this PR, one could configure extrinsic signed extensions by providing some params like so:

```rust
// Configure the transaction parameters; we give a small tip and set the
// transaction to live for 32 blocks from the `latest_block` above:
let tx_params = Params::new()
    .tip(1_000)
    .mortal(latest_block.header(), 32)
    .build();

let hash = api.tx().sign_and_submit(&tx, &from, tx_params).await?;
```

If you want to customize the account nonce, you'd use a different call like `create_signed_with_nonce` instead.

One of the downsides of the above approach is that, if you don't provide any explicit params, transactions will be immortal by default (because the signed extensions didn't have the information to do any better).

Now, with the help of a `RefineParams` trait, transactions will default to being mortal and living for 32 blocks unless an explicit mortality is provided as above.

One notable change is that the offline-only `create_signed_with_nonce` and `create_partial_signed_with_nonce` functions have lost the `_with_nonce` suffix. Since we can't discover nonce/mortality settings offline, you should now provide `Params` and set an explicit nonce (and mortality, if you like) when using these calls, otherwise the nonce will be set to 0 and the mortality to `Immortal`.

For a full list of changes, please see the following:

### Added

- Reworked light client ([#1475](https://github.com/paritytech/subxt/pull/1475))
- `no_std` compatibility for `subxt-signer` ([#1477](https://github.com/paritytech/subxt/pull/1477))
- Typed Storage Keys ([#1419](https://github.com/paritytech/subxt/pull/1419))
- Extrinsic Params Refinement ([#1439](https://github.com/paritytech/subxt/pull/1439))
- Make storage_page_size for the LegacyBackend configurable ([#1458](https://github.com/paritytech/subxt/pull/1458))
- `no_std` compatibility for `subxt-metadata` ([#1401](https://github.com/paritytech/subxt/pull/1401))
- Experimental `reconnecting-rpc-client` ([#1396](https://github.com/paritytech/subxt/pull/1396))

### Changed

- `scale-type-resolver` integration ([#1460](https://github.com/paritytech/subxt/pull/1460))
- subxt: Derive `std::cmp` traits for subxt payloads and addresses ([#1429](https://github.com/paritytech/subxt/pull/1429))
- CLI: Return error on wrongly specified type paths ([#1397](https://github.com/paritytech/subxt/pull/1397))
- rpc v2: chainhead support multiple finalized block hashes in `FollowEvent::Initialized` ([#1476](https://github.com/paritytech/subxt/pull/1476))
- rpc v2: rename transaction to transactionWatch ([#1399](https://github.com/paritytech/subxt/pull/1399))

### Fixed

- Avoid a panic in case we try decoding naff bytes ([#1444](https://github.com/paritytech/subxt/pull/1444))
- Fix error mapping to wrong transaction status ([#1445](https://github.com/paritytech/subxt/pull/1445))
- Update DispatchError to match latest in polkadot-sdk ([#1442](https://github.com/paritytech/subxt/pull/1442))
- Handle errors when fetching storage keys from Unstablebackend ([#1440](https://github.com/paritytech/subxt/pull/1440))
- Swap type aliases around to be semantically correct ([#1441](https://github.com/paritytech/subxt/pull/1441))
