### PR TITLE
codegen: allow(unreachable_patterns) 

### DIFF
--- a/codegen/src/api/mod.rs
+++ b/codegen/src/api/mod.rs
@@ -81,7 +81,7 @@ impl RuntimeGenerator {
 
         Ok(quote! {
             #( #item_mod_attrs )*
-            #[allow(dead_code, unused_imports, non_camel_case_types)]
+            #[allow(dead_code, unused_imports, non_camel_case_types, unreachable_patterns)]
             #[allow(clippy::all)]
             #[allow(rustdoc::broken_intra_doc_links)]
             pub mod #mod_ident {
@@ -233,7 +233,7 @@ impl RuntimeGenerator {
 
         Ok(quote! {
             #( #item_mod_attrs )*
-            #[allow(dead_code, unused_imports, non_camel_case_types)]
+            #[allow(dead_code, unused_imports, non_camel_case_types, unreachable_patterns)]
             #[allow(clippy::all)]
             #[allow(rustdoc::broken_intra_doc_links)]
             pub mod #mod_ident {


### PR DESCRIPTION
It looks like with the new rust version (1.81.0) clippy is complaining, e.g.:
https://gitlab.parity.io/parity/mirrors/parity-bridges-common/-/jobs/7505862

```
error: unreachable pattern
    --> relay-clients/client-polkadot/src/codegen_runtime.rs:5751:22
     |
5751 |                 Void(runtime_types::sp_core::Void),
     |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ matches no values because `codegen_runtime::api::runtime_types::sp_core::Void` is uninhabited
     |
     = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
     = note: `-D unreachable-patterns` implied by `-D warnings`
     = help: to override `-D warnings` add `#[allow(unreachable_patterns)]`
error: unreachable pattern
    --> relay-clients/client-polkadot/src/codegen_runtime.rs:5835:17
     |
5835 |                 ParasShared(runtime_types::polkadot_runtime_parachains::shared::pallet::Call),
     |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ matches no values because `codegen_runtime::api::runtime_types::polkadot_runtime_parachains::shared::pallet::Call` is uninhabited
     |
     = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
error: unreachable pattern
    --> relay-clients/client-polkadot/src/codegen_runtime.rs:5837:19
     |
5837 |                 ParaInclusion(runtime_types::polkadot_runtime_parachains::inclusion::pallet::Call),
     |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ matches no values because `codegen_runtime::api::runtime_types::polkadot_runtime_parachains::inclusion::pallet::Call` is uninhabited
     |
     = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
error: unreachable pattern
    --> relay-clients/client-rococo/src/codegen_runtime.rs:7296:22
     |
7296 |                 Void(runtime_types::sp_core::Void),
     |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ matches no values because `codegen_runtime::api::runtime_types::sp_core::Void` is uninhabited
     |
     = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
     = note: `-D unreachable-patterns` implied by `-D warnings`
     = help: to override `-D warnings` add `#[allow(unreachable_patterns)]`
error: unreachable pattern
    --> relay-clients/client-rococo/src/codegen_runtime.rs:7384:17
     |
7384 |                 ParasShared(runtime_types::polkadot_runtime_parachains::shared::pallet::Call),
     |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ matches no values because `codegen_runtime::api::runtime_types::polkadot_runtime_parachains::shared::pallet::Call` is uninhabited
     |
     = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
error: unreachable pattern
    --> relay-clients/client-rococo/src/codegen_runtime.rs:7386:19
     |
7386 |                 ParaInclusion(runtime_types::polkadot_runtime_parachains::inclusion::pallet::Call),
     |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ matches no values because `codegen_runtime::api::runtime_types::polkadot_runtime_parachains::inclusion::pallet::Call` is uninhabited
     |
     = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
error: unreachable pattern
    --> relay-clients/client-westend/src/codegen_runtime.rs:8835:22
     |
8835 |                 Void(runtime_types::sp_core::Void),
     |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ matches no values because `codegen_runtime::api::runtime_types::sp_core::Void` is uninhabited
     |
     = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
     = note: `-D unreachable-patterns` implied by `-D warnings`
     = help: to override `-D warnings` add `#[allow(unreachable_patterns)]`
error: unreachable pattern
    --> relay-clients/client-westend/src/codegen_runtime.rs:8921:17
     |
8921 |                 ParasShared(runtime_types::polkadot_runtime_parachains::shared::pallet::Call),
     |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ matches no values because `codegen_runtime::api::runtime_types::polkadot_runtime_parachains::shared::pallet::Call` is uninhabited
     |
     = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
error: unreachable pattern
    --> relay-clients/client-westend/src/codegen_runtime.rs:8923:19
     |
8923 |                 ParaInclusion(runtime_types::polkadot_runtime_parachains::inclusion::pallet::Call),
     |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ matches no values because `codegen_runtime::api::runtime_types::polkadot_runtime_parachains::inclusion::pallet::Call` is uninhabited
     |
     = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
error: unreachable pattern
    --> relay-clients/client-kusama/src/codegen_runtime.rs:8864:22
     |
8864 |                 Void(runtime_types::sp_core::Void),
     |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ matches no values because `codegen_runtime::api::runtime_types::sp_core::Void` is uninhabited
     |
     = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
     = note: `-D unreachable-patterns` implied by `-D warnings`
     = help: to override `-D warnings` add `#[allow(unreachable_patterns)]`
error: unreachable pattern
    --> relay-clients/client-kusama/src/codegen_runtime.rs:8962:17
     |
8962 |                 ParasShared(runtime_types::polkadot_runtime_parachains::shared::pallet::Call),
     |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ matches no values because `codegen_runtime::api::runtime_types::polkadot_runtime_parachains::shared::pallet::Call` is uninhabited
     |
     = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
error: unreachable pattern
    --> relay-clients/client-kusama/src/codegen_runtime.rs:8964:19
     |
8964 |                 ParaInclusion(runtime_types::polkadot_runtime_parachains::inclusion::pallet::Call),
     |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ matches no values because `codegen_runtime::api::runtime_types::polkadot_runtime_parachains::inclusion::pallet::Call` is uninhabited
     |
     = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
error: could not compile `relay-polkadot-client` (lib test) due to 3 previous errors
```