### PR TITLE
Stabilize transactionWatch methods

### DIFF
--- a/subxt/src/backend/unstable/mod.rs
+++ b/subxt/src/backend/unstable/mod.rs
@@ -477,7 +477,7 @@ impl<T: Config + Send + Sync + 'static> Backend<T> for UnstableBackend<T> {
         // Then, submit the transaction.
         let mut tx_progress = self
             .methods
-            .transaction_watch_v1_submit_and_watch(extrinsic)
+            .transactionwatch_v1_submit_and_watch(extrinsic)
             .await?;
 
         let mut seen_blocks = HashMap::new();

--- a/subxt/src/backend/unstable/mod.rs
+++ b/subxt/src/backend/unstable/mod.rs
@@ -477,7 +477,7 @@ impl<T: Config + Send + Sync + 'static> Backend<T> for UnstableBackend<T> {
         // Then, submit the transaction.
         let mut tx_progress = self
             .methods
-            .transaction_unstable_submit_and_watch(extrinsic)
+            .transaction_watch_v1_submit_and_watch(extrinsic)
             .await?;
 
         let mut seen_blocks = HashMap::new();

--- a/subxt/src/backend/unstable/rpc_methods.rs
+++ b/subxt/src/backend/unstable/rpc_methods.rs
@@ -272,7 +272,7 @@ impl<T: Config> UnstableRpcMethods<T> {
     }
 
     /// Attempt to submit a transaction, returning events about its progress.
-    pub async fn transaction_watch_v1_submit_and_watch(
+    pub async fn transactionwatch_v1_submit_and_watch(
         &self,
         tx: &[u8],
     ) -> Result<TransactionSubscription<T::Hash>, Error> {

--- a/subxt/src/backend/unstable/rpc_methods.rs
+++ b/subxt/src/backend/unstable/rpc_methods.rs
@@ -272,16 +272,16 @@ impl<T: Config> UnstableRpcMethods<T> {
     }
 
     /// Attempt to submit a transaction, returning events about its progress.
-    pub async fn transaction_unstable_submit_and_watch(
+    pub async fn transaction_watch_v1_submit_and_watch(
         &self,
         tx: &[u8],
     ) -> Result<TransactionSubscription<T::Hash>, Error> {
         let sub = self
             .client
             .subscribe(
-                "transactionWatch_unstable_submitAndWatch",
+                "transactionWatch_v1_submitAndWatch",
                 rpc_params![to_hex(tx)],
-                "transactionWatch_unstable_unwatch",
+                "transactionWatch_v1_unwatch",
             )
             .await?;
 

--- a/testing/integration-tests/src/full_client/client/unstable_rpcs.rs
+++ b/testing/integration-tests/src/full_client/client/unstable_rpcs.rs
@@ -259,7 +259,7 @@ async fn chainspec_v1_properties() {
 
 #[cfg(fullclient)]
 #[subxt_test]
-async fn transaction_watch_v1_submit_and_watch() {
+async fn transactionwatch_v1_submit_and_watch() {
     let ctx = test_context().await;
     let rpc = ctx.unstable_rpc_methods().await;
 
@@ -274,7 +274,7 @@ async fn transaction_watch_v1_submit_and_watch() {
 
     // Test submitting it:
     let mut sub = rpc
-        .transaction_watch_v1_submit_and_watch(&tx_bytes)
+        .transactionwatch_v1_submit_and_watch(&tx_bytes)
         .await
         .unwrap();
 

--- a/testing/integration-tests/src/full_client/client/unstable_rpcs.rs
+++ b/testing/integration-tests/src/full_client/client/unstable_rpcs.rs
@@ -259,7 +259,7 @@ async fn chainspec_v1_properties() {
 
 #[cfg(fullclient)]
 #[subxt_test]
-async fn transaction_unstable_submit_and_watch() {
+async fn transaction_watch_v1_submit_and_watch() {
     let ctx = test_context().await;
     let rpc = ctx.unstable_rpc_methods().await;
 
@@ -274,7 +274,7 @@ async fn transaction_unstable_submit_and_watch() {
 
     // Test submitting it:
     let mut sub = rpc
-        .transaction_unstable_submit_and_watch(&tx_bytes)
+        .transaction_watch_v1_submit_and_watch(&tx_bytes)
         .await
         .unwrap();
 


### PR DESCRIPTION
This PR stabilizes the transactionWatch methods in response to:
- https://github.com/paritytech/polkadot-sdk/pull/4171

cc @paritytech/subxt-team 