### PR TITLE
[ci] Use parity-large runners instead ubuntu-latest-16-cores

### DIFF
--- a/.github/workflows/actions/use-nodes/action.yml
+++ b/.github/workflows/actions/use-nodes/action.yml
@@ -3,7 +3,7 @@ description: Downloads and configures the substrate and polkadot binaries built 
 runs:
   using: composite
   steps:
-    - name: Install curl
+    - name: Install dependencies
       shell: bash
       run: sudo apt-get update && sudo apt-get install -y curl gcc make clang cmake
 

--- a/.github/workflows/actions/use-nodes/action.yml
+++ b/.github/workflows/actions/use-nodes/action.yml
@@ -3,6 +3,10 @@ description: Downloads and configures the substrate and polkadot binaries built 
 runs:
   using: composite
   steps:
+    - name: Install curl
+      shell: bash
+      run: sudo apt-get update && sudo apt-get install -y curl
+
     - name: Download substrate-node binary
       id: download-substrate-binary
       uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6

--- a/.github/workflows/actions/use-nodes/action.yml
+++ b/.github/workflows/actions/use-nodes/action.yml
@@ -5,7 +5,7 @@ runs:
   steps:
     - name: Install curl
       shell: bash
-      run: sudo apt-get update && sudo apt-get install -y curl
+      run: sudo apt-get update && sudo apt-get install -y curl gcc make clang
 
     - name: Download substrate-node binary
       id: download-substrate-binary

--- a/.github/workflows/actions/use-nodes/action.yml
+++ b/.github/workflows/actions/use-nodes/action.yml
@@ -5,7 +5,7 @@ runs:
   steps:
     - name: Install curl
       shell: bash
-      run: sudo apt-get update && sudo apt-get install -y curl gcc make clang
+      run: sudo apt-get update && sudo apt-get install -y curl gcc make clang cmake
 
     - name: Download substrate-node binary
       id: download-substrate-binary

--- a/.github/workflows/actions/use-nodes/action.yml
+++ b/.github/workflows/actions/use-nodes/action.yml
@@ -36,9 +36,8 @@ runs:
         chmod u+x ./polkadot-prepare-worker
         ./substrate-node --version
         ./polkadot --version
-        mkdir -p ~/.local/bin
-        mv ./substrate-node ~/.local/bin
-        mv ./polkadot ~/.local/bin
-        mv ./polkadot-execute-worker ~/.local/bin
-        mv ./polkadot-prepare-worker ~/.local/bin
+        mv ./substrate-node /usr/local/bin
+        mv ./polkadot /usr/local/bin
+        mv ./polkadot-execute-worker /usr/local/bin
+        mv ./polkadot-prepare-worker /usr/local/bin
         rm ./polkadot.tar.gz

--- a/.github/workflows/actions/use-nodes/action.yml
+++ b/.github/workflows/actions/use-nodes/action.yml
@@ -36,8 +36,8 @@ runs:
         chmod u+x ./polkadot-prepare-worker
         ./substrate-node --version
         ./polkadot --version
-        mv ./substrate-node /usr/local/bin
-        mv ./polkadot /usr/local/bin
-        mv ./polkadot-execute-worker /usr/local/bin
-        mv ./polkadot-prepare-worker /usr/local/bin
+        sudo mv ./substrate-node /usr/local/bin
+        sudo mv ./polkadot /usr/local/bin
+        sudo mv ./polkadot-execute-worker /usr/local/bin
+        sudo mv ./polkadot-prepare-worker /usr/local/bin
         rm ./polkadot.tar.gz

--- a/.github/workflows/build-nodes.yml
+++ b/.github/workflows/build-nodes.yml
@@ -6,7 +6,6 @@ on:
   # Run at 2am every day for nightly builds.
   schedule:
     - cron: "0 2 * * *"
-  pull_request:
 
 jobs:
   tests:

--- a/.github/workflows/build-nodes.yml
+++ b/.github/workflows/build-nodes.yml
@@ -6,12 +6,6 @@ on:
   # Run at 2am every day for nightly builds.
   schedule:
     - cron: "0 2 * * *"
-  #remove me, temporary to check self-hosted runners
-  pull_request:
-    # Run jobs for any external PR that wants
-    # to merge to master, too:
-    branches:
-      - master
 
 jobs:
   tests:
@@ -25,12 +19,6 @@ jobs:
 
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler curl gcc make clang cmake
-
-      # - name: Install WASM toolchain
-      #   run: rustup target add wasm32-unknown-unknown
-
-      # - name: Install WASM toolchain
-      #   run: rustup component add rust-src
 
       - name: Install Rust stable toolchain
         uses: actions-rs/toolchain@v1
@@ -60,26 +48,26 @@ jobs:
           cargo install cargo-strip
           cargo strip
 
-      # - name: upload substrate binary
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: nightly-substrate-binary
-      #     path: target/release/substrate-node
-      #     retention-days: 2
-      #     if-no-files-found: error
+      - name: upload substrate binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-substrate-binary
+          path: target/release/substrate-node
+          retention-days: 2
+          if-no-files-found: error
 
       # Note: Uncompressed polkadot binary is ~124MB -> too large for git (max 100MB) without git lfs. Compressed it is only ~45MB
       - name: compress polkadot binary
         run: |
           tar -zcvf target/release/polkadot.tar.gz target/release/polkadot
 
-      # - name: upload polkadot binary
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: nightly-polkadot-binary
-      #     path: |
-      #       target/release/polkadot.tar.gz
-      #       target/release/polkadot-execute-worker
-      #       target/release/polkadot-prepare-worker
-      #     retention-days: 2
-      #     if-no-files-found: error
+      - name: upload polkadot binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-polkadot-binary
+          path: |
+            target/release/polkadot.tar.gz
+            target/release/polkadot-execute-worker
+            target/release/polkadot-prepare-worker
+          retention-days: 2
+          if-no-files-found: error

--- a/.github/workflows/build-nodes.yml
+++ b/.github/workflows/build-nodes.yml
@@ -6,6 +6,7 @@ on:
   # Run at 2am every day for nightly builds.
   schedule:
     - cron: "0 2 * * *"
+  pull_request:
 
 jobs:
   tests:

--- a/.github/workflows/build-nodes.yml
+++ b/.github/workflows/build-nodes.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   tests:
     name: Build Substrate and Polkadot Binaries
-    runs-on: ubuntu-latest-16-cores
+    runs-on: parity-large
     steps:
       - name: checkout polkadot-sdk
         uses: actions/checkout@v4

--- a/.github/workflows/build-nodes.yml
+++ b/.github/workflows/build-nodes.yml
@@ -6,6 +6,12 @@ on:
   # Run at 2am every day for nightly builds.
   schedule:
     - cron: "0 2 * * *"
+  #remove me, temporary to check self-hosted runners
+  pull_request:
+    # Run jobs for any external PR that wants
+    # to merge to master, too:
+    branches:
+      - master
 
 jobs:
   tests:
@@ -18,13 +24,21 @@ jobs:
           repository: paritytech/polkadot-sdk
 
       - name: Install dependencies
-        run: sudo apt-get install -y protobuf-compiler
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler curl gcc make clang cmake
 
-      - name: Install WASM toolchain
-        run: rustup target add wasm32-unknown-unknown
+      # - name: Install WASM toolchain
+      #   run: rustup target add wasm32-unknown-unknown
 
-      - name: Install WASM toolchain
-        run: rustup component add rust-src
+      # - name: Install WASM toolchain
+      #   run: rustup component add rust-src
+
+      - name: Install Rust stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          components: rust-src
+          target: wasm32-unknown-unknown
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2.7.3
@@ -46,26 +60,26 @@ jobs:
           cargo install cargo-strip
           cargo strip
 
-      - name: upload substrate binary
-        uses: actions/upload-artifact@v4
-        with:
-          name: nightly-substrate-binary
-          path: target/release/substrate-node
-          retention-days: 2
-          if-no-files-found: error
+      # - name: upload substrate binary
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: nightly-substrate-binary
+      #     path: target/release/substrate-node
+      #     retention-days: 2
+      #     if-no-files-found: error
 
       # Note: Uncompressed polkadot binary is ~124MB -> too large for git (max 100MB) without git lfs. Compressed it is only ~45MB
       - name: compress polkadot binary
         run: |
           tar -zcvf target/release/polkadot.tar.gz target/release/polkadot
 
-      - name: upload polkadot binary
-        uses: actions/upload-artifact@v4
-        with:
-          name: nightly-polkadot-binary
-          path: |
-            target/release/polkadot.tar.gz
-            target/release/polkadot-execute-worker
-            target/release/polkadot-prepare-worker
-          retention-days: 2
-          if-no-files-found: error
+      # - name: upload polkadot binary
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: nightly-polkadot-binary
+      #     path: |
+      #       target/release/polkadot.tar.gz
+      #       target/release/polkadot-execute-worker
+      #       target/release/polkadot-prepare-worker
+      #     retention-days: 2
+      #     if-no-files-found: error

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -268,7 +268,7 @@ jobs:
 
   tests:
     name: "Test (Native)"
-    runs-on: ubuntu-latest-16-cores
+    runs-on: parity-large
     needs: [clippy, wasm_clippy, check, wasm_check, docs]
     timeout-minutes: 30
     steps:
@@ -302,7 +302,7 @@ jobs:
 
   unstable_backend_tests:
     name: "Test chainhead backend"
-    runs-on: ubuntu-latest-16-cores
+    runs-on: parity-large
     needs: [clippy, wasm_clippy, check, wasm_check, docs]
     timeout-minutes: 30
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -82,7 +82,7 @@ jobs:
 
   clippy:
     name: Cargo clippy
-    runs-on: ubuntu-latest
+    runs-on: parity-large
     needs: [fmt, machete]
     steps:
       - name: Checkout sources
@@ -145,7 +145,7 @@ jobs:
 
   check:
     name: Cargo check
-    runs-on: ubuntu-latest
+    runs-on: parity-large
     needs: [fmt, machete]
     steps:
       - name: Checkout sources
@@ -235,7 +235,7 @@ jobs:
 
   docs:
     name: Check documentation and run doc tests
-    runs-on: ubuntu-latest
+    runs-on: parity-large
     needs: [fmt, machete]
     steps:
       - name: Checkout sources


### PR DESCRIPTION
PR switches `ubuntu-latest-16-cores` runners to `parity-large` since they are cheaper and more powerful.

close https://github.com/paritytech/ci_cd/issues/1065