### PR TITLE
Update deps to use `scale-type-resolver` 0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3734,8 +3734,6 @@ dependencies = [
 [[package]]
 name = "scale-decode"
 version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc79ba56a1c742f5aeeed1f1801f3edf51f7e818f0a54582cac6f131364ea7b"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
@@ -3749,8 +3747,6 @@ dependencies = [
 [[package]]
 name = "scale-decode-derive"
 version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5398fdb3c7bea3cb419bac4983aadacae93fe1a7b5f693f4ebd98c3821aad7a5"
 dependencies = [
  "darling 0.14.4",
  "proc-macro2",
@@ -3761,8 +3757,6 @@ dependencies = [
 [[package]]
 name = "scale-encode"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628800925a33794fb5387781b883b5e14d130fece9af5a63613867b8de07c5c7"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
@@ -3776,8 +3770,6 @@ dependencies = [
 [[package]]
 name = "scale-encode-derive"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a304e1af7cdfbe7a24e08b012721456cc8cecdedadc14b3d10513eada63233c"
 dependencies = [
  "darling 0.14.4",
  "proc-macro-crate 1.3.1",
@@ -3857,8 +3849,6 @@ dependencies = [
 [[package]]
 name = "scale-value"
 version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c07ccfee963104335c971aaf8b7b0e749be8569116322df23f1f75c4ca9e4a28"
 dependencies = [
  "base58",
  "blake2",
@@ -6259,3 +6249,7 @@ dependencies = [
  "quote",
  "syn 2.0.58",
 ]
+
+[[patch.unused]]
+name = "scale-type-resolver"
+version = "0.2.0"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,9 +81,9 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.16"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "android-tzdata"
@@ -165,9 +165,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
+checksum = "f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519"
 
 [[package]]
 name = "ark-bls12-377"
@@ -340,24 +340,23 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "async-channel"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28243a43d821d11341ab73c80bed182dc015c514b951616cf79bd4af39af0c3"
+checksum = "136d4d23bcc79e27423727b36823d86233aad06dfea531837b038394d11e9928"
 dependencies = [
  "concurrent-queue",
  "event-listener 5.3.0",
- "event-listener-strategy 0.5.1",
+ "event-listener-strategy 0.5.2",
  "futures-core",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "async-executor"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f98c37cf288e302c16ef6c8472aad1e034c6c84ce5ea7b8101c98eb4a802fee"
+checksum = "b10202063978b3351199d68f8b22c4e47e4b1b822f8d43fd862d5ea8c006b29a"
 dependencies = [
- "async-lock 3.3.0",
  "async-task",
  "concurrent-queue",
  "fastrand",
@@ -367,11 +366,11 @@ dependencies = [
 
 [[package]]
 name = "async-fs"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc19683171f287921f2405677dd2ed2549c3b3bda697a563ebc3a121ace2aba1"
+checksum = "ebcd09b382f40fcd159c2d695175b2ae620ffa5f3bd6f664131efff4e8b9e04a"
 dependencies = [
- "async-lock 3.3.0",
+ "async-lock",
  "blocking",
  "futures-lite",
 ]
@@ -382,26 +381,17 @@ version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcccb0f599cfa2f8ace422d3555572f47424da5648a4382a9dd0310ff8210884"
 dependencies = [
- "async-lock 3.3.0",
+ "async-lock",
  "cfg-if",
  "concurrent-queue",
  "futures-io",
  "futures-lite",
  "parking",
  "polling",
- "rustix 0.38.32",
+ "rustix 0.38.34",
  "slab",
  "tracing",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "async-lock"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
-dependencies = [
- "event-listener 2.5.3",
 ]
 
 [[package]]
@@ -428,47 +418,47 @@ dependencies = [
 
 [[package]]
 name = "async-process"
-version = "2.2.0"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d999d925640d51b662b7b4e404224dd81de70f4aa4a199383c2c5e5b86885fa3"
+checksum = "a53fc6301894e04a92cb2584fedde80cb25ba8e02d9dc39d4a87d036e22f397d"
 dependencies = [
  "async-channel",
  "async-io",
- "async-lock 3.3.0",
+ "async-lock",
  "async-signal",
  "async-task",
  "blocking",
  "cfg-if",
  "event-listener 5.3.0",
  "futures-lite",
- "rustix 0.38.32",
+ "rustix 0.38.34",
  "tracing",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "async-signal"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e47d90f65a225c4527103a8d747001fc56e375203592b25ad103e1ca13124c5"
+checksum = "afe66191c335039c7bb78f99dc7520b0cbb166b3a1cb33a03f53d8a1c6f2afda"
 dependencies = [
  "async-io",
- "async-lock 2.8.0",
+ "async-lock",
  "atomic-waker",
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix 0.38.32",
+ "rustix 0.38.34",
  "signal-hook-registry",
  "slab",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "async-task"
-version = "4.7.0"
+version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbb36e985947064623dbd357f727af08ffd077f93d696782f3c56365fa2e2799"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -478,7 +468,7 @@ checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -717,18 +707,16 @@ dependencies = [
 
 [[package]]
 name = "blocking"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a37913e8dc4ddcc604f0c6d3bf2887c995153af3611de9e23c352b44c1b9118"
+checksum = "495f7104e962b7356f0aeb34247aca1fe7d2e783b346582db7f2904cb5717e88"
 dependencies = [
  "async-channel",
- "async-lock 3.3.0",
+ "async-lock",
  "async-task",
- "fastrand",
  "futures-io",
  "futures-lite",
  "piper",
- "tracing",
 ]
 
 [[package]]
@@ -785,9 +773,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.92"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2678b2e3449475e95b0aa6f9b506a28e61b3dc8996592b983695e8ebb58a8b41"
+checksum = "d32a725bc159af97c3e629873bb9f88fb8cf8a4867175f76dc987815ea07c83b"
 
 [[package]]
 name = "cfg-if"
@@ -814,14 +802,14 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.37"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d04d43504c61aa6c7531f1871dd0d418d91130162063b789da00fd7057a5e"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits",
- "windows-targets 0.52.4",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -904,7 +892,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -972,9 +960,9 @@ checksum = "2382f75942f4b3be3690fe4f86365e9c853c1587d6ee58212cebf6e2a9ccd101"
 
 [[package]]
 name = "concurrent-queue"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1208,7 +1196,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1256,7 +1244,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1278,7 +1266,7 @@ checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core 0.20.8",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1310,7 +1298,7 @@ checksum = "d65d7ce8132b7c0e54497a4d9a55a1c2a0912a0d786cf894472ba818fba45762"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1321,7 +1309,7 @@ checksum = "62d671cc41a825ebabc75757b62d3d168c577f9149b2d49ece1dad1f72119d25"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1385,7 +1373,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.58",
+ "syn 2.0.60",
  "termcolor",
  "toml",
  "walkdir",
@@ -1485,7 +1473,7 @@ checksum = "7d9ce6874da5d4415896cd45ffbc4d1cfc0c4f9c079427bd870742c30f2f65a9"
 dependencies = [
  "curve25519-dalek 4.1.2",
  "ed25519",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "hex",
  "rand_core 0.6.4",
  "sha2 0.10.8",
@@ -1542,12 +1530,6 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "event-listener"
 version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
@@ -1580,9 +1562,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener-strategy"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "332f51cb23d20b0de8458b86580878211da09bcd4503cb579c225b3d124cabb3"
+checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
 dependencies = [
  "event-listener 5.3.0",
  "pin-project-lite",
@@ -1599,7 +1581,7 @@ dependencies = [
  "prettier-please",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1620,9 +1602,9 @@ checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fastrand"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
+checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "ff"
@@ -1636,9 +1618,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c007b1ae3abe1cb6f85a16305acd418b7ca6343b953633fee2b76d8f108b830f"
+checksum = "38793c55593b33412e3ae40c2c9781ffaa6f438f6f8c10f24e71846fbd7ae01e"
 
 [[package]]
 name = "finito"
@@ -1785,7 +1767,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2021,9 +2003,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash 0.8.11",
  "allocator-api2",
@@ -2182,7 +2164,7 @@ dependencies = [
  "http",
  "hyper",
  "log",
- "rustls 0.21.11",
+ "rustls 0.21.12",
  "rustls-native-certs 0.6.3",
  "tokio",
  "tokio-rustls 0.24.1",
@@ -2280,7 +2262,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -2345,7 +2327,7 @@ dependencies = [
  "subxt-metadata",
  "subxt-signer",
  "subxt-test-macro",
- "syn 2.0.58",
+ "syn 2.0.60",
  "test-runtime",
  "tokio",
  "tracing",
@@ -2616,9 +2598,9 @@ checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "lock_api"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -2636,7 +2618,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc"
 dependencies = [
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -2669,7 +2651,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2cffa4ad52c6f791f4f8b15f0c05f9824b2ced1160e88cc393d64fff9a8ac64"
 dependencies = [
- "rustix 0.38.32",
+ "rustix 0.38.34",
 ]
 
 [[package]]
@@ -2939,9 +2921,9 @@ checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "7e4af0ca4f6caed20e900d564c242b8e5d4903fdacf31d3daf527b66fe6f42fb"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -2949,15 +2931,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -3016,7 +2998,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -3125,7 +3107,7 @@ dependencies = [
  "polkavm-common 0.8.0",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -3137,7 +3119,7 @@ dependencies = [
  "polkavm-common 0.9.0",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -3147,7 +3129,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15e85319a0d5129dc9f021c62607e0804f5fb777a05cdda44d750ac0732def66"
 dependencies = [
  "polkavm-derive-impl 0.8.0",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -3157,20 +3139,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ba81f7b5faac81e528eb6158a6f3c9e0bb1008e0ffa19653bc8dea925ecb429"
 dependencies = [
  "polkavm-derive-impl 0.9.0",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
 name = "polling"
-version = "3.6.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c976a60b2d7e99d6f229e414670a9b85d13ac305cc6d1e9c134de58c5aaaf6"
+checksum = "645493cf344456ef24219d02a768cf1fb92ddf8c92161679ae3d91b91a637be3"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
  "hermit-abi 0.3.9",
  "pin-project-lite",
- "rustix 0.38.32",
+ "rustix 0.38.34",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -3199,7 +3181,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22020dfcf177fcc7bf5deaf7440af371400c67c0de14c399938d8ed4fb4645d3"
 dependencies = [
  "proc-macro2",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -3323,9 +3305,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -3403,9 +3385,9 @@ dependencies = [
 
 [[package]]
 name = "reconnecting-jsonrpsee-ws-client"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1506220461d62d69380b869e65ac1846b38b5357b363b640e46af9672abc7d6"
+checksum = "a89cc4a6f1e641017e300c050f0c4c46a198627fb39ec03e7a028d20256b5e54"
 dependencies = [
  "cfg_aliases",
  "finito",
@@ -3419,11 +3401,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.5.0",
 ]
 
 [[package]]
@@ -3443,7 +3425,7 @@ checksum = "5fddb4f8d99b0a2ebafc65a87a69a7b9875e4b1ae1f00db265d300ef7f28bccc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -3567,9 +3549,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.32"
+version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
  "bitflags 2.5.0",
  "errno",
@@ -3580,9 +3562,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.11"
+version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fecbfb7b1444f477b345853b1fce097a2c6fb637b2bfb87e6bc5db0f043fae4"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
  "ring",
@@ -3592,14 +3574,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.3"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99008d7ad0bbbea527ec27bddbc0e432c5b87d8175178cee68d2eec9c4a1813c"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
 dependencies = [
  "log",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.2",
+ "rustls-webpki 0.102.3",
  "subtle",
  "zeroize",
 ]
@@ -3650,9 +3632,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247"
+checksum = "beb461507cee2c2ff151784c52762cf4d9ff6a61f3e80968600ed24fa837fa54"
 
 [[package]]
 name = "rustls-webpki"
@@ -3666,9 +3648,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.2"
+version = "0.102.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
+checksum = "f3bce581c0dd41bce533ce695a1437fa16a7ab5ac3ccfa99fe1a620a7885eabf"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3721,9 +3703,9 @@ dependencies = [
 
 [[package]]
 name = "scale-bits"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "662d10dcd57b1c2a3c41c9cf68f71fb09747ada1ea932ad961aca7e2ca28315f"
+checksum = "e57b1e7f6b65ed1f04e79a85a57d755ad56d76fdf1e9bddcc9ae14f71fcdcf54"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -3733,7 +3715,9 @@ dependencies = [
 
 [[package]]
 name = "scale-decode"
-version = "0.11.1"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e10e0d345101a013ca3af62c2d44d20213d543cc64d96080c68d931e54360c5"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
@@ -3746,7 +3730,9 @@ dependencies = [
 
 [[package]]
 name = "scale-decode-derive"
-version = "0.11.1"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ab7c6965f4559944d8b957e3a7bedd9f2ff10ac7f55f7bda9dc9b4a0e9fa60c"
 dependencies = [
  "darling 0.14.4",
  "proc-macro2",
@@ -3756,7 +3742,9 @@ dependencies = [
 
 [[package]]
 name = "scale-encode"
-version = "0.6.0"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac89c68dd1142f71a5b97850b9031e9a0d3ce708f5de5e7234cddb3b6fc7c8db"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
@@ -3769,7 +3757,9 @@ dependencies = [
 
 [[package]]
 name = "scale-encode-derive"
-version = "0.6.0"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a4ad472c7c16e4091a08f2f9901a1c117ee865a535b3bfb019e8e53de84ddce"
 dependencies = [
  "darling 0.14.4",
  "proc-macro-crate 1.3.1",
@@ -3806,9 +3796,9 @@ dependencies = [
 
 [[package]]
 name = "scale-type-resolver"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10b800069bfd43374e0f96f653e0d46882a2cb16d6d961ac43bea80f26c76843"
+checksum = "f0cded6518aa0bd6c1be2b88ac81bf7044992f0f154bfbabd5ad34f43512abcb"
 dependencies = [
  "scale-info",
  "smallvec",
@@ -3816,23 +3806,23 @@ dependencies = [
 
 [[package]]
 name = "scale-typegen"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed57b2c642c1e8c905e904c866d16614a3b5621dad323e9b6a6bc902f1380aa9"
+checksum = "e050beece943a0d103a2a248e57fc475e1e68499d9079bdc6c3e76106bc3055e"
 dependencies = [
  "proc-macro2",
  "quote",
  "scale-info",
  "smallvec",
- "syn 2.0.58",
+ "syn 2.0.60",
  "thiserror",
 ]
 
 [[package]]
 name = "scale-typegen-description"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a85be41fdb34abc88f3b13ede67899825b98a08cdf904758e0b18989e8a55418"
+checksum = "ee738c1dc6159972b6a22d0e041b6045dc803d88fd13e12e00adedfd6d41424f"
 dependencies = [
  "anyhow",
  "peekmore",
@@ -3848,7 +3838,9 @@ dependencies = [
 
 [[package]]
 name = "scale-value"
-version = "0.14.1"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9e20eb2f3b02cb16f7ccb575c599f4624567c9ad58206d61995e7fc2a0efb7"
 dependencies = [
  "base58",
  "blake2",
@@ -4005,9 +3997,9 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.198"
+version = "1.0.199"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9846a40c979031340571da2545a4e5b7c4163bdae79b301d5f86d03979451fcc"
+checksum = "0c9f6e76df036c77cd94996771fb40db98187f096dd0b9af39c6c6e452ba966a"
 dependencies = [
  "serde_derive",
 ]
@@ -4023,20 +4015,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.198"
+version = "1.0.199"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
+checksum = "11bd257a6541e141e42ca6d24ae26f7714887b47e89aa739099104c7e4d3b7fc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.115"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
+checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
 dependencies = [
  "itoa",
  "ryu",
@@ -4120,9 +4112,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
@@ -4174,7 +4166,7 @@ dependencies = [
  "async-executor",
  "async-fs",
  "async-io",
- "async-lock 3.3.0",
+ "async-lock",
  "async-net",
  "async-process",
  "blocking",
@@ -4188,7 +4180,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d1eaa97d77be4d026a1e7ffad1bb3b78448763b357ea6f8188d3e6f736a9b9"
 dependencies = [
  "arrayvec 0.7.4",
- "async-lock 3.3.0",
+ "async-lock",
  "atomic-take",
  "base64 0.21.7",
  "bip39",
@@ -4203,7 +4195,7 @@ dependencies = [
  "fnv",
  "futures-lite",
  "futures-util",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "hex",
  "hmac 0.12.1",
  "itertools 0.12.1",
@@ -4243,7 +4235,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5496f2d116b7019a526b1039ec2247dd172b8670633b1a64a614c9ea12c9d8c7"
 dependencies = [
  "async-channel",
- "async-lock 3.3.0",
+ "async-lock",
  "base64 0.21.7",
  "blake2-rfc",
  "derive_more",
@@ -4253,7 +4245,7 @@ dependencies = [
  "futures-channel",
  "futures-lite",
  "futures-util",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "hex",
  "itertools 0.12.1",
  "log",
@@ -4274,9 +4266,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -4395,7 +4387,7 @@ checksum = "48d09fa0a5f7299fb81ee25ae3853d26200f7a348148aed6de76be905c007dbe"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -4527,7 +4519,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -4816,7 +4808,7 @@ dependencies = [
  "subxt",
  "subxt-codegen",
  "subxt-metadata",
- "syn 2.0.58",
+ "syn 2.0.60",
  "thiserror",
  "tokio",
 ]
@@ -4836,7 +4828,7 @@ dependencies = [
  "scale-info",
  "scale-typegen",
  "subxt-metadata",
- "syn 2.0.58",
+ "syn 2.0.60",
  "thiserror",
  "tokio",
 ]
@@ -4852,7 +4844,7 @@ dependencies = [
  "derive-where",
  "derive_more",
  "frame-metadata 16.0.0",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "hex",
  "impl-serde",
  "parity-scale-codec",
@@ -4909,7 +4901,7 @@ dependencies = [
  "quote",
  "scale-typegen",
  "subxt-codegen",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -4921,7 +4913,7 @@ dependencies = [
  "criterion",
  "derive_more",
  "frame-metadata 16.0.0",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "parity-scale-codec",
  "scale-info",
  "sp-crypto-hashing",
@@ -4960,7 +4952,7 @@ name = "subxt-test-macro"
 version = "0.35.0"
 dependencies = [
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -4976,9 +4968,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.58"
+version = "2.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
+checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5005,7 +4997,7 @@ checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
  "fastrand",
- "rustix 0.38.32",
+ "rustix 0.38.34",
  "windows-sys 0.52.0",
 ]
 
@@ -5057,7 +5049,7 @@ checksum = "d1cd413b5d558b4c5bf3680e324a6fa5014e7b7c067a51e69dbdf47eb7148b66"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -5129,7 +5121,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -5138,7 +5130,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls 0.21.11",
+ "rustls 0.21.12",
  "tokio",
 ]
 
@@ -5148,7 +5140,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
 dependencies = [
- "rustls 0.22.3",
+ "rustls 0.22.4",
  "rustls-pki-types",
  "tokio",
 ]
@@ -5188,7 +5180,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.9",
+ "toml_edit 0.22.12",
 ]
 
 [[package]]
@@ -5235,15 +5227,15 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.9"
+version = "0.22.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e40bb779c5187258fd7aad0eb68cb8706a0a81fa712fbea808ab43c4b8374c4"
+checksum = "d3328d4f68a705b2a4498da1d580585d39a6510f98318a2cec3018a7ec61ddef"
 dependencies = [
  "indexmap 2.2.6",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.5",
+ "winnow 0.6.7",
 ]
 
 [[package]]
@@ -5293,7 +5285,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -5671,7 +5663,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
  "wasm-bindgen-shared",
 ]
 
@@ -5705,7 +5697,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5759,9 +5751,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser-nostd"
-version = "0.100.1"
+version = "0.100.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9157cab83003221bfd385833ab587a039f5d6fa7304854042ba358a3b09e0724"
+checksum = "d5a015fe95f3504a94bb1462c717aae75253e39b9dd6c3fb1062c934535c64aa"
 dependencies = [
  "indexmap-nostd",
 ]
@@ -5917,7 +5909,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix 0.38.32",
+ "rustix 0.38.34",
  "windows-sys 0.48.0",
 ]
 
@@ -5939,11 +5931,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
 dependencies = [
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5958,7 +5950,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.4",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -5985,7 +5977,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.4",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -6020,17 +6012,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.4",
- "windows_aarch64_msvc 0.52.4",
- "windows_i686_gnu 0.52.4",
- "windows_i686_msvc 0.52.4",
- "windows_x86_64_gnu 0.52.4",
- "windows_x86_64_gnullvm 0.52.4",
- "windows_x86_64_msvc 0.52.4",
+ "windows_aarch64_gnullvm 0.52.5",
+ "windows_aarch64_msvc 0.52.5",
+ "windows_i686_gnu 0.52.5",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.5",
+ "windows_x86_64_gnu 0.52.5",
+ "windows_x86_64_gnullvm 0.52.5",
+ "windows_x86_64_msvc 0.52.5",
 ]
 
 [[package]]
@@ -6047,9 +6040,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -6065,9 +6058,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6083,9 +6076,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6101,9 +6100,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6119,9 +6118,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6137,9 +6136,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6155,9 +6154,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "winnow"
@@ -6170,9 +6169,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.5"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8"
+checksum = "14b9415ee827af173ebb3f15f9083df5a122eb93572ec28741fb153356ea2578"
 dependencies = [
  "memchr",
 ]
@@ -6227,7 +6226,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -6247,9 +6246,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
-
-[[patch.unused]]
-name = "scale-type-resolver"
-version = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,12 +91,12 @@ proc-macro2 = "1.0.81"
 quote = "1.0.35"
 regex = { version = "1.10.4", default-features = false }
 scale-info = { version = "2.11.0", default-features = false }
-scale-value = { version = "0.14.1", default-features = false }
-scale-bits = { version = "0.5.0", default-features = false }
-scale-decode = { version = "0.11.1", default-features = false }
-scale-encode = { version = "0.6.0", default-features = false }
-scale-typegen = "0.4.2"
-scale-typegen-description = "0.4.3"
+scale-value = { version = "0.15.0", default-features = false }
+scale-bits = { version = "0.6.0", default-features = false }
+scale-decode = { version = "0.12.0", default-features = false }
+scale-encode = { version = "0.7.0", default-features = false }
+scale-typegen = "0.5.0"
+scale-typegen-description = "0.5.0"
 serde = { version = "1.0.198", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.114", default-features = false }
 syn = { version = "2.0.15", features = ["full", "extra-traits"] }
@@ -169,9 +169,3 @@ opt-level = 2
 opt-level = 2
 [profile.test.package.smoldot]
 opt-level = 2
-
-[patch.crates-io]
-scale-type-resolver = { path = "../scale-type-resolver" }
-scale-encode = { path = "../scale-encode/scale-encode" }
-scale-decode = { path = "../scale-decode/scale-decode" }
-scale-value = { path = "../scale-value" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,3 +169,9 @@ opt-level = 2
 opt-level = 2
 [profile.test.package.smoldot]
 opt-level = 2
+
+[patch.crates-io]
+scale-type-resolver = { path = "../scale-type-resolver" }
+scale-encode = { path = "../scale-encode/scale-encode" }
+scale-decode = { path = "../scale-decode/scale-decode" }
+scale-value = { path = "../scale-value" }

--- a/cli/src/commands/explore/pallets/constants.rs
+++ b/cli/src/commands/explore/pallets/constants.rs
@@ -64,11 +64,8 @@ pub fn explore_constants(
         .highlight();
 
     // value
-    let value = scale_value::scale::decode_as_type(
-        &mut constant.value(),
-        constant.ty(),
-        metadata.types(),
-    )?;
+    let value =
+        scale_value::scale::decode_as_type(&mut constant.value(), constant.ty(), metadata.types())?;
     let value = format_scale_value(&value).indent(4);
 
     writedoc!(

--- a/cli/src/commands/explore/pallets/constants.rs
+++ b/cli/src/commands/explore/pallets/constants.rs
@@ -25,7 +25,7 @@ pub fn explore_constants(
         Usage:
             subxt explore pallet {pallet_name} constants <CONSTANT>
                 explore a specific constant of this pallet
-        
+
         {constants}
         "}
     };
@@ -53,7 +53,7 @@ pub fn explore_constants(
         writedoc! {output, "
         Description:
         {doc_string}
-        
+
         "}?;
     }
 
@@ -66,7 +66,7 @@ pub fn explore_constants(
     // value
     let value = scale_value::scale::decode_as_type(
         &mut constant.value(),
-        &constant.ty(),
+        constant.ty(),
         metadata.types(),
     )?;
     let value = format_scale_value(&value).indent(4);

--- a/cli/src/commands/explore/pallets/storage.rs
+++ b/cli/src/commands/explore/pallets/storage.rs
@@ -57,7 +57,7 @@ pub async fn explore_storage(
         Usage:
             subxt explore pallet {pallet_name} storage {storage_entry_placeholder}
                 explore a specific storage entry of this pallet
-        
+
         {storage_entries}
         "}
     };
@@ -139,7 +139,7 @@ pub async fn explore_storage(
         "}?;
     } else {
         writedoc! {output,"
-        
+
         Can be accessed without providing a {key_value_placeholder}.
         "}?;
     }
@@ -164,12 +164,12 @@ pub async fn explore_storage(
             let value = parse_string_into_scale_value(trailing_args)?;
             let value_str = value.indent(4);
             writedoc! {output, "
-    
+
             You submitted the following {key_value_placeholder}:
             {value_str}
             "}?;
 
-            let key_bytes = value.encode_as_type(&type_id, metadata.types())?;
+            let key_bytes = value.encode_as_type(type_id, metadata.types())?;
             let bytes_composite = Value::from_bytes(key_bytes);
             vec![bytes_composite]
         }
@@ -191,7 +191,7 @@ pub async fn explore_storage(
 
     let value = decoded_value_thunk.to_value()?.to_string().highlight();
     writedoc! {output, "
-    
+
     The value of the storage entry is:
         {value}
     "}?;

--- a/cli/src/commands/explore/runtime_apis/mod.rs
+++ b/cli/src/commands/explore/runtime_apis/mod.rs
@@ -27,7 +27,7 @@ use subxt_metadata::RuntimeApiMetadata;
 ///                       exectute is:
 ///                         false => Show input type description + Example Value
 ///                         true  => validate (trailing args + build node connection)
-///                           validation is:  
+///                           validation is:
 ///                             Err => Show Error
 ///                             Ok  => Make a runtime api call witht the provided args.
 ///                               response is:
@@ -51,7 +51,7 @@ pub async fn run<'a>(
         Usage:
             subxt explore api {api_name} <METHOD>
                 explore a specific runtime api method
-        
+
         {methods}
         "}
     };
@@ -63,7 +63,7 @@ pub async fn run<'a>(
             writedoc! {output, "
             Description:
             {doc_string}
-    
+
             "}?;
         }
         writeln!(output, "{}", usage())?;
@@ -89,7 +89,7 @@ pub async fn run<'a>(
         writedoc! {output, "
         Description:
         {doc_string}
-        
+
         "}?;
     }
 
@@ -116,7 +116,7 @@ pub async fn run<'a>(
         formatdoc! {"
         The method expects an {input_value_placeholder} with this shape:
         {fields_description}
-    
+
         For example you could provide this {input_value_placeholder}:
         {fields_example}"}
     };
@@ -156,13 +156,13 @@ pub async fn run<'a>(
             let value_str = value.indent(4);
             // convert to bytes:
             writedoc! {output, "
-            
+
             You submitted the following {input_value_placeholder}:
             {value_str}
             "}?;
             // encode, then decode. This ensures that the scale value is of the correct shape for the param:
-            let bytes = value.encode_as_type(&ty.ty, metadata.types())?;
-            let value = Value::decode_as_type(&mut &bytes[..], &ty.ty, metadata.types())?;
+            let bytes = value.encode_as_type(ty.ty, metadata.types())?;
+            let value = Value::decode_as_type(&mut &bytes[..], ty.ty, metadata.types())?;
             Ok(value)
         })
         .collect::<color_eyre::Result<Vec<Value>>>()?;
@@ -178,7 +178,7 @@ pub async fn run<'a>(
 
     let output_value = output_value.to_value()?.to_string().highlight();
     writedoc! {output, "
-    
+
     Returned value:
         {output_value}
     "}?;

--- a/core/src/blocks/extrinsic_signed_extensions.rs
+++ b/core/src/blocks/extrinsic_signed_extensions.rs
@@ -47,7 +47,7 @@ impl<'a, T: Config> ExtrinsicSignedExtensions<'a, T> {
             let cursor = &mut &bytes[byte_start_idx..];
             if let Err(err) = scale_decode::visitor::decode_with_visitor(
                 cursor,
-                &ty_id,
+                ty_id,
                 metadata.types(),
                 scale_decode::visitor::IgnoreVisitor::new(),
             )
@@ -146,7 +146,7 @@ impl<'a, T: Config> ExtrinsicSignedExtension<'a, T> {
     pub fn value(&self) -> Result<Value<u32>, Error> {
         let value = scale_value::scale::decode_as_type(
             &mut &self.bytes[..],
-            &self.ty_id,
+            self.ty_id,
             self.metadata.types(),
         )?;
         Ok(value)
@@ -163,7 +163,7 @@ impl<'a, T: Config> ExtrinsicSignedExtension<'a, T> {
     }
 
     fn as_type<E: DecodeAsType>(&self) -> Result<E, Error> {
-        let value = E::decode_as_type(&mut &self.bytes[..], &self.ty_id, self.metadata.types())?;
+        let value = E::decode_as_type(&mut &self.bytes[..], self.ty_id, self.metadata.types())?;
         Ok(value)
     }
 }

--- a/core/src/blocks/extrinsics.rs
+++ b/core/src/blocks/extrinsics.rs
@@ -194,7 +194,7 @@ where
                 // Skip over the address, signature and extra fields.
                 scale_decode::visitor::decode_with_visitor(
                     cursor,
-                    &ids.address,
+                    ids.address,
                     metadata.types(),
                     scale_decode::visitor::IgnoreVisitor::new(),
                 )
@@ -203,7 +203,7 @@ where
 
                 scale_decode::visitor::decode_with_visitor(
                     cursor,
-                    &ids.signature,
+                    ids.signature,
                     metadata.types(),
                     scale_decode::visitor::IgnoreVisitor::new(),
                 )
@@ -212,7 +212,7 @@ where
 
                 scale_decode::visitor::decode_with_visitor(
                     cursor,
-                    &ids.extra,
+                    ids.extra,
                     metadata.types(),
                     scale_decode::visitor::IgnoreVisitor::new(),
                 )
@@ -370,7 +370,7 @@ where
             .variant
             .fields
             .iter()
-            .map(|f| scale_decode::Field::new(&f.ty.id, f.name.as_deref()));
+            .map(|f| scale_decode::Field::new(f.ty.id, f.name.as_deref()));
         let decoded =
             scale_value::scale::decode_as_fields(bytes, &mut fields, self.metadata.types())?;
 
@@ -388,7 +388,7 @@ where
                 .variant
                 .fields
                 .iter()
-                .map(|f| scale_decode::Field::new(&f.ty.id, f.name.as_deref()));
+                .map(|f| scale_decode::Field::new(f.ty.id, f.name.as_deref()));
             let decoded =
                 E::decode_as_fields(&mut self.field_bytes(), &mut fields, self.metadata.types())?;
             Ok(Some(decoded))
@@ -403,7 +403,7 @@ where
     pub fn as_root_extrinsic<E: DecodeAsType>(&self) -> Result<E, Error> {
         let decoded = E::decode_as_type(
             &mut &self.call_bytes()[..],
-            &self.metadata.outer_enums().call_enum_ty(),
+            self.metadata.outer_enums().call_enum_ty(),
             self.metadata.types(),
         )?;
 

--- a/core/src/dynamic.rs
+++ b/core/src/dynamic.rs
@@ -67,7 +67,7 @@ impl DecodedValueThunk {
     pub fn to_value(&self) -> Result<DecodedValue, scale_decode::Error> {
         let val = scale_value::scale::decode_as_type(
             &mut &*self.scale_bytes,
-            &self.type_id,
+            self.type_id,
             self.metadata.types(),
         )?;
         Ok(val)
@@ -76,7 +76,7 @@ impl DecodedValueThunk {
     pub fn as_type<T: DecodeAsType>(&self) -> Result<T, scale_decode::Error> {
         T::decode_as_type(
             &mut &self.scale_bytes[..],
-            &self.type_id,
+            self.type_id,
             self.metadata.types(),
         )
     }

--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -272,7 +272,7 @@ impl<T: Config> EventDetails<T> {
             // Skip over the bytes for this field:
             scale_decode::visitor::decode_with_visitor(
                 input,
-                &field_metadata.ty.id,
+                field_metadata.ty.id,
                 metadata.types(),
                 scale_decode::visitor::IgnoreVisitor::new(),
             )
@@ -373,7 +373,7 @@ impl<T: Config> EventDetails<T> {
             .variant
             .fields
             .iter()
-            .map(|f| scale_decode::Field::new(&f.ty.id, f.name.as_deref()));
+            .map(|f| scale_decode::Field::new(f.ty.id, f.name.as_deref()));
 
         let decoded =
             scale_value::scale::decode_as_fields(bytes, &mut fields, self.metadata.types())?;
@@ -390,7 +390,7 @@ impl<T: Config> EventDetails<T> {
                 .variant
                 .fields
                 .iter()
-                .map(|f| scale_decode::Field::new(&f.ty.id, f.name.as_deref()));
+                .map(|f| scale_decode::Field::new(f.ty.id, f.name.as_deref()));
             let decoded =
                 E::decode_as_fields(&mut self.field_bytes(), &mut fields, self.metadata.types())?;
             Ok(Some(decoded))
@@ -407,7 +407,7 @@ impl<T: Config> EventDetails<T> {
 
         let decoded = E::decode_as_type(
             &mut &bytes[..],
-            &self.metadata.outer_enums().event_enum_ty(),
+            self.metadata.outer_enums().event_enum_ty(),
             self.metadata.types(),
         )?;
 

--- a/core/src/metadata/decode_encode_traits.rs
+++ b/core/src/metadata/decode_encode_traits.rs
@@ -22,7 +22,7 @@ impl<T: scale_decode::DecodeAsType> DecodeWithMetadata for T {
         type_id: u32,
         metadata: &Metadata,
     ) -> Result<T, scale_decode::Error> {
-        let val = T::decode_as_type(bytes, &type_id, metadata.types())?;
+        let val = T::decode_as_type(bytes, type_id, metadata.types())?;
         Ok(val)
     }
 }
@@ -46,7 +46,7 @@ impl<T: scale_encode::EncodeAsType> EncodeWithMetadata for T {
         metadata: &Metadata,
         bytes: &mut Vec<u8>,
     ) -> Result<(), scale_encode::Error> {
-        self.encode_as_type_to(&type_id, metadata.types(), bytes)?;
+        self.encode_as_type_to(type_id, metadata.types(), bytes)?;
         Ok(())
     }
 }

--- a/core/src/runtime_api/payload.rs
+++ b/core/src/runtime_api/payload.rs
@@ -108,7 +108,7 @@ impl<ArgsData: EncodeAsFields, ReturnTy: DecodeWithMetadata> Payload
             .ok_or_else(|| MetadataError::RuntimeMethodNotFound((*self.method_name).to_owned()))?;
         let mut fields = api_method
             .inputs()
-            .map(|input| scale_encode::Field::named(&input.ty, &input.name));
+            .map(|input| scale_encode::Field::named(input.ty, &input.name));
 
         self.args_data
             .encode_as_fields_to(&mut fields, metadata.types(), out)?;

--- a/core/src/storage/storage_key.rs
+++ b/core/src/storage/storage_key.rs
@@ -206,7 +206,7 @@ impl<K: ?Sized> StorageKey for StaticStorageKey<K> {
         types: &PortableRegistry,
     ) -> Result<(), Error> {
         let (hasher, ty_id) = hashers.next_or_err()?;
-        let encoded_value = self.bytes.encode_as_type(&ty_id, types)?;
+        let encoded_value = self.bytes.encode_as_type(ty_id, types)?;
         hash_bytes(&encoded_value, hasher, bytes);
         Ok(())
     }
@@ -245,7 +245,7 @@ impl StorageKey for Vec<scale_value::Value> {
     ) -> Result<(), Error> {
         for value in self.iter() {
             let (hasher, ty_id) = hashers.next_or_err()?;
-            let encoded_value = value.encode_as_type(&ty_id, types)?;
+            let encoded_value = value.encode_as_type(ty_id, types)?;
             hash_bytes(&encoded_value, hasher, bytes);
         }
         Ok(())
@@ -264,7 +264,7 @@ impl StorageKey for Vec<scale_value::Value> {
             match consume_hash_returning_key_bytes(bytes, hasher, ty_id, types)? {
                 Some(value_bytes) => {
                     let value =
-                        scale_value::scale::decode_as_type(&mut &*value_bytes, &ty_id, types)?;
+                        scale_value::scale::decode_as_type(&mut &*value_bytes, ty_id, types)?;
                     result.push(value.remove_context());
                 }
                 None => {
@@ -302,7 +302,7 @@ fn consume_hash_returning_key_bytes<'a>(
     if hasher.ends_with_key() {
         scale_decode::visitor::decode_with_visitor(
             bytes,
-            &ty_id,
+            ty_id,
             types,
             IgnoreVisitor::<PortableRegistry>::new(),
         )

--- a/core/src/tx/payload.rs
+++ b/core/src/tx/payload.rs
@@ -152,7 +152,7 @@ impl<CallData: EncodeAsFields> Payload for DefaultPayload<CallData> {
         let mut fields = call
             .fields
             .iter()
-            .map(|f| scale_encode::Field::new(&f.ty.id, f.name.as_deref()));
+            .map(|f| scale_encode::Field::new(f.ty.id, f.name.as_deref()));
 
         self.call_data
             .encode_as_fields_to(&mut fields, metadata.types(), out)

--- a/core/src/utils/bits.rs
+++ b/core/src/utils/bits.rs
@@ -156,7 +156,7 @@ impl<Store, Order, R: TypeResolver> scale_decode::Visitor for DecodedBitsVisitor
     fn unchecked_decode_as_type<'scale, 'info>(
         self,
         input: &mut &'scale [u8],
-        type_id: &R::TypeId,
+        type_id: R::TypeId,
         types: &'info R,
     ) -> scale_decode::visitor::DecodeAsTypeResult<
         Self,
@@ -181,7 +181,7 @@ impl<Store, Order> scale_decode::IntoVisitor for DecodedBits<Store, Order> {
 impl<Store, Order> scale_encode::EncodeAsType for DecodedBits<Store, Order> {
     fn encode_as_type_to<R: TypeResolver>(
         &self,
-        type_id: &R::TypeId,
+        type_id: R::TypeId,
         types: &R,
         out: &mut Vec<u8>,
     ) -> Result<(), scale_encode::Error> {

--- a/core/src/utils/static_type.rs
+++ b/core/src/utils/static_type.rs
@@ -22,7 +22,7 @@ pub struct Static<T>(pub T);
 impl<T: Encode> EncodeAsType for Static<T> {
     fn encode_as_type_to<R: TypeResolver>(
         &self,
-        _type_id: &R::TypeId,
+        _type_id: R::TypeId,
         _types: &R,
         out: &mut Vec<u8>,
     ) -> Result<(), scale_encode::Error> {
@@ -41,7 +41,7 @@ impl<T: Decode, R: TypeResolver> Visitor for StaticDecodeAsTypeVisitor<T, R> {
     fn unchecked_decode_as_type<'scale, 'info>(
         self,
         input: &mut &'scale [u8],
-        _type_id: &R::TypeId,
+        _type_id: R::TypeId,
         _types: &'info R,
     ) -> DecodeAsTypeResult<Self, Result<Self::Value<'scale, 'info>, Self::Error>> {
         use scale_decode::{visitor::DecodeError, Error};

--- a/core/src/utils/unchecked_extrinsic.rs
+++ b/core/src/utils/unchecked_extrinsic.rs
@@ -55,7 +55,7 @@ impl<Address, Call, Signature, Extra> scale_encode::EncodeAsType
 {
     fn encode_as_type_to<R: TypeResolver>(
         &self,
-        type_id: &R::TypeId,
+        type_id: R::TypeId,
         types: &R,
         out: &mut Vec<u8>,
     ) -> Result<(), scale_encode::Error> {
@@ -93,7 +93,7 @@ impl<Address, Call, Signature, Extra, R: TypeResolver> Visitor
     fn unchecked_decode_as_type<'scale, 'info>(
         self,
         input: &mut &'scale [u8],
-        type_id: &R::TypeId,
+        type_id: R::TypeId,
         types: &'info R,
     ) -> DecodeAsTypeResult<Self, Result<Self::Value<'scale, 'info>, Self::Error>> {
         DecodeAsTypeResult::Decoded(Self::Value::decode_as_type(input, type_id, types))

--- a/core/src/utils/wrapper_opaque.rs
+++ b/core/src/utils/wrapper_opaque.rs
@@ -86,7 +86,7 @@ impl<T> EncodeAsType for WrapperKeepOpaque<T> {
                 expected_id: format!("{type_id:?}"),
             }))
         })
-        .visit_composite(|(_type_id,out), _path, _fields| {
+        .visit_composite(|(_type_id, out), _path, _fields| {
             self.data.encode_to(out);
             Ok(())
         });
@@ -111,12 +111,13 @@ impl<T, R: TypeResolver> Visitor for WrapperKeepOpaqueVisitor<T, R> {
         use scale_decode::error::{Error, ErrorKind};
         use scale_decode::visitor::DecodeError;
 
-        if value.name().as_ref() !== Some("WrapperKeepOpaque") {
-            return Err(Error::new(ErrorKind::VisitorDecodeError {
-                DecodeError::TypeResolvingError(
-                    format!("Expected a type named 'WrapperKeepOpaque', got: {:?}", value.name())
-                )
-            ));
+        if value.name() != Some("WrapperKeepOpaque") {
+            return Err(Error::new(ErrorKind::VisitorDecodeError(
+                DecodeError::TypeResolvingError(format!(
+                    "Expected a type named 'WrapperKeepOpaque', got: {:?}",
+                    value.name()
+                )),
+            )));
         }
 
         if value.remaining() != 2 {

--- a/core/src/utils/wrapper_opaque.rs
+++ b/core/src/utils/wrapper_opaque.rs
@@ -72,26 +72,27 @@ impl<T> WrapperKeepOpaque<T> {
 impl<T> EncodeAsType for WrapperKeepOpaque<T> {
     fn encode_as_type_to<R: TypeResolver>(
         &self,
-        type_id: &R::TypeId,
+        type_id: R::TypeId,
         types: &R,
         out: &mut Vec<u8>,
     ) -> Result<(), scale_encode::Error> {
         use scale_encode::error::{Error, ErrorKind, Kind};
 
-        let visitor = visitor::new(out, |_, _| {
+        let ctx = (type_id.clone(), out);
+        let visitor = visitor::new(ctx, |(type_id, _out), _| {
             // Check that the target shape lines up: any other shape but composite is wrong.
             Err(Error::new(ErrorKind::WrongShape {
                 actual: Kind::Struct,
-                expected_id: format!("{:?}", type_id),
+                expected_id: format!("{type_id:?}"),
             }))
         })
-        .visit_composite(|out, _fields| {
+        .visit_composite(|(_type_id,out), _path, _fields| {
             self.data.encode_to(out);
             Ok(())
         });
 
         types
-            .resolve_type(type_id, visitor)
+            .resolve_type(type_id.clone(), visitor)
             .map_err(|_| Error::new(ErrorKind::TypeNotFound(format!("{:?}", type_id))))?
     }
 }
@@ -105,7 +106,7 @@ impl<T, R: TypeResolver> Visitor for WrapperKeepOpaqueVisitor<T, R> {
     fn visit_composite<'scale, 'info>(
         self,
         value: &mut scale_decode::visitor::types::Composite<'scale, 'info, R>,
-        _type_id: &R::TypeId,
+        _type_id: R::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         use scale_decode::error::{Error, ErrorKind};
 
@@ -193,7 +194,7 @@ mod test {
         let (type_id, types) = make_type::<T>();
 
         let scale_codec_encoded = t.encode();
-        let encode_as_type_encoded = t.encode_as_type(&type_id, &types).unwrap();
+        let encode_as_type_encoded = t.encode_as_type(type_id, &types).unwrap();
 
         assert_eq!(
             scale_codec_encoded, encode_as_type_encoded,
@@ -201,7 +202,7 @@ mod test {
         );
 
         let decode_as_type_bytes = &mut &*scale_codec_encoded;
-        let decoded_as_type = T::decode_as_type(decode_as_type_bytes, &type_id, &types)
+        let decoded_as_type = T::decode_as_type(decode_as_type_bytes, type_id, &types)
             .expect("decode-as-type decodes");
 
         let decode_scale_codec_bytes = &mut &*scale_codec_encoded;

--- a/core/src/utils/wrapper_opaque.rs
+++ b/core/src/utils/wrapper_opaque.rs
@@ -109,8 +109,15 @@ impl<T, R: TypeResolver> Visitor for WrapperKeepOpaqueVisitor<T, R> {
         _type_id: R::TypeId,
     ) -> Result<Self::Value<'scale, 'info>, Self::Error> {
         use scale_decode::error::{Error, ErrorKind};
+        use scale_decode::visitor::DecodeError;
 
-        // TODO: When `scale-type-resolver` [provides struct names](https://github.com/paritytech/scale-type-resolver/issues/4), check that this struct name is `WrapperKeepOpaque`
+        if value.name().as_ref() !== Some("WrapperKeepOpaque") {
+            return Err(Error::new(ErrorKind::VisitorDecodeError {
+                DecodeError::TypeResolvingError(
+                    format!("Expected a type named 'WrapperKeepOpaque', got: {:?}", value.name())
+                )
+            ));
+        }
 
         if value.remaining() != 2 {
             return Err(Error::new(ErrorKind::WrongLength {

--- a/subxt/src/error/dispatch_error.rs
+++ b/subxt/src/error/dispatch_error.rs
@@ -210,7 +210,7 @@ impl ModuleError {
     pub fn as_root_error<E: DecodeAsType>(&self) -> Result<E, Error> {
         let decoded = E::decode_as_type(
             &mut &self.bytes[..],
-            &self.metadata.outer_enums().error_enum_ty(),
+            self.metadata.outer_enums().error_enum_ty(),
             self.metadata.types(),
         )?;
 
@@ -272,7 +272,7 @@ impl DispatchError {
             fn unchecked_decode_as_type<'scale, 'info>(
                 self,
                 input: &mut &'scale [u8],
-                _type_id: &R::TypeId,
+                _type_id: R::TypeId,
                 _types: &'info R,
             ) -> DecodeAsTypeResult<Self, Result<Self::Value<'scale, 'info>, Self::Error>>
             {


### PR DESCRIPTION
Mainly this just means converting `&type_id`s to `type_id`s as we pass them by value and not reference now.

Also add back a check in `WrapperKeepOpaque` to confirm that the struct we're pointing at is the right one, to resovle a small TODO.