### PR TITLE
fetch-metadata: remove tokio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10635,6 +10635,7 @@ dependencies = [
  "subxt-metadata",
  "syn 2.0.77",
  "thiserror",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10635,7 +10635,6 @@ dependencies = [
  "subxt-metadata",
  "syn 2.0.77",
  "thiserror",
- "tokio",
 ]
 
 [[package]]
@@ -10699,6 +10698,7 @@ name = "subxt-macro"
 version = "0.37.0"
 dependencies = [
  "darling 0.20.10",
+ "futures",
  "parity-scale-codec",
  "polkadot-sdk",
  "proc-macro-error2",

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -13,8 +13,9 @@ description = "Generate an API for interacting with a substrate node from FRAME 
 
 [features]
 default = []
-fetch-metadata = ["dep:jsonrpsee", "dep:frame-metadata"]
-web = ["jsonrpsee?/async-wasm-client", "jsonrpsee?/client-web-transport", "getrandom/js"]
+fetch-metadata = ["dep:jsonrpsee", "dep:frame-metadata", "dep:url"]
+# NOTE: This is just hack that only enables `getrandom/js` and doesn't do anything else.
+web = ["getrandom/js"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", workspace = true, features = ["derive"] }
@@ -29,6 +30,7 @@ jsonrpsee = { workspace = true, features = ["ws-client", "http-client"], optiona
 hex = { workspace = true, features = ["std"] }
 thiserror = { workspace = true }
 scale-typegen = { workspace = true }
+url = { workspace = true, optional = true }
 
 # Included if "web" feature is enabled, to enable its js feature.
 getrandom = { workspace = true, optional = true }

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -13,7 +13,7 @@ description = "Generate an API for interacting with a substrate node from FRAME 
 
 [features]
 default = []
-fetch-metadata = ["dep:jsonrpsee", "dep:tokio", "dep:frame-metadata"]
+fetch-metadata = ["dep:jsonrpsee", "dep:frame-metadata"]
 web = ["jsonrpsee?/async-wasm-client", "jsonrpsee?/client-web-transport", "getrandom/js"]
 
 [dependencies]
@@ -25,9 +25,8 @@ quote = { workspace = true }
 syn = { workspace = true }
 scale-info = { workspace = true }
 subxt-metadata = { workspace = true }
-jsonrpsee = { workspace = true, features = ["async-client", "client-ws-transport-tls", "http-client"], optional = true }
+jsonrpsee = { workspace = true, features = ["ws-client", "http-client"], optional = true }
 hex = { workspace = true, features = ["std"] }
-tokio = { workspace = true, features = ["rt-multi-thread"], optional = true }
 thiserror = { workspace = true }
 scale-typegen = { workspace = true }
 

--- a/codegen/src/fetch_metadata.rs
+++ b/codegen/src/fetch_metadata.rs
@@ -11,7 +11,7 @@ use jsonrpsee::{
 };
 use std::time::Duration;
 
-pub use jsonrpsee::client_transport::ws::Url;
+pub use url::Url;
 
 /// The metadata version that is fetched from the node.
 #[derive(Default, Debug, Clone, Copy)]

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -29,6 +29,7 @@ quote = { workspace = true }
 subxt-codegen = { workspace = true, features = ["fetch-metadata"] }
 scale-typegen = { workspace = true }
 polkadot-sdk = { workspace = true, optional = true, features = ["sp-io", "sc-executor-common", "sp-state-machine", "sp-maybe-compressed-blob", "sc-executor"] }
+futures = { workspace = true, features = ["executor"] }
 
 [lints]
 workspace = true

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -29,7 +29,7 @@ quote = { workspace = true }
 subxt-codegen = { workspace = true, features = ["fetch-metadata"] }
 scale-typegen = { workspace = true }
 polkadot-sdk = { workspace = true, optional = true, features = ["sp-io", "sc-executor-common", "sp-state-machine", "sp-maybe-compressed-blob", "sc-executor"] }
-futures = { workspace = true }
+futures = { workspace = true, features = ["executor"] }
 
 [lints]
 workspace = true

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -29,7 +29,7 @@ quote = { workspace = true }
 subxt-codegen = { workspace = true, features = ["fetch-metadata"] }
 scale-typegen = { workspace = true }
 polkadot-sdk = { workspace = true, optional = true, features = ["sp-io", "sc-executor-common", "sp-state-machine", "sp-maybe-compressed-blob", "sc-executor"] }
-futures = { workspace = true, features = ["executor"] }
+futures = { workspace = true }
 
 [lints]
 workspace = true


### PR DESCRIPTION
I don't think it's worth to use tokio in fetch-metadata for the blocking API and I removed in favor if futures::executor::block_on