### PR TITLE
POC: use `snafu` instead of `derive_more` for errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4278,6 +4278,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "snafu"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75976f4748ab44f6e5332102be424e7c2dc18daeaf7e725f2040c3ebb133512e"
+dependencies = [
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4b19911debfb8c2fb1107bc6cb2d61868aaf53a988449213959bb1b5b1ed95f"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
+]
+
+[[package]]
 name = "socket2"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4855,7 +4876,6 @@ dependencies = [
  "bitvec",
  "blake2",
  "derive-where",
- "derive_more",
  "frame-metadata 16.0.0",
  "hashbrown 0.14.5",
  "hex",
@@ -4869,6 +4889,7 @@ dependencies = [
  "scale-value",
  "serde",
  "serde_json",
+ "snafu",
  "sp-core",
  "sp-crypto-hashing",
  "sp-keyring",
@@ -4924,11 +4945,11 @@ dependencies = [
  "assert_matches",
  "bitvec",
  "criterion",
- "derive_more",
  "frame-metadata 16.0.0",
  "hashbrown 0.14.5",
  "parity-scale-codec",
  "scale-info",
+ "snafu",
  "sp-crypto-hashing",
 ]
 
@@ -4939,7 +4960,6 @@ dependencies = [
  "bip32",
  "bip39",
  "cfg-if",
- "derive_more",
  "getrandom",
  "hex",
  "hex-literal",
@@ -4953,6 +4973,7 @@ dependencies = [
  "secp256k1",
  "secrecy",
  "sha2 0.10.8",
+ "snafu",
  "sp-core",
  "sp-crypto-hashing",
  "sp-keyring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ console_error_panic_hook = "0.1.7"
 darling = "0.20.8"
 derive-where = "1.2.7"
 derive_more = "0.99.17"
+snafu = { version = "0.8.2", default-features = false, features = ["rust_1_65"] }
 either = { version = "1.11.0", default-features = false }
 frame-metadata = { version = "16.0.0", default-features = false }
 futures = { version = "0.3.30", default-features = false, features = ["std"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -45,7 +45,7 @@ scale-encode = { workspace = true, default-features = false, features = ["derive
 frame-metadata = { workspace = true, default-features = false }
 subxt-metadata = { workspace = true, default-features = false }
 derive-where = { workspace = true }
-derive_more = { workspace = true }
+snafu = { workspace = true }
 hex = { workspace = true, default-features = false, features = ["alloc"] }
 serde = { workspace = true, default-features = false, features = ["derive"] }
 serde_json = { workspace = true, default-features = false, features = ["raw_value", "alloc"] }

--- a/core/src/blocks/extrinsic_signed_extensions.rs
+++ b/core/src/blocks/extrinsic_signed_extensions.rs
@@ -51,8 +51,9 @@ impl<'a, T: Config> ExtrinsicSignedExtensions<'a, T> {
                 metadata.types(),
                 scale_decode::visitor::IgnoreVisitor::new(),
             )
-            .map_err(|e| Error::Decode(e.into()))
-            {
+            .map_err(|e| Error::Decode {
+                source: crate::error_utils::DisplayError(e.into()),
+            }) {
                 index = num_signed_extensions; // (such that None is returned in next iteration)
                 return Some(Err(err));
             }

--- a/core/src/config/signed_extensions.rs
+++ b/core/src/config/signed_extensions.rs
@@ -429,7 +429,9 @@ macro_rules! impl_tuples {
                         if is_type_empty(e.extra_ty(), types) {
                             continue
                         } else {
-                            return Err(ExtrinsicParamsError::UnknownSignedExtension(e.identifier().to_owned()));
+                            return Err(ExtrinsicParamsError::UnknownSignedExtension {
+                                extension: e.identifier().to_owned()
+                            });
                         }
                     };
                     params.push(ext);

--- a/core/src/constants/mod.rs
+++ b/core/src/constants/mod.rs
@@ -55,8 +55,8 @@ pub fn validate<Addr: Address>(address: &Addr, metadata: &Metadata) -> Result<()
         let expected_hash = metadata
             .pallet_by_name_err(address.pallet_name())?
             .constant_hash(address.constant_name())
-            .ok_or_else(|| {
-                MetadataError::ConstantNameNotFound(address.constant_name().to_owned())
+            .ok_or_else(|| MetadataError::ConstantNameNotFound {
+                name: address.constant_name().to_owned(),
             })?;
         if actual_hash != expected_hash {
             return Err(MetadataError::IncompatibleCodegen.into());
@@ -75,7 +75,9 @@ pub fn get<Addr: Address>(address: &Addr, metadata: &Metadata) -> Result<Addr::T
     let constant = metadata
         .pallet_by_name_err(address.pallet_name())?
         .constant_by_name(address.constant_name())
-        .ok_or_else(|| MetadataError::ConstantNameNotFound(address.constant_name().to_owned()))?;
+        .ok_or_else(|| MetadataError::ConstantNameNotFound {
+            name: address.constant_name().to_owned(),
+        })?;
     let value = <Addr::Target as DecodeWithMetadata>::decode_with_metadata(
         &mut constant.value(),
         constant.ty(),

--- a/core/src/custom_values/mod.rs
+++ b/core/src/custom_values/mod.rs
@@ -43,9 +43,12 @@ use alloc::vec::Vec;
 pub fn validate<Addr: Address + ?Sized>(address: &Addr, metadata: &Metadata) -> Result<(), Error> {
     if let Some(actual_hash) = address.validation_hash() {
         let custom = metadata.custom();
-        let custom_value = custom
-            .get(address.name())
-            .ok_or_else(|| MetadataError::CustomValueNameNotFound(address.name().into()))?;
+        let custom_value =
+            custom
+                .get(address.name())
+                .ok_or_else(|| MetadataError::CustomValueNameNotFound {
+                    name: address.name().into(),
+                })?;
         let expected_hash = custom_value.hash();
         if actual_hash != expected_hash {
             return Err(MetadataError::IncompatibleCodegen.into());

--- a/core/src/error_utils.rs
+++ b/core/src/error_utils.rs
@@ -1,0 +1,24 @@
+use core::fmt::{self, Debug, Display};
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct DisplayError<T>(pub T);
+
+impl<T> Debug for DisplayError<T>
+where
+    T: Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl<T> Display for DisplayError<T>
+where
+    T: Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl<T> snafu::Error for DisplayError<T> where T: Display + Debug {}

--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -258,9 +258,11 @@ impl<T: Config> EventDetails<T> {
 
         // Get metadata for the event:
         let event_pallet = metadata.pallet_by_index_err(pallet_index)?;
-        let event_variant = event_pallet
-            .event_variant_by_index(variant_index)
-            .ok_or(MetadataError::VariantIndexNotFound(variant_index))?;
+        let event_variant = event_pallet.event_variant_by_index(variant_index).ok_or(
+            MetadataError::VariantIndexNotFound {
+                variant_idx: variant_index,
+            },
+        )?;
         tracing::debug!(
             "Decoding Event '{}::{}'",
             event_pallet.name(),

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -23,6 +23,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 pub extern crate alloc;
 
+mod error_utils;
+
 #[macro_use]
 mod macros;
 

--- a/core/src/metadata/metadata_type.rs
+++ b/core/src/metadata/metadata_type.rs
@@ -27,7 +27,9 @@ impl Metadata {
         name: &str,
     ) -> Result<subxt_metadata::PalletMetadata, MetadataError> {
         self.pallet_by_name(name)
-            .ok_or_else(|| MetadataError::PalletNameNotFound(name.to_owned()))
+            .ok_or_else(|| MetadataError::PalletNameNotFound {
+                name: name.to_owned(),
+            })
     }
 
     /// Identical to `metadata.pallet_by_index()`, but returns an error if the pallet is not found.
@@ -36,7 +38,7 @@ impl Metadata {
         index: u8,
     ) -> Result<subxt_metadata::PalletMetadata, MetadataError> {
         self.pallet_by_index(index)
-            .ok_or(MetadataError::PalletIndexNotFound(index))
+            .ok_or(MetadataError::PalletIndexNotFound { pallet_idx: index })
     }
 
     /// Identical to `metadata.runtime_api_trait_by_name()`, but returns an error if the trait is not found.
@@ -45,7 +47,9 @@ impl Metadata {
         name: &str,
     ) -> Result<subxt_metadata::RuntimeApiMetadata, MetadataError> {
         self.runtime_api_trait_by_name(name)
-            .ok_or_else(|| MetadataError::RuntimeTraitNotFound(name.to_owned()))
+            .ok_or_else(|| MetadataError::RuntimeTraitNotFound {
+                name: name.to_owned(),
+            })
     }
 
     /// Identical to `metadata.custom().get(name)`, but returns an error if the trait is not found.
@@ -55,7 +59,9 @@ impl Metadata {
     ) -> Result<subxt_metadata::CustomValueMetadata, MetadataError> {
         self.custom()
             .get(name)
-            .ok_or_else(|| MetadataError::CustomValueNameNotFound(name.to_owned()))
+            .ok_or_else(|| MetadataError::CustomValueNameNotFound {
+                name: name.to_owned(),
+            })
     }
 }
 

--- a/core/src/runtime_api/mod.rs
+++ b/core/src/runtime_api/mod.rs
@@ -90,7 +90,9 @@ pub fn decode_value<P: Payload>(
     let api_method = metadata
         .runtime_api_trait_by_name_err(payload.trait_name())?
         .method_by_name(payload.method_name())
-        .ok_or_else(|| MetadataError::RuntimeMethodNotFound(payload.method_name().to_owned()))?;
+        .ok_or_else(|| MetadataError::RuntimeMethodNotFound {
+            name: payload.method_name().to_owned(),
+        })?;
 
     let val = <P::ReturnType as DecodeWithMetadata>::decode_with_metadata(
         &mut &bytes[..],

--- a/core/src/runtime_api/payload.rs
+++ b/core/src/runtime_api/payload.rs
@@ -105,7 +105,9 @@ impl<ArgsData: EncodeAsFields, ReturnTy: DecodeWithMetadata> Payload
         let api_method = metadata
             .runtime_api_trait_by_name_err(&self.trait_name)?
             .method_by_name(&self.method_name)
-            .ok_or_else(|| MetadataError::RuntimeMethodNotFound((*self.method_name).to_owned()))?;
+            .ok_or_else(|| MetadataError::RuntimeMethodNotFound {
+                name: (*self.method_name).to_owned(),
+            })?;
         let mut fields = api_method
             .inputs()
             .map(|input| scale_encode::Field::named(input.ty, &input.name));

--- a/core/src/storage/address.rs
+++ b/core/src/storage/address.rs
@@ -154,10 +154,14 @@ where
         let pallet = metadata.pallet_by_name_err(self.pallet_name())?;
         let storage = pallet
             .storage()
-            .ok_or_else(|| MetadataError::StorageNotFoundInPallet(self.pallet_name().to_owned()))?;
-        let entry = storage
-            .entry_by_name(self.entry_name())
-            .ok_or_else(|| MetadataError::StorageEntryNotFound(self.entry_name().to_owned()))?;
+            .ok_or_else(|| MetadataError::StorageNotFoundInPallet {
+                name: self.pallet_name().to_owned(),
+            })?;
+        let entry = storage.entry_by_name(self.entry_name()).ok_or_else(|| {
+            MetadataError::StorageEntryNotFound {
+                entry_name: self.entry_name().to_owned(),
+            }
+        })?;
 
         let hashers = StorageHashers::new(entry.entry_type(), metadata.types())?;
         self.keys

--- a/core/src/storage/storage_key.rs
+++ b/core/src/storage/storage_key.rs
@@ -5,6 +5,7 @@
 use super::utils::hash_bytes;
 use crate::{
     error::{Error, MetadataError, StorageAddressError},
+    error_utils::DisplayError,
     utils::{Encoded, Static},
 };
 use alloc::vec;
@@ -34,7 +35,7 @@ impl StorageHashers {
         {
             let ty = types
                 .resolve(*key_ty)
-                .ok_or(MetadataError::TypeNotFound(*key_ty))?;
+                .ok_or(MetadataError::TypeNotFound { type_id: *key_ty })?;
 
             if let TypeDef::Tuple(tuple) = &ty.type_def {
                 if hashers.len() == 1 {
@@ -306,7 +307,9 @@ fn consume_hash_returning_key_bytes<'a>(
             types,
             IgnoreVisitor::<PortableRegistry>::new(),
         )
-        .map_err(|err| Error::Decode(err.into()))?;
+        .map_err(|err| Error::Decode {
+            source: DisplayError(err.into()),
+        })?;
         // Return the key bytes, having advanced the input cursor past them.
         let key_bytes = &before_key[..before_key.len() - bytes.len()];
 

--- a/core/src/storage/utils.rs
+++ b/core/src/storage/utils.rs
@@ -46,11 +46,16 @@ pub fn lookup_storage_entry_details<'a>(
     metadata: &'a Metadata,
 ) -> Result<(PalletMetadata<'a>, &'a StorageEntryMetadata), Error> {
     let pallet_metadata = metadata.pallet_by_name_err(pallet_name)?;
-    let storage_metadata = pallet_metadata
-        .storage()
-        .ok_or_else(|| MetadataError::StorageNotFoundInPallet(pallet_name.to_owned()))?;
-    let storage_entry = storage_metadata
-        .entry_by_name(entry_name)
-        .ok_or_else(|| MetadataError::StorageEntryNotFound(entry_name.to_owned()))?;
+    let storage_metadata =
+        pallet_metadata
+            .storage()
+            .ok_or_else(|| MetadataError::StorageNotFoundInPallet {
+                name: pallet_name.to_owned(),
+            })?;
+    let storage_entry = storage_metadata.entry_by_name(entry_name).ok_or_else(|| {
+        MetadataError::StorageEntryNotFound {
+            entry_name: entry_name.to_owned(),
+        }
+    })?;
     Ok((pallet_metadata, storage_entry))
 }

--- a/core/src/tx/mod.rs
+++ b/core/src/tx/mod.rs
@@ -80,7 +80,9 @@ pub fn validate<Call: Payload>(call: &Call, metadata: &Metadata) -> Result<(), E
         let expected_hash = metadata
             .pallet_by_name_err(details.pallet_name)?
             .call_hash(details.call_name)
-            .ok_or_else(|| MetadataError::CallNameNotFound(details.call_name.to_owned()))?;
+            .ok_or_else(|| MetadataError::CallNameNotFound {
+                name: details.call_name.to_owned(),
+            })?;
 
         if details.hash != expected_hash {
             return Err(MetadataError::IncompatibleCodegen.into());

--- a/core/src/tx/payload.rs
+++ b/core/src/tx/payload.rs
@@ -141,7 +141,9 @@ impl<CallData: EncodeAsFields> Payload for DefaultPayload<CallData> {
         let pallet = metadata.pallet_by_name_err(&self.pallet_name)?;
         let call = pallet
             .call_variant_by_name(&self.call_name)
-            .ok_or_else(|| MetadataError::CallNameNotFound((*self.call_name).to_owned()))?;
+            .ok_or_else(|| MetadataError::CallNameNotFound {
+                name: (*self.call_name).to_owned(),
+            })?;
 
         let pallet_index = pallet.index();
         let call_index = call.index;

--- a/core/src/utils/account_id.rs
+++ b/core/src/utils/account_id.rs
@@ -11,8 +11,8 @@ use alloc::string::String;
 use alloc::vec;
 use alloc::vec::Vec;
 use codec::{Decode, Encode};
-use derive_more::Display;
 use serde::{Deserialize, Serialize};
+use snafu::Snafu;
 
 /// A 32-byte cryptographic identifier. This is a simplified version of Substrate's
 /// `sp_core::crypto::AccountId32`. To obtain more functionality, convert this into
@@ -105,16 +105,16 @@ impl AccountId32 {
 }
 
 /// An error obtained from trying to interpret an SS58 encoded string into an AccountId32
-#[derive(Clone, Copy, Eq, PartialEq, Debug, Display)]
+#[derive(Clone, Copy, Eq, PartialEq, Debug, Snafu)]
 #[allow(missing_docs)]
 pub enum FromSs58Error {
-    #[display(fmt = "Base 58 requirement is violated")]
+    #[snafu(display("Base 58 requirement is violated"))]
     BadBase58,
-    #[display(fmt = "Length is bad")]
+    #[snafu(display("Length is bad"))]
     BadLength,
-    #[display(fmt = "Invalid checksum")]
+    #[snafu(display("Invalid checksum"))]
     InvalidChecksum,
-    #[display(fmt = "Invalid SS58 prefix byte.")]
+    #[snafu(display("Invalid SS58 prefix byte."))]
     InvalidPrefix,
 }
 

--- a/metadata/Cargo.toml
+++ b/metadata/Cargo.toml
@@ -23,7 +23,7 @@ frame-metadata = { workspace = true, default-features = false, features = ["curr
 codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
 sp-crypto-hashing = { workspace = true }
 hashbrown = { workspace = true }
-derive_more = { workspace = true }
+snafu = { workspace = true }
 
 [dev-dependencies]
 bitvec = { workspace = true, features = ["alloc"] }

--- a/metadata/src/from_into/mod.rs
+++ b/metadata/src/from_into/mod.rs
@@ -3,31 +3,45 @@
 // see LICENSE for license details.
 
 use alloc::string::String;
-use derive_more::Display;
-
+use snafu::Snafu;
 mod v14;
 mod v15;
 
 /// An error emitted if something goes wrong converting [`frame_metadata`]
 /// types into [`crate::Metadata`].
-#[derive(Debug, Display, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Snafu)]
 #[non_exhaustive]
 pub enum TryFromError {
     /// Type missing from type registry
-    #[display(fmt = "Type id {_0} is expected but not found in the type registry")]
-    TypeNotFound(u32),
+    #[snafu(display("Type id {type_id} is expected but not found in the type registry"))]
+    TypeNotFound {
+        /// Id of the type
+        type_id: u32,
+    },
     /// Type was not a variant/enum type
-    #[display(fmt = "Type {_0} was not a variant/enum type, but is expected to be one")]
-    VariantExpected(u32),
+    #[snafu(display("Type {type_id} was not a variant/enum type, but is expected to be one"))]
+    VariantExpected {
+        /// Id of the type
+        type_id: u32,
+    },
     /// An unsupported metadata version was provided.
-    #[display(fmt = "Cannot convert v{_0} metadata into Metadata type")]
-    UnsupportedMetadataVersion(u32),
+    #[snafu(display("Cannot convert v{version} metadata into Metadata type"))]
+    UnsupportedMetadataVersion {
+        /// Metadata version
+        version: u32,
+    },
     /// Type name missing from type registry
-    #[display(fmt = "Type name {_0} is expected but not found in the type registry")]
-    TypeNameNotFound(String),
+    #[snafu(display("Type name {name} is expected but not found in the type registry"))]
+    TypeNameNotFound {
+        /// Name of the type
+        name: String,
+    },
     /// Invalid type path.
-    #[display(fmt = "Type has an invalid path {_0}")]
-    InvalidTypePath(String),
+    #[snafu(display("Type has an invalid path {path}"))]
+    InvalidTypePath {
+        /// Path of the type
+        path: String,
+    },
 }
 
 #[cfg(feature = "std")]
@@ -46,46 +60,46 @@ impl TryFrom<frame_metadata::RuntimeMetadataPrefixed> for crate::Metadata {
     fn try_from(value: frame_metadata::RuntimeMetadataPrefixed) -> Result<Self, Self::Error> {
         match value.1 {
             frame_metadata::RuntimeMetadata::V0(_) => {
-                Err(TryFromError::UnsupportedMetadataVersion(0))
+                Err(TryFromError::UnsupportedMetadataVersion { version: 0 })
             }
             frame_metadata::RuntimeMetadata::V1(_) => {
-                Err(TryFromError::UnsupportedMetadataVersion(1))
+                Err(TryFromError::UnsupportedMetadataVersion { version: 1 })
             }
             frame_metadata::RuntimeMetadata::V2(_) => {
-                Err(TryFromError::UnsupportedMetadataVersion(2))
+                Err(TryFromError::UnsupportedMetadataVersion { version: 2 })
             }
             frame_metadata::RuntimeMetadata::V3(_) => {
-                Err(TryFromError::UnsupportedMetadataVersion(3))
+                Err(TryFromError::UnsupportedMetadataVersion { version: 3 })
             }
             frame_metadata::RuntimeMetadata::V4(_) => {
-                Err(TryFromError::UnsupportedMetadataVersion(4))
+                Err(TryFromError::UnsupportedMetadataVersion { version: 4 })
             }
             frame_metadata::RuntimeMetadata::V5(_) => {
-                Err(TryFromError::UnsupportedMetadataVersion(5))
+                Err(TryFromError::UnsupportedMetadataVersion { version: 5 })
             }
             frame_metadata::RuntimeMetadata::V6(_) => {
-                Err(TryFromError::UnsupportedMetadataVersion(6))
+                Err(TryFromError::UnsupportedMetadataVersion { version: 6 })
             }
             frame_metadata::RuntimeMetadata::V7(_) => {
-                Err(TryFromError::UnsupportedMetadataVersion(7))
+                Err(TryFromError::UnsupportedMetadataVersion { version: 7 })
             }
             frame_metadata::RuntimeMetadata::V8(_) => {
-                Err(TryFromError::UnsupportedMetadataVersion(8))
+                Err(TryFromError::UnsupportedMetadataVersion { version: 8 })
             }
             frame_metadata::RuntimeMetadata::V9(_) => {
-                Err(TryFromError::UnsupportedMetadataVersion(9))
+                Err(TryFromError::UnsupportedMetadataVersion { version: 9 })
             }
             frame_metadata::RuntimeMetadata::V10(_) => {
-                Err(TryFromError::UnsupportedMetadataVersion(10))
+                Err(TryFromError::UnsupportedMetadataVersion { version: 10 })
             }
             frame_metadata::RuntimeMetadata::V11(_) => {
-                Err(TryFromError::UnsupportedMetadataVersion(11))
+                Err(TryFromError::UnsupportedMetadataVersion { version: 11 })
             }
             frame_metadata::RuntimeMetadata::V12(_) => {
-                Err(TryFromError::UnsupportedMetadataVersion(12))
+                Err(TryFromError::UnsupportedMetadataVersion { version: 12 })
             }
             frame_metadata::RuntimeMetadata::V13(_) => {
-                Err(TryFromError::UnsupportedMetadataVersion(13))
+                Err(TryFromError::UnsupportedMetadataVersion { version: 13 })
             }
             frame_metadata::RuntimeMetadata::V14(m) => m.try_into(),
             frame_metadata::RuntimeMetadata::V15(m) => m.try_into(),

--- a/signer/Cargo.toml
+++ b/signer/Cargo.toml
@@ -52,7 +52,7 @@ hex = { workspace = true, features = ["alloc"] }
 cfg-if = { workspace = true }
 codec = { package = "parity-scale-codec", workspace = true, features = ["derive"] }
 sp-crypto-hashing = { workspace = true }
-derive_more = { workspace = true }
+snafu = { workspace = true }
 pbkdf2 = { workspace = true }
 sha2 = { workspace = true }
 hmac = { workspace = true }

--- a/signer/src/crypto/secret_uri.rs
+++ b/signer/src/crypto/secret_uri.rs
@@ -4,9 +4,9 @@
 
 use super::DeriveJunction;
 use alloc::vec::Vec;
-use derive_more::Display;
 use regex::Regex;
 use secrecy::SecretString;
+use snafu::Snafu;
 
 // This code is taken from sp_core::crypto::DeriveJunction. The logic should be identical,
 // though the code is tweaked a touch!
@@ -117,10 +117,10 @@ impl core::str::FromStr for SecretUri {
 }
 
 /// This is returned if `FromStr` cannot parse a string into a `SecretUri`.
-#[derive(Debug, Copy, Clone, PartialEq, Display)]
+#[derive(Debug, Copy, Clone, PartialEq, Snafu)]
 pub enum SecretUriError {
     /// Parsing the secret URI from a string failed; wrong format.
-    #[display(fmt = "Invalid secret phrase format")]
+    #[snafu(display("Invalid secret phrase format"))]
     InvalidFormat,
 }
 

--- a/signer/src/eth.rs
+++ b/signer/src/eth.rs
@@ -9,9 +9,9 @@ use alloc::format;
 use alloc::string::String;
 use core::fmt::{Display, Formatter};
 use core::str::FromStr;
-use derive_more::Display;
 use keccak_hash::keccak;
 use secp256k1::Message;
+use snafu::Snafu;
 
 const SECRET_KEY_LENGTH: usize = 32;
 
@@ -215,13 +215,15 @@ pub fn verify<M: AsRef<[u8]>>(sig: &Signature, message: M, pubkey: &ecdsa::Publi
 }
 
 /// An error handed back if creating a keypair fails.
-#[derive(Debug, PartialEq, Display)]
+#[derive(Debug, PartialEq, Snafu)]
 pub enum Error {
     /// Invalid seed.
-    #[display(fmt = "Invalid seed (was it the wrong length?)")]
+    #[snafu(display("Invalid seed (was it the wrong length?)"))]
     InvalidSeed,
     /// Invalid derivation path.
-    #[display(fmt = "Could not derive from path; some valeus in the path may have been >= 2^31?")]
+    #[snafu(display(
+        "Could not derive from path; some valeus in the path may have been >= 2^31?"
+    ))]
     DeriveFromPath,
 }
 

--- a/signer/src/utils.rs
+++ b/signer/src/utils.rs
@@ -34,3 +34,28 @@ macro_rules! once_static_cloned {
         )+
     };
 }
+
+use core::fmt::{self, Debug, Display};
+
+#[derive(PartialEq)]
+pub struct DisplayError<T>(pub T);
+
+impl<T> Debug for DisplayError<T>
+where
+    T: Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl<T> Display for DisplayError<T>
+where
+    T: Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl<T> snafu::Error for DisplayError<T> where T: Display + Debug {}

--- a/subxt/src/error/dispatch_error.rs
+++ b/subxt/src/error/dispatch_error.rs
@@ -171,7 +171,9 @@ impl ModuleError {
         let pallet = self.metadata.pallet_by_index_err(self.pallet_index())?;
         let variant = pallet
             .error_variant_by_index(self.error_index())
-            .ok_or_else(|| MetadataError::VariantIndexNotFound(self.error_index()))?;
+            .ok_or_else(|| MetadataError::VariantIndexNotFound {
+                variant_idx: self.error_index(),
+            })?;
 
         Ok(ModuleErrorDetails { pallet, variant })
     }

--- a/subxt/src/error/mod.rs
+++ b/subxt/src/error/mod.rs
@@ -85,13 +85,13 @@ pub enum Error {
 impl From<CoreError> for Error {
     fn from(value: CoreError) -> Self {
         match value {
-            CoreError::Codec(e) => Error::Codec(e),
-            CoreError::Metadata(e) => Error::Metadata(e),
-            CoreError::StorageAddress(e) => Error::StorageAddress(e),
-            CoreError::Decode(e) => Error::Decode(e),
-            CoreError::Encode(e) => Error::Encode(e),
-            CoreError::ExtrinsicParams(e) => Error::ExtrinsicParams(e),
-            CoreError::Block(e) => Error::Block(e.into()),
+            CoreError::Codec { source: e } => Error::Codec(e.0),
+            CoreError::Metadata { source: e } => Error::Metadata(e),
+            CoreError::StorageAddress { source: e } => Error::StorageAddress(e),
+            CoreError::Decode { source: e } => Error::Decode(e.0),
+            CoreError::Encode { source: e } => Error::Encode(e.0),
+            CoreError::ExtrinsicParams { source: e } => Error::ExtrinsicParams(e),
+            CoreError::Block { source: e } => Error::Block(e.into()),
         }
     }
 }
@@ -187,8 +187,8 @@ impl From<CoreBlockError> for BlockError {
     fn from(value: CoreBlockError) -> Self {
         match value {
             CoreBlockError::MissingType => BlockError::MissingType,
-            CoreBlockError::UnsupportedVersion(n) => BlockError::UnsupportedVersion(n),
-            CoreBlockError::DecodingError(e) => BlockError::DecodingError(e),
+            CoreBlockError::UnsupportedVersion { version: n } => BlockError::UnsupportedVersion(n),
+            CoreBlockError::DecodingError { source: e } => BlockError::DecodingError(e.0),
         }
     }
 }

--- a/subxt/src/storage/storage_type.rs
+++ b/subxt/src/storage/storage_type.rs
@@ -268,7 +268,9 @@ where
         self.client
             .metadata()
             .pallet_by_name(pallet_name.as_ref())
-            .ok_or_else(|| MetadataError::PalletNameNotFound(pallet_name.as_ref().into()))?;
+            .ok_or_else(|| MetadataError::PalletNameNotFound {
+                name: pallet_name.as_ref().into(),
+            })?;
 
         // construct the storage key. This is done similarly in `frame_support::traits::metadata::StorageVersion::storage_key()`.
         pub const STORAGE_VERSION_STORAGE_KEY_POSTFIX: &[u8] = b":__STORAGE_VERSION__:";


### PR DESCRIPTION
### Description
- this is an alternative to #1600 (see #1503)
- Replaces `derive_more` usage with `snafu`

Changing the library was somewhat easy, however: 
- `snafu` uses its own custom `snafu::Error` type in no-std contexts, therefore we needed to define a wrapper type that implements `snafu::AsErrorSource` for external error types and this led to a bit of boilerplate. 
- `snafu` doesn't support tuple variants yet, so its impossible to define an `Error` enum like this:
```rust
#[derive(Snafu)]
enum Error {
 #[snafu(display("example text {0}"))]
  MyEnum(AnotherError) 
}
```
it will be defined as: 
```rust
#[derive(Snafu)]
enum Error {
 #[snafu(display("example text {source}"), context(false))]
  MyEnum {
    source: AnotherError
  } 
}
- for external types it will look like example below, given we defined `DisplayError` wrapper for compatibility
```rust
#[derive(Snafu)]
enum Error {
 #[snafu(display("example text {source}"), context(false))]
  MyEnum {
    #[snafu(source(from(AnotherErrorExternal,DisplayError)))]
    source: DisplayError<AnotherError>
  } 
}
```

- This is a POC to gather some discussion whether it's better to go with `snafu` or use some other library or define `Display`/`From` by hand
- This will also incur dowstream breakage for users of subxt-metadata, subxt-signer, subxt-core