### PR TITLE
Ensures poll order wrt subscription ID's

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "artifacts"
-version = "0.36.1"
+version = "0.37.0"
 dependencies = [
  "substrate-runner",
 ]
@@ -1812,7 +1812,7 @@ dependencies = [
 
 [[package]]
 name = "generate-custom-metadata"
-version = "0.36.1"
+version = "0.37.0"
 dependencies = [
  "frame-metadata 16.0.0",
  "parity-scale-codec",
@@ -2309,7 +2309,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.36.1"
+version = "0.37.0"
 dependencies = [
  "assert_matches",
  "cfg_aliases",
@@ -4745,7 +4745,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-runner"
-version = "0.36.1"
+version = "0.37.0"
 
 [[package]]
 name = "subtle"
@@ -4755,7 +4755,7 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "subxt"
-version = "0.36.1"
+version = "0.37.0"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -4798,7 +4798,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-cli"
-version = "0.36.1"
+version = "0.37.0"
 dependencies = [
  "clap 4.5.4",
  "color-eyre",
@@ -4827,7 +4827,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-codegen"
-version = "0.36.1"
+version = "0.37.0"
 dependencies = [
  "frame-metadata 16.0.0",
  "getrandom",
@@ -4847,7 +4847,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-core"
-version = "0.36.1"
+version = "0.37.0"
 dependencies = [
  "assert_matches",
  "base58",
@@ -4879,7 +4879,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-lightclient"
-version = "0.36.1"
+version = "0.37.0"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4904,7 +4904,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.36.1"
+version = "0.37.0"
 dependencies = [
  "darling 0.20.8",
  "parity-scale-codec",
@@ -4917,7 +4917,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-metadata"
-version = "0.36.1"
+version = "0.37.0"
 dependencies = [
  "assert_matches",
  "bitvec",
@@ -4931,7 +4931,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-signer"
-version = "0.36.1"
+version = "0.37.0"
 dependencies = [
  "bip32",
  "bip39",
@@ -4958,7 +4958,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-test-macro"
-version = "0.36.1"
+version = "0.37.0"
 dependencies = [
  "quote",
  "syn 2.0.60",
@@ -5021,7 +5021,7 @@ dependencies = [
 
 [[package]]
 name = "test-runtime"
-version = "0.36.1"
+version = "0.37.0"
 dependencies = [
  "hex",
  "impl-serde",
@@ -5446,7 +5446,7 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "ui-tests"
-version = "0.36.1"
+version = "0.37.0"
 dependencies = [
  "frame-metadata 16.0.0",
  "generate-custom-metadata",

--- a/subxt/src/backend/unstable/mod.rs
+++ b/subxt/src/backend/unstable/mod.rs
@@ -728,7 +728,7 @@ where
 {
     loop {
         let reconnected = follow_handle.reconnected().fuse();
-        let action = retry(|| fun()).fuse();
+        let action = retry(&mut fun).fuse();
 
         pin_mut!(reconnected, action);
 

--- a/subxt/src/backend/utils.rs
+++ b/subxt/src/backend/utils.rs
@@ -106,27 +106,11 @@ where
     F: FnMut() -> T,
     T: Future<Output = Result<R, Error>>,
 {
-    const REJECTED_MAX_RETRIES: usize = 10;
-    let mut rejected_retries = 0;
-
     loop {
         match retry_future().await {
             Ok(v) => return Ok(v),
             Err(e) => {
                 if e.is_disconnected_will_reconnect() {
-                    continue;
-                }
-
-                // TODO: https://github.com/paritytech/subxt/issues/1567
-                // This is a hack because if a reconnection occurs
-                // the order of pending calls is not guaranteed.
-                //
-                // Such that it's possible the a pending future completes
-                // before `chainHead_follow` is established with fresh
-                // subscription id.
-                //
-                if e.is_rejected() && rejected_retries < REJECTED_MAX_RETRIES {
-                    rejected_retries += 1;
                     continue;
                 }
 


### PR DESCRIPTION
### Description 
Under current implementation unstable backend will be re-trying to make a call with a fixed amount of attempts instead of backing off on backend reconnection and waiting for newly initialized subscription_id.(see #1567 and comments in the mr referenced there)

The implementation here is adding a `.reconnected()` method for the backend and a new wrapper function that will poll `_.reconnected()` and `action_being_retried`.

So with this new wrapper flowchart will go like this in a loop: 
```rust
reconnected.next() = None, action = Pending => {
  cancel action;
  return Error(Subscription_droppped)
}
reconnected.next() = Some(true), action = Pending => {
  // Subscription received FollowEvent::Initialized
  loop again to retry the action
}
reconnected.next() = Some(false), action = Pending => {
  // Subscription received FollowEvent::Stop
  loop { 
    reconnected.next() until it returns Some(true)
  }  
  loop again to retry the action
}
reconnected.next() = Pending, action = Ready(result) => {
  try polling the pending `reconnected.next()` and if it is None {
   return result from the action
  } else {
    loop { 
       reconnected.next() until it returns Some(true)
    }
    loop again to retry the action
  }
}
```
Not sure whether we need to track `FollowEvent::Initialized()` in `reconnected()` as code that grabs subscription_id will wait for the new `subscription id` after being re-run again

closes #1567