### PR TITLE
dependabot: remove ignore for polkadot-sdk crates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,14 +5,6 @@ updates:
       - "**/*"
     schedule:
       interval: weekly
-    ignore:
-    # these need to be updated together, so dependabot PRs
-    # are just noise. So, ignore them:
-    - dependency-name: sp-core
-    - dependency-name: sp-keyring
-    - dependency-name: sp-runtime
-    - dependency-name: sp-crypto-hashing
-    - dependency-name: sp-version
   - package-ecosystem: github-actions
     directory: "**/*"
     schedule:


### PR DESCRIPTION
polkadot-sdk crates are now released on crates.io in accordance with the release process "something every month" and subxt needs update them as well to keep up with the ecosystem

This is really so we don't forget them.