### PR TITLE
chore: release v0.36.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.36.1] - 2024-05-27
+
+This release mainly adds support for the sign extension `CheckMetadataHash` and fixes a regression introduced in v0.36.0
+where the type de-duplication was too aggressive and lots of the same type such as `BoundedVec` was duplicated to
+plenty of different types such as BoundedVec1, BoundedVec2, .. BoundedVec<N>.
+
+### Added
+- Implemented `sign_prehashed` for `ecdsa::Keypair` and `eth::Keypair` ([#1598](https://github.com/paritytech/subxt/pull/1598))
+- Add a basic version of the CheckMetadataHash signed extension ([#1590](https://github.com/paritytech/subxt/pull/1590))
+
+## Changed
+- Remove `derive_more` ([#1600](https://github.com/paritytech/subxt/pull/1600))
+- chore(deps): bump scale-typegen v0.8.0 ([#1615](https://github.com/paritytech/subxt/pull/1615))
+
 ## [0.36.0] - 2024-05-16
 
 This release adds a few new features, which I'll go over below in more detail.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "artifacts"
-version = "0.36.0"
+version = "0.36.1"
 dependencies = [
  "substrate-runner",
 ]
@@ -1812,7 +1812,7 @@ dependencies = [
 
 [[package]]
 name = "generate-custom-metadata"
-version = "0.36.0"
+version = "0.36.1"
 dependencies = [
  "frame-metadata 16.0.0",
  "parity-scale-codec",
@@ -2309,7 +2309,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.36.0"
+version = "0.36.1"
 dependencies = [
  "assert_matches",
  "cfg_aliases",
@@ -4745,7 +4745,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-runner"
-version = "0.36.0"
+version = "0.36.1"
 
 [[package]]
 name = "subtle"
@@ -4755,7 +4755,7 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "subxt"
-version = "0.36.0"
+version = "0.36.1"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -4798,7 +4798,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-cli"
-version = "0.36.0"
+version = "0.36.1"
 dependencies = [
  "clap 4.5.4",
  "color-eyre",
@@ -4827,7 +4827,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-codegen"
-version = "0.36.0"
+version = "0.36.1"
 dependencies = [
  "frame-metadata 16.0.0",
  "getrandom",
@@ -4847,7 +4847,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-core"
-version = "0.36.0"
+version = "0.36.1"
 dependencies = [
  "assert_matches",
  "base58",
@@ -4879,7 +4879,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-lightclient"
-version = "0.36.0"
+version = "0.36.1"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4904,7 +4904,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.36.0"
+version = "0.36.1"
 dependencies = [
  "darling 0.20.8",
  "parity-scale-codec",
@@ -4917,7 +4917,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-metadata"
-version = "0.36.0"
+version = "0.36.1"
 dependencies = [
  "assert_matches",
  "bitvec",
@@ -4931,7 +4931,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-signer"
-version = "0.36.0"
+version = "0.36.1"
 dependencies = [
  "bip32",
  "bip39",
@@ -4958,7 +4958,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-test-macro"
-version = "0.36.0"
+version = "0.36.1"
 dependencies = [
  "quote",
  "syn 2.0.60",
@@ -5021,7 +5021,7 @@ dependencies = [
 
 [[package]]
 name = "test-runtime"
-version = "0.36.0"
+version = "0.36.1"
 dependencies = [
  "hex",
  "impl-serde",
@@ -5446,7 +5446,7 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "ui-tests"
-version = "0.36.0"
+version = "0.36.1"
 dependencies = [
  "frame-metadata 16.0.0",
  "generate-custom-metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ resolver = "2"
 [workspace.package]
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
-version = "0.36.0"
+version = "0.36.1"
 rust-version = "1.74.0"
 license = "Apache-2.0 OR GPL-3.0"
 repository = "https://github.com/paritytech/subxt"
@@ -138,13 +138,13 @@ sp-runtime = "34.0.0"
 sp-keyring = "34.0.0"
 
 # Subxt workspace crates:
-subxt = { version = "0.36.0", path = "subxt", default-features = false }
-subxt-core = { version = "0.36.0", path = "core", default-features = false }
-subxt-macro = { version = "0.36.0", path = "macro" }
-subxt-metadata = { version = "0.36.0", path = "metadata", default-features = false }
-subxt-codegen = { version = "0.36.0", path = "codegen" }
-subxt-signer = { version = "0.36.0", path = "signer", default-features = false }
-subxt-lightclient = { version = "0.36.0", path = "lightclient", default-features = false }
+subxt = { version = "0.36.1", path = "subxt", default-features = false }
+subxt-core = { version = "0.36.1", path = "core", default-features = false }
+subxt-macro = { version = "0.36.1", path = "macro" }
+subxt-metadata = { version = "0.36.1", path = "metadata", default-features = false }
+subxt-codegen = { version = "0.36.1", path = "codegen" }
+subxt-signer = { version = "0.36.1", path = "signer", default-features = false }
+subxt-lightclient = { version = "0.36.1", path = "lightclient", default-features = false }
 test-runtime = { path = "testing/test-runtime" }
 substrate-runner = { path = "testing/substrate-runner" }
 


### PR DESCRIPTION
```markdown
## [0.36.1] - 2024-05-27

This release mainly adds support for the sign extension `CheckMetadataHash` and fixes a regression introduced in v0.36.0
where the type de-duplication was too aggressive and lots of the same type such as `BoundedVec` was duplicated to
plenty of different types such as BoundedVec1, BoundedVec2, .. BoundedVec<N>.

### Added
- Implemented `sign_prehashed` for `ecdsa::Keypair` and `eth::Keypair` ([#1598](https://github.com/paritytech/subxt/pull/1598))
- Add a basic version of the CheckMetadataHash signed extension ([#1590](https://github.com/paritytech/subxt/pull/1590))

## Changed
- Remove `derive_more` ([#1600](https://github.com/paritytech/subxt/pull/1600))
- chore(deps): bump scale-typegen v0.8.0 ([#1615](https://github.com/paritytech/subxt/pull/1615))

```