### PR TITLE
Stabilize transactionBroadcast methods

### DIFF
--- a/subxt/src/backend/unstable/rpc_methods.rs
+++ b/subxt/src/backend/unstable/rpc_methods.rs
@@ -289,24 +289,24 @@ impl<T: Config> UnstableRpcMethods<T> {
     }
 
     /// Broadcast the transaction on the p2p network until the
-    /// [`Self::transaction_unstable_stop`] is called.
+    /// [`Self::transaction_v1_stop`] is called.
     ///
     /// Returns an operation ID that can be used to stop the broadcasting process.
     /// Returns `None` if the server cannot handle the request at the moment.
-    pub async fn transaction_unstable_broadcast(&self, tx: &[u8]) -> Result<Option<String>, Error> {
+    pub async fn transaction_v1_broadcast(&self, tx: &[u8]) -> Result<Option<String>, Error> {
         self.client
-            .request("transaction_unstable_broadcast", rpc_params![to_hex(tx)])
+            .request("transaction_v1_broadcast", rpc_params![to_hex(tx)])
             .await
     }
 
     /// Stop the broadcasting process of the transaction.
     ///
-    /// The operation ID is obtained from the [`Self::transaction_unstable_broadcast`] method.
+    /// The operation ID is obtained from the [`Self::transaction_v1_broadcast`] method.
     ///
     /// Returns an error if the operation ID does not correspond to any active transaction for this connection.
-    pub async fn transaction_unstable_stop(&self, operation_id: &str) -> Result<(), Error> {
+    pub async fn transaction_v1_stop(&self, operation_id: &str) -> Result<(), Error> {
         self.client
-            .request("transaction_unstable_stop", rpc_params![operation_id])
+            .request("transaction_v1_stop", rpc_params![operation_id])
             .await
     }
 }

--- a/testing/integration-tests/src/full_client/client/unstable_rpcs.rs
+++ b/testing/integration-tests/src/full_client/client/unstable_rpcs.rs
@@ -318,7 +318,7 @@ async fn next_operation_event<
 }
 
 #[tokio::test]
-async fn transaction_unstable_broadcast() {
+async fn transaction_v1_broadcast() {
     let bob = dev::bob();
     let bob_address: MultiAddress<AccountId32, u32> = bob.public_key().into();
 
@@ -346,7 +346,7 @@ async fn transaction_unstable_broadcast() {
 
     // Submit the transaction.
     let _operation_id = rpc
-        .transaction_unstable_broadcast(&tx_bytes)
+        .transaction_v1_broadcast(&tx_bytes)
         .await
         .unwrap()
         .expect("Server is not overloaded by 1 tx; qed");
@@ -383,7 +383,7 @@ async fn transaction_unstable_broadcast() {
 }
 
 #[tokio::test]
-async fn transaction_unstable_stop() {
+async fn transaction_v1_stop() {
     let bob = dev::bob();
     let bob_address: MultiAddress<AccountId32, u32> = bob.public_key().into();
 
@@ -392,7 +392,7 @@ async fn transaction_unstable_stop() {
 
     // Cannot stop an operation that was not started.
     let _err = rpc
-        .transaction_unstable_stop("non-existent-operation-id")
+        .transaction_v1_stop("non-existent-operation-id")
         .await
         .unwrap_err();
 
@@ -409,15 +409,12 @@ async fn transaction_unstable_stop() {
 
     // Submit the transaction.
     let operation_id = rpc
-        .transaction_unstable_broadcast(&tx_bytes)
+        .transaction_v1_broadcast(&tx_bytes)
         .await
         .unwrap()
         .expect("Server is not overloaded by 1 tx; qed");
 
-    rpc.transaction_unstable_stop(&operation_id).await.unwrap();
+    rpc.transaction_v1_stop(&operation_id).await.unwrap();
     // Cannot stop it twice.
-    let _err = rpc
-        .transaction_unstable_stop(&operation_id)
-        .await
-        .unwrap_err();
+    let _err = rpc.transaction_v1_stop(&operation_id).await.unwrap_err();
 }


### PR DESCRIPTION
This PR stabilizes the transactionBroadcast methods in response to:
- https://github.com/paritytech/polkadot-sdk/pull/4169

cc @paritytech/subxt-team 