### PR TITLE
clippy: Remove unneeded `?Sized` bound and replace never type with `()`

### DIFF
--- a/core/src/storage/storage_key.rs
+++ b/core/src/storage/storage_key.rs
@@ -182,7 +182,7 @@ impl<K: codec::Encode + ?Sized> StaticStorageKey<K> {
     }
 }
 
-impl<K: codec::Decode + ?Sized> StaticStorageKey<K> {
+impl<K: codec::Decode> StaticStorageKey<K> {
     /// Decodes the encoded inner bytes into the type `K`.
     pub fn decoded(&self) -> Result<K, Error> {
         let decoded = K::decode(&mut self.bytes())?;

--- a/subxt/src/backend/legacy/rpc_methods.rs
+++ b/subxt/src/backend/legacy/rpc_methods.rs
@@ -332,7 +332,9 @@ impl<T: Config> LegacyRpcMethods<T> {
         public: Vec<u8>,
     ) -> Result<(), Error> {
         let params = rpc_params![key_type, suri, Bytes(public)];
-        self.client.request("author_insertKey", params).await?;
+        self.client
+            .request::<()>("author_insertKey", params)
+            .await?;
         Ok(())
     }
 

--- a/subxt/src/backend/legacy/rpc_methods.rs
+++ b/subxt/src/backend/legacy/rpc_methods.rs
@@ -332,10 +332,7 @@ impl<T: Config> LegacyRpcMethods<T> {
         public: Vec<u8>,
     ) -> Result<(), Error> {
         let params = rpc_params![key_type, suri, Bytes(public)];
-        self.client
-            .request::<()>("author_insertKey", params)
-            .await?;
-        Ok(())
+        self.client.request("author_insertKey", params).await
     }
 
     /// Generate new session keys and returns the corresponding public keys.

--- a/subxt/src/backend/unstable/rpc_methods.rs
+++ b/subxt/src/backend/unstable/rpc_methods.rs
@@ -73,7 +73,7 @@ impl<T: Config> UnstableRpcMethods<T> {
         operation_id: &str,
     ) -> Result<(), Error> {
         self.client
-            .request(
+            .request::<()>(
                 "chainHead_v1_continue",
                 rpc_params![follow_subscription, operation_id],
             )
@@ -93,7 +93,7 @@ impl<T: Config> UnstableRpcMethods<T> {
         operation_id: &str,
     ) -> Result<(), Error> {
         self.client
-            .request(
+            .request::<()>(
                 "chainHead_v1_stopOperation",
                 rpc_params![follow_subscription, operation_id],
             )
@@ -221,7 +221,7 @@ impl<T: Config> UnstableRpcMethods<T> {
         hash: T::Hash,
     ) -> Result<(), Error> {
         self.client
-            .request("chainHead_v1_unpin", rpc_params![subscription_id, hash])
+            .request::<()>("chainHead_v1_unpin", rpc_params![subscription_id, hash])
             .await?;
 
         Ok(())

--- a/subxt/src/backend/unstable/rpc_methods.rs
+++ b/subxt/src/backend/unstable/rpc_methods.rs
@@ -73,13 +73,11 @@ impl<T: Config> UnstableRpcMethods<T> {
         operation_id: &str,
     ) -> Result<(), Error> {
         self.client
-            .request::<()>(
+            .request(
                 "chainHead_v1_continue",
                 rpc_params![follow_subscription, operation_id],
             )
-            .await?;
-
-        Ok(())
+            .await
     }
 
     /// Stops an operation started with `chainHead_v1_body`, `chainHead_v1_call`, or
@@ -93,13 +91,11 @@ impl<T: Config> UnstableRpcMethods<T> {
         operation_id: &str,
     ) -> Result<(), Error> {
         self.client
-            .request::<()>(
+            .request(
                 "chainHead_v1_stopOperation",
                 rpc_params![follow_subscription, operation_id],
             )
-            .await?;
-
-        Ok(())
+            .await
     }
 
     /// Call the `chainHead_v1_body` method and return an operation ID to obtain the block's body.
@@ -221,10 +217,8 @@ impl<T: Config> UnstableRpcMethods<T> {
         hash: T::Hash,
     ) -> Result<(), Error> {
         self.client
-            .request::<()>("chainHead_v1_unpin", rpc_params![subscription_id, hash])
-            .await?;
-
-        Ok(())
+            .request("chainHead_v1_unpin", rpc_params![subscription_id, hash])
+            .await
     }
 
     /// Return the genesis hash.


### PR DESCRIPTION
Tiny PR to fix a clippy warning detected in: https://github.com/paritytech/subxt/actions/runs/10735929095/job/29774331171



```
error: `?Sized` bound is ignored because of a `Sized` requirement
   --> core/src/storage/storage_key.rs:185:25
    |
185 | impl<K: codec::Decode + ?Sized> StaticStorageKey<K> {
    |                         ^^^^^^
    |
note: `K` cannot be unsized because of the bound
   --> core/src/storage/storage_key.rs:185:9
    |
185 | impl<K: codec::Decode + ?Sized> StaticStorageKey<K> {
    |         ^^^^^^^^^^^^^
    = note: ...because `Decode` has the bound `Sized`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_maybe_sized
    = note: `-D clippy::needless-maybe-sized` implied by `-D clippy::all`
    = help: to override `-D clippy::all` add `#[allow(clippy::needless_maybe_sized)]`
help: change the bounds that require `Sized`, or remove the `?Sized` bound
    |
185 - impl<K: codec::Decode + ?Sized> StaticStorageKey<K> {
185 + impl<K: codec::Decode> StaticStorageKey<K> {
```