### PR TITLE
chore(deps): remove `unused dep sp-core` from signer 

### DIFF
--- a/signer/Cargo.toml
+++ b/signer/Cargo.toml
@@ -25,7 +25,6 @@ std = [
     "bip39/std",
     "schnorrkel/std",
     "secp256k1/std",
-    "sp-core/std"
 ]
 
 # Pick the signer implementation(s) you need by enabling the


### PR DESCRIPTION
`sp-core` is part of the std feature flag and must be part of the dependencies.

It's probably leaked from the workspace and that's why it worked in CI.