### PR TITLE
chore(deps): bump frame-decode to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3006,9 +3006,9 @@ dependencies = [
 
 [[package]]
 name = "frame-decode"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed90459016b06a2855321469cb01fbc74208c80c06b085d1ed13162cf8bd7e1b"
+checksum = "055387e30382aec12f626c6d9086b7a7a08844f2a2074c14b415eef48237cff4"
 dependencies = [
  "frame-metadata 16.0.0",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ darling = "0.20.10"
 derive-where = "1.2.7"
 either = { version = "1.13.0", default-features = false }
 finito = { version = "0.1.0", default-features = false }
-frame-decode = { version = "0.3.0", default-features = false }
+frame-decode = { version = "0.4.0", default-features = false }
 frame-metadata = { version = "16.0.0", default-features = false }
 futures = { version = "0.3.30", default-features = false, features = ["std"] }
 getrandom = { version = "0.2", default-features = false }

--- a/metadata/src/lib.rs
+++ b/metadata/src/lib.rs
@@ -27,7 +27,8 @@ use alloc::string::String;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use frame_decode::extrinsics::{
-    ExtrinsicInfo, ExtrinsicInfoArg, ExtrinsicInfoError, ExtrinsicSignatureInfo,
+    ExtrinsicCallInfo, ExtrinsicExtensionInfo, ExtrinsicInfoArg, ExtrinsicInfoError,
+    ExtrinsicSignatureInfo,
 };
 use hashbrown::HashMap;
 use scale_info::{form::PortableForm, PortableRegistry, Variant};
@@ -70,11 +71,11 @@ pub struct Metadata {
 impl frame_decode::extrinsics::ExtrinsicTypeInfo for Metadata {
     type TypeId = u32;
 
-    fn get_extrinsic_info(
+    fn get_call_info(
         &self,
         pallet_index: u8,
         call_index: u8,
-    ) -> Result<ExtrinsicInfo<'_, Self::TypeId>, ExtrinsicInfoError<'_>> {
+    ) -> Result<ExtrinsicCallInfo<'_, Self::TypeId>, ExtrinsicInfoError<'_>> {
         let pallet = self.pallet_by_index(pallet_index).ok_or({
             ExtrinsicInfoError::PalletNotFound {
                 index: pallet_index,
@@ -89,7 +90,7 @@ impl frame_decode::extrinsics::ExtrinsicTypeInfo for Metadata {
             }
         })?;
 
-        Ok(ExtrinsicInfo {
+        Ok(ExtrinsicCallInfo {
             pallet_name: Cow::Borrowed(pallet.name()),
             call_name: Cow::Borrowed(&call.name),
             args: call
@@ -105,11 +106,30 @@ impl frame_decode::extrinsics::ExtrinsicTypeInfo for Metadata {
 
     fn get_signature_info(
         &self,
-    ) -> Result<ExtrinsicSignatureInfo<'_, Self::TypeId>, ExtrinsicInfoError<'_>> {
+    ) -> Result<ExtrinsicSignatureInfo<Self::TypeId>, ExtrinsicInfoError<'_>> {
         Ok(ExtrinsicSignatureInfo {
             address_id: self.extrinsic().address_ty(),
             signature_id: self.extrinsic().signature_ty(),
-            transaction_extension_ids: self
+        })
+    }
+
+    fn get_extension_info(
+        &self,
+        extension_version: Option<u8>,
+    ) -> Result<ExtrinsicExtensionInfo<'_, Self::TypeId>, ExtrinsicInfoError<'_>> {
+        // For now, if there exists an extension version that's non-zero, we say we don't know
+        // how to decode it. When multiple extension versions exist, we may have to tighten up
+        // on this and require V16 metadata to decode.
+        if let Some(extension_version) = extension_version {
+            if extension_version != 0 {
+                return Err(ExtrinsicInfoError::ExtrinsicExtensionVersionNotSupported {
+                    extension_version,
+                });
+            }
+        }
+
+        Ok(ExtrinsicExtensionInfo {
+            extension_ids: self
                 .extrinsic()
                 .signed_extensions()
                 .iter()


### PR DESCRIPTION
This brings the extrinsic decoding in line with latest `polkadot-sdk` master.