### PR TITLE
substrate runner: increase log parsing to 100 lines

### DIFF
--- a/testing/substrate-runner/src/lib.rs
+++ b/testing/substrate-runner/src/lib.rs
@@ -251,7 +251,7 @@ fn try_find_substrate_port_from_output(
     let mut p2p_address = None;
     let mut p2p_port = None;
 
-    for line in BufReader::new(r).lines().take(50) {
+    for line in BufReader::new(r).lines().take(100) {
         let line = line.expect("failed to obtain next line from stdout for port discovery");
 
         // Parse the port lines


### PR DESCRIPTION
We have seen lots of test failing because of parsing the libp2p I think that's because the logging has increased in polkadot-sdk