### PR TITLE
Allow running integration tests given a SUBXT_TEST_URL=ws://foo:port

### DIFF
--- a/testing/integration-tests/src/utils/node_proc.rs
+++ b/testing/integration-tests/src/utils/node_proc.rs
@@ -243,11 +243,19 @@ async fn build_unstable_client<T: Config>(
 }
 
 #[cfg(lightclient)]
-async fn build_light_client<T: Config>(proc: &SubstrateNode) -> Result<OnlineClient<T>, String> {
+async fn build_light_client<T: Config>(
+    maybe_proc: &Option<SubstrateNode>,
+) -> Result<OnlineClient<T>, String> {
     use subxt::lightclient::{ChainConfig, LightClient};
 
+    let proc = if let Some(proc) = maybe_proc {
+        proc
+    } else {
+        return Err("Cannot build light client: no substrate node is running (you can't start a light client when pointing to an external node)".into());
+    };
+
     // RPC endpoint.
-    let ws_url = get_url(proc.as_ref().map(|p| p.ws_port()));
+    let ws_url = proc.ws_port();
 
     // Wait for a few blocks to be produced using the subxt client.
     let client = OnlineClient::<T>::from_url(ws_url.clone())

--- a/testing/integration-tests/src/utils/node_proc.rs
+++ b/testing/integration-tests/src/utils/node_proc.rs
@@ -11,9 +11,11 @@ use subxt::{
     Config, OnlineClient,
 };
 
-// The URL that we'll connect to for our tests comes
-// from SUBXT_TEXT_HOST env var or defaults to localhost.
-// In the former case, we won't spawn a binary.
+// The URL that we'll connect to for our tests comes from SUBXT_TEXT_HOST env var,
+// defaulting to localhost if not provided. If the env var is set, we won't spawn
+// a binary. Note though that some tests expect and modify a fresh state, and so will
+// fail. Fo a similar reason wyou should also use `--test-threads 1` when running tests
+// to reduce the number of conflicts between state altering tests.
 const URL_ENV_VAR: &str = "SUBXT_TEST_URL";
 fn is_url_provided() -> bool {
     std::env::var(URL_ENV_VAR).is_ok()

--- a/testing/integration-tests/src/utils/node_proc.rs
+++ b/testing/integration-tests/src/utils/node_proc.rs
@@ -24,8 +24,12 @@ fn get_url(port: Option<u16>) -> String {
     match (std::env::var(URL_ENV_VAR).ok(), port) {
         (Some(host), None) => host,
         (None, Some(port)) => format!("ws://127.0.0.1:{port}"),
-        (Some(_), Some(_)) => panic!("{URL_ENV_VAR} and port provided: only one or the other should exist"),
-        (None, None) => panic!("No {URL_ENV_VAR} or port was provided, so we don't know where to connect to"),
+        (Some(_), Some(_)) => {
+            panic!("{URL_ENV_VAR} and port provided: only one or the other should exist")
+        }
+        (None, None) => {
+            panic!("No {URL_ENV_VAR} or port was provided, so we don't know where to connect to")
+        }
     }
 }
 

--- a/testing/integration-tests/src/utils/node_proc.rs
+++ b/testing/integration-tests/src/utils/node_proc.rs
@@ -247,7 +247,7 @@ async fn build_light_client<T: Config>(proc: &SubstrateNode) -> Result<OnlineCli
     use subxt::lightclient::{ChainConfig, LightClient};
 
     // RPC endpoint.
-    let ws_url = format!("ws://{}:{}", get_url(), proc.ws_port());
+    let ws_url = get_url(proc.as_ref().map(|p| p.ws_port()));
 
     // Wait for a few blocks to be produced using the subxt client.
     let client = OnlineClient::<T>::from_url(ws_url.clone())
@@ -261,8 +261,7 @@ async fn build_light_client<T: Config>(proc: &SubstrateNode) -> Result<OnlineCli
 
     // Now, configure a light client; fetch the chain spec and modify the bootnodes.
     let bootnode = format!(
-        "/ip4/{}/tcp/{}/p2p/{}",
-        get_url(),
+        "/ip4/127.0.0.1/tcp/{}/p2p/{}",
         proc.p2p_port(),
         proc.p2p_address()
     );

--- a/testing/integration-tests/src/utils/node_proc.rs
+++ b/testing/integration-tests/src/utils/node_proc.rs
@@ -254,8 +254,8 @@ async fn build_light_client<T: Config>(
         return Err("Cannot build light client: no substrate node is running (you can't start a light client when pointing to an external node)".into());
     };
 
-    // RPC endpoint.
-    let ws_url = proc.ws_port();
+    // RPC endpoint. Only localhost works.
+    let ws_url = format!("ws://127.0.0.1:{}", proc.ws_port());
 
     // Wait for a few blocks to be produced using the subxt client.
     let client = OnlineClient::<T>::from_url(ws_url.clone())


### PR DESCRIPTION
This isn't always super useful because the tests assume a fresh node each time, but gives us the ability to run all or specific tests against some external ndoe at least.

To avoid ctests conflicting you'll need to use `--test-threads 1`. You'll still see some failures because a few tests will assume a fresh state and then update it.