### PR TITLE
storage_type: Strip key proper hash and entry bytes (32 instead of 16)

### DIFF
--- a/subxt/src/storage/storage_type.rs
+++ b/subxt/src/storage/storage_type.rs
@@ -314,10 +314,10 @@ where
     }
 }
 
-/// Strips the first 16 bytes (8 for the pallet hash, 8 for the entry hash) off some storage address bytes.
+/// Strips the first 32 bytes (16 for the pallet hash, 16 for the entry hash) off some storage address bytes.
 fn strip_storage_addess_root_bytes(address_bytes: &mut &[u8]) -> Result<(), StorageAddressError> {
-    if address_bytes.len() >= 16 {
-        *address_bytes = &address_bytes[16..];
+    if address_bytes.len() >= 32 {
+        *address_bytes = &address_bytes[32..];
         Ok(())
     } else {
         Err(StorageAddressError::UnexpectedAddressBytes)

--- a/subxt/src/storage/storage_type.rs
+++ b/subxt/src/storage/storage_type.rs
@@ -255,7 +255,7 @@ where
 
                     let key_bytes = kv.key;
                     let cursor = &mut &key_bytes[..];
-                    strip_storage_addess_root_bytes(cursor)?;
+                    strip_storage_address_root_bytes(cursor)?;
 
                     let keys = <Address::Keys as StorageKey>::decode_storage_key(
                         cursor,
@@ -315,7 +315,7 @@ where
 }
 
 /// Strips the first 32 bytes (16 for the pallet hash, 16 for the entry hash) off some storage address bytes.
-fn strip_storage_addess_root_bytes(address_bytes: &mut &[u8]) -> Result<(), StorageAddressError> {
+fn strip_storage_address_root_bytes(address_bytes: &mut &[u8]) -> Result<(), StorageAddressError> {
     if address_bytes.len() >= 32 {
         *address_bytes = &address_bytes[32..];
         Ok(())

--- a/testing/integration-tests/src/full_client/storage/mod.rs
+++ b/testing/integration-tests/src/full_client/storage/mod.rs
@@ -237,7 +237,7 @@ async fn storage_pallet_storage_version() -> Result<(), subxt::Error> {
 }
 
 #[subxt_test]
-async fn storage_decode_keys() -> Result<(), subxt::Error> {
+async fn storage_iter_decode_keys() -> Result<(), subxt::Error> {
     use futures::StreamExt;
 
     let ctx = test_context().await;

--- a/testing/integration-tests/src/full_client/storage/mod.rs
+++ b/testing/integration-tests/src/full_client/storage/mod.rs
@@ -235,3 +235,54 @@ async fn storage_pallet_storage_version() -> Result<(), subxt::Error> {
         .await?;
     Ok(())
 }
+
+#[subxt_test]
+async fn storage_decode_keys() -> Result<(), subxt::Error> {
+    use futures::StreamExt;
+
+    let ctx = test_context().await;
+    let api = ctx.client();
+
+    let storage_static = node_runtime::storage().system().account_iter();
+    let results_static = api
+        .storage()
+        .at_latest()
+        .await?
+        .iter(storage_static)
+        .await?;
+
+    let storage_dynamic = subxt::dynamic::storage("System", "Account", vec![]);
+    let results_dynamic = api
+        .storage()
+        .at_latest()
+        .await?
+        .iter(storage_dynamic)
+        .await?;
+
+    // Even the testing node should have more than 3 accounts registered.
+    let results_static = results_static.take(3).collect::<Vec<_>>().await;
+    let results_dynamic = results_dynamic.take(3).collect::<Vec<_>>().await;
+
+    assert_eq!(results_static.len(), 3);
+    assert_eq!(results_dynamic.len(), 3);
+
+    let twox_system = sp_core::twox_128("System".as_bytes());
+    let twox_account = sp_core::twox_128("Account".as_bytes());
+
+    for (static_kv, dynamic_kv) in results_static.into_iter().zip(results_dynamic.into_iter()) {
+        let static_kv = static_kv?;
+        let dynamic_kv = dynamic_kv?;
+
+        // We only care about the underlying key bytes.
+        assert_eq!(static_kv.key_bytes, dynamic_kv.key_bytes);
+
+        let bytes = static_kv.key_bytes;
+        assert!(bytes.len() > 32);
+
+        // The first 16 bytes should be the twox hash of "System" and the next 16 bytes should be the twox hash of "Account".
+        assert_eq!(&bytes[..16], &twox_system[..]);
+        assert_eq!(&bytes[16..32], &twox_account[..]);
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
This PR ensures that we can properly decode storage key addresses.

There was an issue confirmed by https://github.com/paritytech/subxt/issues/1517, where the decoding of keys for dynamic storage queries would always fail at:

https://github.com/paritytech/subxt/blob/75c905dcb7ce61832d4d6395ffd2cbd7f28a89a6/subxt/src/storage/storage_type.rs#L260-L264

After investigating the code path, the error is coming from the following lines: 
https://github.com/paritytech/subxt/blob/75c905dcb7ce61832d4d6395ffd2cbd7f28a89a6/core/src/storage/storage_key.rs#L272-L275

The check appeared to be correct, as well as consuming hasher keys via `consume_hash_returning_key_bytes`.

After inspecting the key address bytes, we wrongly assumed the storage prefix bytes length.

Our storage keys start with the following:

```
twox_128(storage prefix) ++ twox_128(storage entry name)
```

In the issue, it is `twox_128(System) ++ twox_128(Accounts)`.

The output of the twox is: [16 bytes](https://paritytech.github.io/polkadot-sdk/master/frame_support/struct.Twox128.html#associatedtype.Output), not 8 as stated and assumed in our code base.

### Testing Done
- reproduced the issue via storage_iter_dynamic example
- Compared addr bytes with expected prefix:
  - twox_128("System"): 26aa394eea5630e07c48ae0c9558cef7
  - twox_128("Account"): b99d880ec681799c0cf30e8886371da9


Closes: https://github.com/paritytech/subxt/issues/1517