### PR TITLE
fix: enable dependabot for all crates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: "cargo"
-    directory: "/"
+    directory: "**/*"
     schedule:
       interval: weekly
     ignore:
@@ -13,6 +13,6 @@ updates:
     - dependency-name: sp-crypto-hashing
     - dependency-name: sp-version
   - package-ecosystem: github-actions
-    directory: '/'
+    directory: "**/*"
     schedule:
       interval: weekly


### PR DESCRIPTION
We have some crates outside the workspace which aren't updated on dependabot updates such as `testing/wasm-rpc-tests` and some example which this fixes.

See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#directories