### PR TITLE
config: Add Debug Clone for common configs

### DIFF
--- a/core/src/config/polkadot.rs
+++ b/core/src/config/polkadot.rs
@@ -11,6 +11,7 @@ pub use crate::utils::{AccountId32, MultiAddress, MultiSignature};
 pub use primitive_types::{H256, U256};
 
 /// Default set of commonly used types by Polkadot nodes.
+#[derive(Debug, Clone)]
 pub enum PolkadotConfig {}
 
 impl Config for PolkadotConfig {

--- a/core/src/config/polkadot.rs
+++ b/core/src/config/polkadot.rs
@@ -11,7 +11,7 @@ pub use crate::utils::{AccountId32, MultiAddress, MultiSignature};
 pub use primitive_types::{H256, U256};
 
 /// Default set of commonly used types by Polkadot nodes.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum PolkadotConfig {}
 
 impl Config for PolkadotConfig {

--- a/core/src/config/polkadot.rs
+++ b/core/src/config/polkadot.rs
@@ -11,7 +11,9 @@ pub use crate::utils::{AccountId32, MultiAddress, MultiSignature};
 pub use primitive_types::{H256, U256};
 
 /// Default set of commonly used types by Polkadot nodes.
-#[derive(Debug, Clone, Copy)]
+// Note: The trait implementations exist just to make life easier,
+// but shouldn't strictly be necessary since users can't instantiate this type.
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub enum PolkadotConfig {}
 
 impl Config for PolkadotConfig {

--- a/core/src/config/substrate.rs
+++ b/core/src/config/substrate.rs
@@ -16,6 +16,7 @@ pub use primitive_types::{H256, U256};
 /// Default set of commonly used types by Substrate runtimes.
 // Note: We only use this at the type level, so it should be impossible to
 // create an instance of it.
+#[derive(Debug, Clone)]
 pub enum SubstrateConfig {}
 
 impl Config for SubstrateConfig {

--- a/core/src/config/substrate.rs
+++ b/core/src/config/substrate.rs
@@ -16,7 +16,7 @@ pub use primitive_types::{H256, U256};
 /// Default set of commonly used types by Substrate runtimes.
 // Note: We only use this at the type level, so it should be impossible to
 // create an instance of it.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum SubstrateConfig {}
 
 impl Config for SubstrateConfig {

--- a/core/src/config/substrate.rs
+++ b/core/src/config/substrate.rs
@@ -16,7 +16,9 @@ pub use primitive_types::{H256, U256};
 /// Default set of commonly used types by Substrate runtimes.
 // Note: We only use this at the type level, so it should be impossible to
 // create an instance of it.
-#[derive(Debug, Clone, Copy)]
+// The trait implementations exist just to make life easier,
+// but shouldn't strictly be necessary since users can't instantiate this type.
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub enum SubstrateConfig {}
 
 impl Config for SubstrateConfig {


### PR DESCRIPTION
This tiny PR implements `Debug, Clone` for `SubstrateConfig` and `PolkadotConfig`.

This might be useful for developers that have wrappers over these types, or that store these types in other structs.

cc @AndreiEres let me know if this solves the issue with debugging types from polkadot-interceptor 🙏 