### PR TITLE
fix: error message on rpc errors

### DIFF
--- a/lightclient/src/lib.rs
+++ b/lightclient/src/lib.rs
@@ -43,7 +43,7 @@ pub enum LightClientError {
 #[derive(Debug, thiserror::Error)]
 pub enum LightClientRpcError {
     /// Error response from the JSON-RPC server.
-    #[error("{0}")]
+    #[error(transparent)]
     JsonRpcError(JsonRpcError),
     /// Smoldot could not handle the RPC call.
     #[error("Smoldot could not handle the RPC call: {0}.")]

--- a/subxt/src/backend/rpc/reconnecting_rpc_client/mod.rs
+++ b/subxt/src/backend/rpc/reconnecting_rpc_client/mod.rs
@@ -135,7 +135,7 @@ pub enum Error {
     #[error(transparent)]
     DisconnectedWillReconnect(#[from] DisconnectedWillReconnect),
     /// Other rpc error.
-    #[error("{0}")]
+    #[error(transparent)]
     RpcError(RpcError),
 }
 

--- a/subxt/src/error/mod.rs
+++ b/subxt/src/error/mod.rs
@@ -37,7 +37,7 @@ pub enum Error {
     #[error("Scale codec error: {0}")]
     Codec(#[from] codec::Error),
     /// Rpc error.
-    #[error("Rpc error: {0}")]
+    #[error(transparent)]
     Rpc(#[from] RpcError),
     /// Serde serialization error
     #[error("Serde json error: {0}")]


### PR DESCRIPTION
This PR changes the error message from:

```
Error getting nonce: Rpc error: RPC error: The background task closed connection closed; restart required
```

to:

```
Error getting nonce: RPC error: The background task closed connection closed; restart required
```

Thus, no need to emit RPC twice...