### PR TITLE
Swap BinaryHeap for Vec to avoid Ord constraint issue

### DIFF
--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -391,7 +391,7 @@ fn default_substitutes(crate_path: &syn::Path) -> TypeSubstitutes {
         ),
         (
             parse_quote!(BinaryHeap),
-            parse_quote!(#crate_path::utils::KeyedVec),
+            parse_quote!(#crate_path::alloc::vec::Vec),
         ),
         (
             parse_quote!(BTreeSet),

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -348,7 +348,7 @@ fn default_derives(crate_path: &syn::Path) -> DerivesRegistry {
 fn default_substitutes(crate_path: &syn::Path) -> TypeSubstitutes {
     let mut type_substitutes = TypeSubstitutes::new();
 
-    let defaults: [(syn::Path, syn::Path); 11] = [
+    let defaults: [(syn::Path, syn::Path); 12] = [
         (
             parse_quote!(bitvec::order::Lsb0),
             parse_quote!(#crate_path::utils::bits::Lsb0),
@@ -387,6 +387,10 @@ fn default_substitutes(crate_path: &syn::Path) -> TypeSubstitutes {
         // suitable type params) avoids these issues.
         (
             parse_quote!(BTreeMap),
+            parse_quote!(#crate_path::utils::KeyedVec),
+        ),
+        (
+            parse_quote!(BinaryHeap),
             parse_quote!(#crate_path::utils::KeyedVec),
         ),
         (


### PR DESCRIPTION
Substitute BinaryHeap for Vec in the same way that we do for BTreeMap/Set to avoid issues with the `Ord` constraint on the generic type (because this may be a generated type, and we don't automatically apply `Ord` to generated types).

Now that we have recursive derives, we might be able to be smarter about this sort of thing in the future by autoamtically recursively deriving Ord on the relevant types (which should be OK because it would very likely have existed on the ndoe side anyway to be using such types)

Closes #1515 