### PR TITLE
Allow tx payloads to be boxed

### DIFF
--- a/core/src/tx/payload.rs
+++ b/core/src/tx/payload.rs
@@ -9,8 +9,8 @@ use crate::error::MetadataError;
 use crate::metadata::Metadata;
 use crate::Error;
 use alloc::borrow::{Cow, ToOwned};
-use alloc::string::String;
 use alloc::boxed::Box;
+use alloc::string::String;
 
 use alloc::vec::Vec;
 use codec::Encode;

--- a/core/src/tx/payload.rs
+++ b/core/src/tx/payload.rs
@@ -38,6 +38,32 @@ pub trait Payload {
     }
 }
 
+macro_rules! boxed_payload {
+    ($ty:path) => {
+        impl<T: Payload + ?Sized> Payload for $ty {
+            fn encode_call_data_to(
+                &self,
+                metadata: &Metadata,
+                out: &mut Vec<u8>,
+            ) -> Result<(), Error> {
+                self.as_ref().encode_call_data_to(metadata, out)
+            }
+            fn encode_call_data(&self, metadata: &Metadata) -> Result<Vec<u8>, Error> {
+                self.as_ref().encode_call_data(metadata)
+            }
+            fn validation_details(&self) -> Option<ValidationDetails<'_>> {
+                self.as_ref().validation_details()
+            }
+        }
+    };
+}
+
+boxed_payload!(Box<T>);
+#[cfg(feature = "std")]
+boxed_payload!(std::sync::Arc<T>);
+#[cfg(feature = "std")]
+boxed_payload!(std::rc::Rc<T>);
+
 /// Details required to validate the shape of a transaction payload against some metadata.
 pub struct ValidationDetails<'a> {
     /// The pallet name.

--- a/core/src/tx/payload.rs
+++ b/core/src/tx/payload.rs
@@ -58,7 +58,7 @@ macro_rules! boxed_payload {
     };
 }
 
-boxed_payload!(Box<T>);
+boxed_payload!(alloc::boxed::Box<T>);
 #[cfg(feature = "std")]
 boxed_payload!(std::sync::Arc<T>);
 #[cfg(feature = "std")]

--- a/core/src/tx/payload.rs
+++ b/core/src/tx/payload.rs
@@ -10,6 +10,7 @@ use crate::metadata::Metadata;
 use crate::Error;
 use alloc::borrow::{Cow, ToOwned};
 use alloc::string::String;
+use alloc::boxed::Box;
 
 use alloc::vec::Vec;
 use codec::Encode;
@@ -58,7 +59,7 @@ macro_rules! boxed_payload {
     };
 }
 
-boxed_payload!(alloc::boxed::Box<T>);
+boxed_payload!(Box<T>);
 #[cfg(feature = "std")]
 boxed_payload!(std::sync::Arc<T>);
 #[cfg(feature = "std")]

--- a/subxt/examples/tx_boxed.rs
+++ b/subxt/examples/tx_boxed.rs
@@ -1,0 +1,43 @@
+#![allow(missing_docs)]
+use subxt::{OnlineClient, PolkadotConfig};
+use subxt_signer::sr25519::dev;
+
+#[subxt::subxt(runtime_metadata_path = "../artifacts/polkadot_metadata_small.scale")]
+pub mod polkadot {}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let api = OnlineClient::<PolkadotConfig>::new().await?;
+
+    // Prepare some extrinsics. These are boxed so that they can live alongside each other.
+    let txs = [dynamic_remark(), balance_transfer(), remark()];
+
+    for tx in txs {
+        let from = dev::alice();
+        api.tx()
+            .sign_and_submit_then_watch_default(&tx, &from)
+            .await?
+            .wait_for_finalized_success()
+            .await?;
+
+        println!("Submitted tx");
+    }
+
+    Ok(())
+}
+
+fn balance_transfer() -> Box<dyn subxt::tx::Payload> {
+    let dest = dev::bob().public_key().into();
+    Box::new(polkadot::tx().balances().transfer_allow_death(dest, 10_000))
+}
+
+fn remark() -> Box<dyn subxt::tx::Payload> {
+    Box::new(polkadot::tx().system().remark(vec![1, 2, 3, 4, 5]))
+}
+
+fn dynamic_remark() -> Box<dyn subxt::tx::Payload> {
+    use subxt::dynamic::{tx, Value};
+    let tx_payload = tx("System", "remark", vec![Value::from_bytes("Hello")]);
+
+    Box::new(tx_payload)
+}

--- a/subxt/src/book/usage/transactions.rs
+++ b/subxt/src/book/usage/transactions.rs
@@ -196,6 +196,14 @@
 //! This example doesn't wait for the transaction to be included in a block; it just submits it and
 //! hopes for the best!
 //!
+//! ### Boxing transaction payloads
+//!
+//! Transaction payloads can be boxed so that they all share a common type and can be stored together.
+//!
+//! ```rust,ignore
+#![doc = include_str!("../../../examples/tx_boxed.rs")]
+//! ```
+//!
 //! ### Custom handling of transaction status updates
 //!
 //! If you'd like more control or visibility over exactly which status updates are being emitted for


### PR DESCRIPTION
Support boxing payloads so that they can share a common type and be stored together etc.

I considered doing the same to eg runtime/storage etc but they all have an associated type which means that, in practise, it wouldn't be so useful there.

Closes #1670