### PR TITLE
fix: `defalt-feature` -> `default-features` in Cargo.toml

### DIFF
--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -42,7 +42,7 @@ features = ["fetch-metadata"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [package.metadata.playground]
-defalt-features = true
+default-features = true
 
 [lints]
 workspace = true

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -75,11 +75,11 @@ polkadot-sdk = { workspace = true, features = ["sp-crypto-hashing", "sp-core", "
 hex = { workspace = true }
 
 [package.metadata.docs.rs]
-defalt-features = true
+default-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [package.metadata.playground]
-defalt-features = true
+default-features = true
 
 [lints]
 workspace = true

--- a/lightclient/Cargo.toml
+++ b/lightclient/Cargo.toml
@@ -70,8 +70,8 @@ instant = { workspace = true, optional = true }
 getrandom = { workspace = true, optional = true }
 
 [package.metadata.docs.rs]
-defalt-features = true
+default-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [package.metadata.playground]
-defalt-features = true
+default-features = true

--- a/signer/Cargo.toml
+++ b/signer/Cargo.toml
@@ -92,11 +92,11 @@ polkadot-sdk = { workspace = true, features = ["sp-core", "sp-keyring"] }
 ignored = ["getrandom"]
 
 [package.metadata.docs.rs]
-defalt-features = true
+default-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [package.metadata.playground]
-defalt-features = true
+default-features = true
 
 [lints]
 workspace = true


### PR DESCRIPTION
This is only used by docs.rs when publishing the crates which is why we are not notified about it.