### PR TITLE
Prepare 0.37.1 patch release with rudimentory V5 extrinsic support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.37.1] - 2024-10-22
+
+This patch release adds basic support for V5 extrinsics into `subxt-core`. We only bump `subxt-core` in this release; other crates should then take this patch automatically but you may need to `cargo update` to get the change.
+
 ## [0.37.0] - 2024-05-28
 
 This release mainly adds support for the sign extension `CheckMetadataHash` and fixes a regression introduced in v0.36.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "artifacts"
-version = "0.36.1"
+version = "0.37.0"
 dependencies = [
  "substrate-runner",
 ]
@@ -1812,7 +1812,7 @@ dependencies = [
 
 [[package]]
 name = "generate-custom-metadata"
-version = "0.36.1"
+version = "0.37.0"
 dependencies = [
  "frame-metadata 16.0.0",
  "parity-scale-codec",
@@ -2309,7 +2309,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.36.1"
+version = "0.37.0"
 dependencies = [
  "assert_matches",
  "cfg_aliases",
@@ -4745,7 +4745,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-runner"
-version = "0.36.1"
+version = "0.37.0"
 
 [[package]]
 name = "subtle"
@@ -4755,7 +4755,7 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "subxt"
-version = "0.36.1"
+version = "0.37.0"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -4798,7 +4798,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-cli"
-version = "0.36.1"
+version = "0.37.0"
 dependencies = [
  "clap 4.5.4",
  "color-eyre",
@@ -4827,7 +4827,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-codegen"
-version = "0.36.1"
+version = "0.37.0"
 dependencies = [
  "frame-metadata 16.0.0",
  "getrandom",
@@ -4847,7 +4847,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-core"
-version = "0.36.1"
+version = "0.37.1"
 dependencies = [
  "assert_matches",
  "base58",
@@ -4879,7 +4879,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-lightclient"
-version = "0.36.1"
+version = "0.37.0"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4904,7 +4904,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.36.1"
+version = "0.37.0"
 dependencies = [
  "darling 0.20.8",
  "parity-scale-codec",
@@ -4917,7 +4917,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-metadata"
-version = "0.36.1"
+version = "0.37.0"
 dependencies = [
  "assert_matches",
  "bitvec",
@@ -4931,7 +4931,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-signer"
-version = "0.36.1"
+version = "0.37.0"
 dependencies = [
  "bip32",
  "bip39",
@@ -4958,7 +4958,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-test-macro"
-version = "0.36.1"
+version = "0.37.0"
 dependencies = [
  "quote",
  "syn 2.0.60",
@@ -5021,7 +5021,7 @@ dependencies = [
 
 [[package]]
 name = "test-runtime"
-version = "0.36.1"
+version = "0.37.0"
 dependencies = [
  "hex",
  "impl-serde",
@@ -5446,7 +5446,7 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "ui-tests"
-version = "0.36.1"
+version = "0.37.0"
 dependencies = [
  "frame-metadata 16.0.0",
  "generate-custom-metadata",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subxt-core"
-version.workspace = true
+version = "0.37.1"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/core/src/blocks/extrinsics.rs
+++ b/core/src/blocks/extrinsics.rs
@@ -195,7 +195,7 @@ where
             .then(|| -> Result<SignedExtrinsicDetails, Error> {
                 let address_start_idx = bytes.len() - cursor.len();
                 // Skip over the address, signature and extra fields. If V5 general
-                // extrinsic then there is no address and signature so skip nothing,
+                // extrinsic then there is no address and signature so skip nothing.
                 if !is_general {
                     scale_decode::visitor::decode_with_visitor(
                         cursor,

--- a/core/src/blocks/extrinsics.rs
+++ b/core/src/blocks/extrinsics.rs
@@ -174,7 +174,7 @@ where
         let bytes: Arc<[u8]> = strip_compact_prefix(extrinsic_bytes)?.1.into();
 
         // Extrinsic are encoded in memory in the following way:
-        //   - first byte: abbbbbbb (a = 0 for unsigned, 1 for signed, b = version)
+        //   - first byte: aabbbbbb (a = 00 for unsigned, 10 for signed, 01 for general, b = version)
         //   - signature: [unknown TBD with metadata].
         //   - extrinsic data
         let first_byte: u8 = Decode::decode(&mut &bytes[..])?;

--- a/subxt/src/backend/legacy/rpc_methods.rs
+++ b/subxt/src/backend/legacy/rpc_methods.rs
@@ -332,8 +332,7 @@ impl<T: Config> LegacyRpcMethods<T> {
         public: Vec<u8>,
     ) -> Result<(), Error> {
         let params = rpc_params![key_type, suri, Bytes(public)];
-        self.client.request("author_insertKey", params).await?;
-        Ok(())
+        self.client.request("author_insertKey", params).await
     }
 
     /// Generate new session keys and returns the corresponding public keys.

--- a/subxt/src/backend/unstable/rpc_methods.rs
+++ b/subxt/src/backend/unstable/rpc_methods.rs
@@ -77,9 +77,7 @@ impl<T: Config> UnstableRpcMethods<T> {
                 "chainHead_v1_continue",
                 rpc_params![follow_subscription, operation_id],
             )
-            .await?;
-
-        Ok(())
+            .await
     }
 
     /// Stops an operation started with `chainHead_v1_body`, `chainHead_v1_call`, or
@@ -97,9 +95,7 @@ impl<T: Config> UnstableRpcMethods<T> {
                 "chainHead_v1_stopOperation",
                 rpc_params![follow_subscription, operation_id],
             )
-            .await?;
-
-        Ok(())
+            .await
     }
 
     /// Call the `chainHead_v1_body` method and return an operation ID to obtain the block's body.
@@ -222,9 +218,7 @@ impl<T: Config> UnstableRpcMethods<T> {
     ) -> Result<(), Error> {
         self.client
             .request("chainHead_v1_unpin", rpc_params![subscription_id, hash])
-            .await?;
-
-        Ok(())
+            .await
     }
 
     /// Return the genesis hash.


### PR DESCRIPTION
I hacked in basic support for V5 extrinsics here. This was much simpler to do then porting this release to use `frame-decode` in a non-breaking way.

This should help to unblock users on 0.37 who start running into V5 extrinsics in eg Substrate's kitchensink runtime.

(I hacked the tests to work again and things seemed to decode OK still)