### PR TITLE
Prep for 0.36.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,12 @@ Check out a full example [here](https://github.com/paritytech/subxt/blob/327b70a
 
 We plan to improve on this in the future, baking in better Ethereum support if possible so that it's as seamless to use `AccountId20` as it is `AccountId32`.
 
+### Stabilizing the new V2 RPCs ([#1540](https://github.com/paritytech/subxt/pull/1540), [#1539](https://github.com/paritytech/subxt/pull/1539), [#1538](https://github.com/paritytech/subxt/pull/1538))
+
+A bunch of the new RPCs are now stable in the spec, and have consequently been stabilized here, bringing the `unstable-backend` a step closer to being stabilized itself! We'll probably first remove the feature flag and next make it the default backend, in upcoming releases.
+
+All of the notable changes in this release are as follows:
+
 ### Added
 
 - Add `frontier/ethereum` example ([#1557](https://github.com/paritytech/subxt/pull/1557))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,106 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.36.0] - 2024-05-16
+
+This release adds a few new features, which I'll go over below in more detail.
+
+### [`subxt-core`](https://github.com/paritytech/subxt/pull/1508)
+
+We now have a brand new `subxt-core` crate, which is `#[no-std]` compatible, and contains a lot of the core logic that is needed in Subxt. Using this crate, you can do things in a no-std environment like:
+
+- `blocks`: decode and explore block bodies.
+- `constants`: access and validate the constant addresses in some metadata.
+- `custom_values`: access and validate the custom value addresses in some metadata.
+- `metadata`: decode bytes into the metadata used throughout this library.
+- `storage`: construct storage request payloads and decode the results you'd get back.
+- `tx`: construct and sign transactions (extrinsics).
+- `runtime_api`: construct runtime API request payloads and decode the results you'd get back.
+- `events`: decode and explore events.
+
+Check out [the docs](https://docs.rs/subxt-core/latest/subxt_core/) for more, including examples of each case.
+
+A breaking change that comes from migrating a bunch of logic to this new crate is that the `ExtrinsicParams` trait is now handed `&ClientState<T>` rather than a `Client`. `ClientState` is just a concrete struct containing the state that one needs for things like signed extensions.
+
+### [Support for reconnecting](https://github.com/paritytech/subxt/pull/1505)
+
+We've baked in a bunch of support for automatically reconnecting after a connection loss into Subxt. This comes in three parts:
+1. An RPC client that is capable of reconnecting. This is gated behind the `unstable-reconnecting-rpc-client` feature flag at the moment, and
+2. Handling in the subxt Backends such that when the RPC client notifies it that it is reconnecting, the backend will transparently handle this behind the scenes, or else pass on a `DisconnectedWillReconnect` error to the user where it cannot.
+3. A couple of util helpers (`subxt::backend::retry` and `subxt::backend::retry_stream`) which can be used in conjunction with a reconnecting RPC client to make it easy to automatically retry manual RPC method calls (which don't themselves make any attempt to reconnect) where needed.
+
+We'd love feedback on this reconnecting work! To try it out, enable the `unstable-reconnecting-rpc-client` feature flag and then you can make use of this like so:
+
+```rust
+use std::time::Duration;
+use futures::StreamExt;
+use subxt::backend::rpc::reconnecting_rpc_client::{Client, ExponentialBackoff};
+use subxt::{OnlineClient, PolkadotConfig};
+
+// Generate an interface that we can use from the node's metadata.
+#[subxt::subxt(runtime_metadata_path = "../artifacts/polkadot_metadata_small.scale")]
+pub mod polkadot {}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Create a new client with with a reconnecting RPC client.
+    let rpc = Client::builder()
+        // We can configure the retry policy; here to an exponential backoff.
+        // This API accepts an iterator of retry delays, and here we use `take`
+        // to limit the number of retries.
+        .retry_policy(
+            ExponentialBackoff::from_millis(100)
+                .max_delay(Duration::from_secs(10))
+                .take(3),
+        )
+        .build("ws://localhost:9944".to_string())
+        .await?;
+
+    // Use this reconnecting client when instantiating a Subxt client:
+    let api: OnlineClient<PolkadotConfig> = OnlineClient::from_rpc_client(rpc.clone()).await?;
+```
+
+Check out the full example [here](https://github.com/paritytech/subxt/blob/64d3aae521112c8bc7366385c54a9340185d81ac/subxt/examples/setup_reconnecting_rpc_client.rs).
+
+### [Better Ethereum support](https://github.com/paritytech/subxt/pull/1501)
+
+We've added built-in support for Ethereum style chains (eg Frontier and Moonbeam) in `subxt-signer`, making it easier to sign transactions for these chains now.
+
+Check out a full example [here](https://github.com/paritytech/subxt/blob/327b70ac94c4d925c8529a1e301d596d7db181ea/subxt/examples/tx_basic_frontier.rs).
+
+We plan to improve on this in the future, baking in better Ethereum support if possible so that it's as seamless to use `AccountId20` as it is `AccountId32`.
+
+### Added
+
+- Add `frontier/ethereum` example ([#1557](https://github.com/paritytech/subxt/pull/1557))
+- Rpc: add full support reconnecting rpc client ([#1505](https://github.com/paritytech/subxt/pull/1505))
+- Signer: ethereum implementation ([#1501](https://github.com/paritytech/subxt/pull/1501))
+- `subxt-core` crate ([#1466](https://github.com/paritytech/subxt/pull/1466))
+
+### Changed
+
+- Bump scale-decode and related deps to latest ([#1583](https://github.com/paritytech/subxt/pull/1583))
+- Update Artifacts (auto-generated) ([#1577](https://github.com/paritytech/subxt/pull/1577))
+- Update deps to use `scale-type-resolver` 0.2 ([#1565](https://github.com/paritytech/subxt/pull/1565))
+- Stabilize transactionBroadcast methods ([#1540](https://github.com/paritytech/subxt/pull/1540))
+- Stabilize transactionWatch methods ([#1539](https://github.com/paritytech/subxt/pull/1539))
+- Stabilize chainHead methods ([#1538](https://github.com/paritytech/subxt/pull/1538))
+- Rename traits to remove T suffix ([#1535](https://github.com/paritytech/subxt/pull/1535))
+- Add Debug/Clone/etc for common Configs for convenience ([#1542](https://github.com/paritytech/subxt/pull/1542))
+- Unstable_rpc: Add transactionBroadcast and transactionStop ([#1497](https://github.com/paritytech/subxt/pull/1497))
+
+### Fixed
+
+- metadata: Fix cargo clippy ([#1574](https://github.com/paritytech/subxt/pull/1574))
+- Fixed import in `subxt-signer::eth` ([#1553](https://github.com/paritytech/subxt/pull/1553))
+- chore: fix typos and link broken ([#1541](https://github.com/paritytech/subxt/pull/1541))
+- Make subxt-core ready for publishing ([#1508](https://github.com/paritytech/subxt/pull/1508))
+- Remove dupe storage item if we get one back, to be compatible with Smoldot + legacy RPCs ([#1534](https://github.com/paritytech/subxt/pull/1534))
+- fix: substrate runner libp2p port ([#1533](https://github.com/paritytech/subxt/pull/1533))
+- Swap BinaryHeap for Vec to avoid Ord constraint issue ([#1523](https://github.com/paritytech/subxt/pull/1523))
+- storage_type: Strip key proper hash and entry bytes (32 instead of 16) ([#1522](https://github.com/paritytech/subxt/pull/1522))
+- testing: Prepare light client testing with substrate binary and add subxt-test macro ([#1507](https://github.com/paritytech/subxt/pull/1507))
+
 ## [0.35.0] - 2024-03-21
 
 This release contains several fixes, adds `no_std` support to a couple of crates (`subxt-signer` and `subxt-metadata`) and introduces a few quality of life improvements, which I'll quickly cover:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,8 @@ A breaking change that comes from migrating a bunch of logic to this new crate i
 
 We've baked in a bunch of support for automatically reconnecting after a connection loss into Subxt. This comes in three parts:
 1. An RPC client that is capable of reconnecting. This is gated behind the `unstable-reconnecting-rpc-client` feature flag at the moment, and
-2. Handling in the subxt Backends such that when the RPC client notifies it that it is reconnecting, the backend will transparently handle this behind the scenes, or else pass on a `DisconnectedWillReconnect` error to the user where it cannot.
-3. A couple of util helpers (`subxt::backend::retry` and `subxt::backend::retry_stream`) which can be used in conjunction with a reconnecting RPC client to make it easy to automatically retry manual RPC method calls (which don't themselves make any attempt to reconnect) where needed.
+2. Handling in the subxt Backends such that when the RPC client notifies it that it is reconnecting, the backend will transparently handle this behind the scenes, or else pass on a `DisconnectedWillReconnect` error to the user where it cannot. Note that the individual `LegacyRpcMethods` and `UnstableRpcMethods` are _not_ automatically retried on reconnection. Which leads us to..
+3. A couple of util helpers (`subxt::backend::retry` and `subxt::backend::retry_stream`) which can be used in conjunction with a reconnecting RPC client to make it easy to automatically retry RPC method calls where needed.
 
 We'd love feedback on this reconnecting work! To try it out, enable the `unstable-reconnecting-rpc-client` feature flag and then you can make use of this like so:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "artifacts"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "substrate-runner",
 ]
@@ -1812,7 +1812,7 @@ dependencies = [
 
 [[package]]
 name = "generate-custom-metadata"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "frame-metadata 16.0.0",
  "parity-scale-codec",
@@ -2309,7 +2309,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "assert_matches",
  "cfg_aliases",
@@ -4746,7 +4746,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-runner"
-version = "0.35.0"
+version = "0.36.0"
 
 [[package]]
 name = "subtle"
@@ -4756,7 +4756,7 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "subxt"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -4799,7 +4799,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-cli"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "clap 4.5.4",
  "color-eyre",
@@ -4828,7 +4828,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-codegen"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "frame-metadata 16.0.0",
  "getrandom",
@@ -4848,7 +4848,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-core"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "assert_matches",
  "base58",
@@ -4881,7 +4881,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-lightclient"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4906,7 +4906,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "darling 0.20.8",
  "parity-scale-codec",
@@ -4919,7 +4919,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-metadata"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "assert_matches",
  "bitvec",
@@ -4934,7 +4934,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-signer"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "bip32",
  "bip39",
@@ -4962,7 +4962,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-test-macro"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "quote",
  "syn 2.0.60",
@@ -5025,7 +5025,7 @@ dependencies = [
 
 [[package]]
 name = "test-runtime"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "hex",
  "impl-serde",
@@ -5450,7 +5450,7 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "ui-tests"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "frame-metadata 16.0.0",
  "generate-custom-metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ resolver = "2"
 [workspace.package]
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
-version = "0.35.0"
+version = "0.36.0"
 rust-version = "1.74.0"
 license = "Apache-2.0 OR GPL-3.0"
 repository = "https://github.com/paritytech/subxt"
@@ -139,13 +139,13 @@ sp-runtime = "34.0.0"
 sp-keyring = "34.0.0"
 
 # Subxt workspace crates:
-subxt = { version = "0.35.0", path = "subxt", default-features = false }
-subxt-core = { version = "0.35.0", path = "core", default-features = false }
-subxt-macro = { version = "0.35.0", path = "macro" }
-subxt-metadata = { version = "0.35.0", path = "metadata", default-features = false }
-subxt-codegen = { version = "0.35.0", path = "codegen" }
-subxt-signer = { version = "0.35.0", path = "signer", default-features = false }
-subxt-lightclient = { version = "0.35.0", path = "lightclient", default-features = false }
+subxt = { version = "0.36.0", path = "subxt", default-features = false }
+subxt-core = { version = "0.36.0", path = "core", default-features = false }
+subxt-macro = { version = "0.36.0", path = "macro" }
+subxt-metadata = { version = "0.36.0", path = "metadata", default-features = false }
+subxt-codegen = { version = "0.36.0", path = "codegen" }
+subxt-signer = { version = "0.36.0", path = "signer", default-features = false }
+subxt-lightclient = { version = "0.36.0", path = "lightclient", default-features = false }
 test-runtime = { path = "testing/test-runtime" }
 substrate-runner = { path = "testing/substrate-runner" }
 

--- a/subxt/examples/storage_fetch.rs
+++ b/subxt/examples/storage_fetch.rs
@@ -22,10 +22,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .storage()
         .at_latest()
         .await?
-        .fetch_raw(subxt_core::storage::get_address_bytes(&storage_query, &api.metadata()).unwrap())
+        .fetch(&storage_query)
         .await?;
 
-    let v = hex::encode(result.unwrap());
+    let v = result.unwrap().data.free;
     println!("Alice: {v}");
     Ok(())
 }


### PR DESCRIPTION
## [0.36.0] - 2024-05-16

This release adds a few new features, which I'll go over below in more detail.

### [`subxt-core`](https://github.com/paritytech/subxt/pull/1508)

We now have a brand new `subxt-core` crate, which is `#[no-std]` compatible, and contains a lot of the core logic that is needed in Subxt. Using this crate, you can do things in a no-std environment like:

- `blocks`: decode and explore block bodies.
- `constants`: access and validate the constant addresses in some metadata.
- `custom_values`: access and validate the custom value addresses in some metadata.
- `metadata`: decode bytes into the metadata used throughout this library.
- `storage`: construct storage request payloads and decode the results you'd get back.
- `tx`: construct and sign transactions (extrinsics).
- `runtime_api`: construct runtime API request payloads and decode the results you'd get back.
- `events`: decode and explore events.

Check out [the docs](https://docs.rs/subxt-core/latest/subxt_core/) for more, including examples of each case.

A breaking change that comes from migrating a bunch of logic to this new crate is that the `ExtrinsicParams` trait is now handed `&ClientState<T>` rather than a `Client`. `ClientState` is just a concrete struct containing the state that one needs for things like signed extensions.

### [Support for reconnecting](https://github.com/paritytech/subxt/pull/1505)

We've baked in a bunch of support for automatically reconnecting after a connection loss into Subxt. This comes in three parts:
1. An RPC client that is capable of reconnecting. This is gated behind the `unstable-reconnecting-rpc-client` feature flag at the moment, and
2. Handling in the subxt Backends such that when the RPC client notifies it that it is reconnecting, the backend will transparently handle this behind the scenes, or else pass on a `DisconnectedWillReconnect` error to the user where it cannot. Note that the individual `LegacyRpcMethods` and `UnstableRpcMethods` are _not_ automatically retried on reconnection. Which leads us to..
3. A couple of util helpers (`subxt::backend::retry` and `subxt::backend::retry_stream`) which can be used in conjunction with a reconnecting RPC client to make it easy to automatically retry RPC method calls where needed.

We'd love feedback on this reconnecting work! To try it out, enable the `unstable-reconnecting-rpc-client` feature flag and then you can make use of this like so:

```rust
use std::time::Duration;
use futures::StreamExt;
use subxt::backend::rpc::reconnecting_rpc_client::{Client, ExponentialBackoff};
use subxt::{OnlineClient, PolkadotConfig};

// Generate an interface that we can use from the node's metadata.
#[subxt::subxt(runtime_metadata_path = "../artifacts/polkadot_metadata_small.scale")]
pub mod polkadot {}

#[tokio::main]
async fn main() -> Result<(), Box<dyn std::error::Error>> {
    // Create a new client with with a reconnecting RPC client.
    let rpc = Client::builder()
        // We can configure the retry policy; here to an exponential backoff.
        // This API accepts an iterator of retry delays, and here we use `take`
        // to limit the number of retries.
        .retry_policy(
            ExponentialBackoff::from_millis(100)
                .max_delay(Duration::from_secs(10))
                .take(3),
        )
        .build("ws://localhost:9944".to_string())
        .await?;

    // Use this reconnecting client when instantiating a Subxt client:
    let api: OnlineClient<PolkadotConfig> = OnlineClient::from_rpc_client(rpc.clone()).await?;
```

Check out the full example [here](https://github.com/paritytech/subxt/blob/64d3aae521112c8bc7366385c54a9340185d81ac/subxt/examples/setup_reconnecting_rpc_client.rs).

### [Better Ethereum support](https://github.com/paritytech/subxt/pull/1501)

We've added built-in support for Ethereum style chains (eg Frontier and Moonbeam) in `subxt-signer`, making it easier to sign transactions for these chains now.

Check out a full example [here](https://github.com/paritytech/subxt/blob/327b70ac94c4d925c8529a1e301d596d7db181ea/subxt/examples/tx_basic_frontier.rs).

We plan to improve on this in the future, baking in better Ethereum support if possible so that it's as seamless to use `AccountId20` as it is `AccountId32`.

### Stabilizing the new V2 RPCs ([#1540](https://github.com/paritytech/subxt/pull/1540), [#1539](https://github.com/paritytech/subxt/pull/1539), [#1538](https://github.com/paritytech/subxt/pull/1538))

A bunch of the new RPCs are now stable in the spec, and have consequently been stabilized here, bringing the `unstable-backend` a step closer to being stabilized itself! We'll probably first remove the feature flag and next make it the default backend, in upcoming releases.

All of the notable changes in this release are as follows:

### Added

- Add `frontier/ethereum` example ([#1557](https://github.com/paritytech/subxt/pull/1557))
- Rpc: add full support reconnecting rpc client ([#1505](https://github.com/paritytech/subxt/pull/1505))
- Signer: ethereum implementation ([#1501](https://github.com/paritytech/subxt/pull/1501))
- `subxt-core` crate ([#1466](https://github.com/paritytech/subxt/pull/1466))

### Changed

- Bump scale-decode and related deps to latest ([#1583](https://github.com/paritytech/subxt/pull/1583))
- Update Artifacts (auto-generated) ([#1577](https://github.com/paritytech/subxt/pull/1577))
- Update deps to use `scale-type-resolver` 0.2 ([#1565](https://github.com/paritytech/subxt/pull/1565))
- Stabilize transactionBroadcast methods ([#1540](https://github.com/paritytech/subxt/pull/1540))
- Stabilize transactionWatch methods ([#1539](https://github.com/paritytech/subxt/pull/1539))
- Stabilize chainHead methods ([#1538](https://github.com/paritytech/subxt/pull/1538))
- Rename traits to remove T suffix ([#1535](https://github.com/paritytech/subxt/pull/1535))
- Add Debug/Clone/etc for common Configs for convenience ([#1542](https://github.com/paritytech/subxt/pull/1542))
- Unstable_rpc: Add transactionBroadcast and transactionStop ([#1497](https://github.com/paritytech/subxt/pull/1497))

### Fixed

- metadata: Fix cargo clippy ([#1574](https://github.com/paritytech/subxt/pull/1574))
- Fixed import in `subxt-signer::eth` ([#1553](https://github.com/paritytech/subxt/pull/1553))
- chore: fix typos and link broken ([#1541](https://github.com/paritytech/subxt/pull/1541))
- Make subxt-core ready for publishing ([#1508](https://github.com/paritytech/subxt/pull/1508))
- Remove dupe storage item if we get one back, to be compatible with Smoldot + legacy RPCs ([#1534](https://github.com/paritytech/subxt/pull/1534))
- fix: substrate runner libp2p port ([#1533](https://github.com/paritytech/subxt/pull/1533))
- Swap BinaryHeap for Vec to avoid Ord constraint issue ([#1523](https://github.com/paritytech/subxt/pull/1523))
- storage_type: Strip key proper hash and entry bytes (32 instead of 16) ([#1522](https://github.com/paritytech/subxt/pull/1522))
- testing: Prepare light client testing with substrate binary and add subxt-test macro ([#1507](https://github.com/paritytech/subxt/pull/1507))
