### PR TITLE
testing: Modify the storage_fetch_raw_keys to reflect substrate-binary

### DIFF
--- a/testing/integration-tests/src/full_client/client/mod.rs
+++ b/testing/integration-tests/src/full_client/client/mod.rs
@@ -42,7 +42,7 @@ async fn storage_fetch_raw_keys() {
         .count()
         .await;
 
-    assert_eq!(len, 13)
+    assert_eq!(len, 14)
 }
 
 #[cfg(fullclient)]

--- a/testing/integration-tests/src/full_client/client/mod.rs
+++ b/testing/integration-tests/src/full_client/client/mod.rs
@@ -67,7 +67,7 @@ async fn storage_iter() {
         .count()
         .await;
 
-    assert_eq!(len, 13);
+    assert_eq!(len, 14);
 }
 
 #[cfg(fullclient)]


### PR DESCRIPTION
The CI is failing for origin/master since the latest substrate binary changes.

This has been detected by our dependabot https://github.com/paritytech/subxt/pull/1666.

Closes: https://github.com/paritytech/subxt/issues/1649.