### PR TITLE
Remove dupe storage item if we get one back, to be compatible with Smoldot + legacy RPCs

### DIFF
--- a/subxt/src/backend/legacy/mod.rs
+++ b/subxt/src/backend/legacy/mod.rs
@@ -379,6 +379,11 @@ pub struct StorageFetchDescendantKeysStream<T: Config> {
     storage_page_size: u32,
     // What key do we start paginating from? None = from the beginning.
     pagination_start_key: Option<Vec<u8>>,
+    // // What key did we see last? In Smoldot, the legacy storage API will hand
+    // // back the `start_key` (ie the key we saw last time) as the first key,
+    // // whereas in Substrate it will not. Here we'll want to skip over it to avoid
+    // // returning it twice.
+    // last_seen_key: Option<Vec<u8>>,
     // Keys, future and cached:
     keys_fut: Option<Pin<Box<dyn Future<Output = Result<Vec<Vec<u8>>, Error>> + Send + 'static>>>,
     // Set to true when we're done:
@@ -405,7 +410,17 @@ impl<T: Config> Stream for StorageFetchDescendantKeysStream<T> {
                 };
 
                 match keys {
-                    Ok(keys) => {
+                    Ok(mut keys) => {
+                        if this.pagination_start_key.is_some()
+                            && keys.first() == this.pagination_start_key.as_ref()
+                        {
+                            // Currently, Smoldot returns the "start key" as the first key in the input
+                            // (see https://github.com/smol-dot/smoldot/issues/1692), whereas Substrate doesn't.
+                            // We don't expect the start key to be returned either (since it was the last key of prev
+                            // iteration), so remove it if we see it. This `remove()` method isn't very efficient but
+                            // this will be a non issue with the RPC V2 APIs or if Smoldot aligns with Substrate anyway.
+                            keys.remove(0);
+                        }
                         if keys.is_empty() {
                             // No keys left; we're done!
                             this.done = true;
@@ -428,7 +443,7 @@ impl<T: Config> Stream for StorageFetchDescendantKeysStream<T> {
             let key = this.key.clone();
             let at = this.at;
             let storage_page_size = this.storage_page_size;
-            let pagination_start_key = this.pagination_start_key.take();
+            let pagination_start_key = this.pagination_start_key.clone();
             let keys_fut = async move {
                 methods
                     .state_get_keys_paged(

--- a/subxt/src/backend/legacy/mod.rs
+++ b/subxt/src/backend/legacy/mod.rs
@@ -379,11 +379,6 @@ pub struct StorageFetchDescendantKeysStream<T: Config> {
     storage_page_size: u32,
     // What key do we start paginating from? None = from the beginning.
     pagination_start_key: Option<Vec<u8>>,
-    // // What key did we see last? In Smoldot, the legacy storage API will hand
-    // // back the `start_key` (ie the key we saw last time) as the first key,
-    // // whereas in Substrate it will not. Here we'll want to skip over it to avoid
-    // // returning it twice.
-    // last_seen_key: Option<Vec<u8>>,
     // Keys, future and cached:
     keys_fut: Option<Pin<Box<dyn Future<Output = Result<Vec<Vec<u8>>, Error>> + Send + 'static>>>,
     // Set to true when we're done:


### PR DESCRIPTION
Smoldot returns the provided `start_key` when fetching storage items (see https://github.com/smol-dot/smoldot/issues/1692), whereas we don't expect this back from Substrate (it's badly named really; `start_key` does imply it will be handed back to me).

In Subxt we remove such an entry if we find it when iterating over storage entries, to avoid duplicate entries being returned.

Closes #1453, closes #1525