### PR TITLE
Disable `clippy::unwrap_or_default` lint for the project

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ unused_extern_crates = "deny"
 [workspace.lints.clippy]
 type_complexity = "allow"
 all = "deny"
+unwrap_or_default = "allow"
 
 [workspace.dependencies]
 async-trait = "0.1.80"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,8 @@ unused_extern_crates = "deny"
 [workspace.lints.clippy]
 type_complexity = "allow"
 all = "deny"
-unwrap_or_default = "allow"
+# https://github.com/rust-lang/rust-clippy/issues/12643
+manual-unwrap-or-default = "allow"
 
 [workspace.dependencies]
 async-trait = "0.1.80"

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -43,3 +43,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [package.metadata.playground]
 defalt-features = true
+
+[lints]
+workspace = true

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -35,7 +35,6 @@ std = [
 substrate-compat = ["sp-core", "sp-runtime"]
 
 [dependencies]
-
 codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
 scale-info = { workspace = true, default-features = false, features = ["bit-vec"] }
 scale-value = { workspace = true, default-features = false }
@@ -83,3 +82,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [package.metadata.playground]
 defalt-features = true
+
+[lints]
+workspace = true

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -27,3 +27,6 @@ syn = { workspace = true }
 quote = { workspace = true }
 subxt-codegen = { workspace = true, features = ["fetch-metadata"] }
 scale-typegen = { workspace = true }
+
+[lints]
+workspace = true

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -3,7 +3,8 @@
 // see LICENSE for license details.
 
 //! Subxt macro for generating Substrate runtime interfaces.
-#![allow(clippy::manual_unwrap_or_default, missing_docs)]
+// TODO: The workspace lint is not working properly so it's disabled here for now.
+#![allow(clippy::manual_unwrap_or_default)]
 
 use codec::Decode;
 use darling::{ast::NestedMeta, FromMeta};

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -85,6 +85,7 @@ struct SubstituteType {
 }
 
 // Note: docs for this are in the subxt library; don't add further docs here as they will be appended.
+#[allow(missing_docs)]
 #[proc_macro_attribute]
 #[proc_macro_error]
 pub fn subxt(args: TokenStream, input: TokenStream) -> TokenStream {

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -3,8 +3,7 @@
 // see LICENSE for license details.
 
 //! Subxt macro for generating Substrate runtime interfaces.
-
-extern crate proc_macro;
+#![allow(clippy::manual_unwrap_or_default, missing_docs)]
 
 use codec::Decode;
 use darling::{ast::NestedMeta, FromMeta};

--- a/metadata/Cargo.toml
+++ b/metadata/Cargo.toml
@@ -37,3 +37,6 @@ bench = false
 [[bench]]
 name = "bench"
 harness = false
+
+[lints]
+workspace = true

--- a/metadata/benches/bench.rs
+++ b/metadata/benches/bench.rs
@@ -3,7 +3,7 @@
 // see LICENSE for license details.
 
 //! Benchmarks for metadata hashing.
-
+#![allow(missing_docs)]
 use codec::Decode;
 use criterion::*;
 use frame_metadata::{RuntimeMetadata, RuntimeMetadataPrefixed};
@@ -92,4 +92,5 @@ criterion_group!(
         bench_get_constant_hash,
         bench_get_storage_hash,
 );
+
 criterion_main!(benches);

--- a/signer/Cargo.toml
+++ b/signer/Cargo.toml
@@ -79,3 +79,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [package.metadata.playground]
 defalt-features = true
+
+[lints]
+workspace = true

--- a/signer/src/eth.rs
+++ b/signer/src/eth.rs
@@ -206,7 +206,18 @@ impl Display for AccountId20 {
         write!(f, "{}", self.checksum())
     }
 }
-
+/// Verify that some signature for a message was created by the owner of the [`PublicKey`].
+///
+/// ```rust
+/// use subxt_signer::{ bip39::Mnemonic, eth };
+///
+/// let keypair = eth::dev::alith();
+/// let message = b"Hello!";
+///
+/// let signature = keypair.sign(message);
+/// let public_key = keypair.public_key();
+/// assert!(eth::verify(&signature, message, &public_key));
+/// ```
 pub fn verify<M: AsRef<[u8]>>(sig: &Signature, message: M, pubkey: &ecdsa::PublicKey) -> bool {
     let message_hash = keccak(message.as_ref());
     let wrapped =

--- a/signer/src/eth.rs
+++ b/signer/src/eth.rs
@@ -206,6 +206,7 @@ impl Display for AccountId20 {
         write!(f, "{}", self.checksum())
     }
 }
+
 /// Verify that some signature for a message was created by the owner of the [`PublicKey`].
 ///
 /// ```rust

--- a/signer/src/utils.rs
+++ b/signer/src/utils.rs
@@ -21,6 +21,7 @@ macro_rules! once_static_cloned {
     ($($(#[$attr:meta])* $vis:vis fn $name:ident() -> $ty:ty { $expr:expr } )+) => {
         $(
             $(#[$attr])*
+            #[allow(missing_docs)]
             $vis fn $name() -> $ty {
                 cfg_if::cfg_if! {
                     if #[cfg(feature = "std")] {


### PR DESCRIPTION
### Description 
see  rust-lang/rust-clippy#12643
subxt uses `darling` which uses `unwrap_or_default` in generated code.