### PR TITLE
Re-export jsonrpsee from `subxt::ext`

### DIFF
--- a/subxt/src/lib.rs
+++ b/subxt/src/lib.rs
@@ -112,6 +112,10 @@ pub mod ext {
     pub use scale_value;
     pub use subxt_core;
 
+    cfg_jsonrpsee! {
+        pub use jsonrpsee;
+    }
+
     cfg_substrate_compat! {
         pub use subxt_core::ext::{sp_runtime, sp_core};
     }


### PR DESCRIPTION
Re-export so that downstream code can downcast RpcError to ErrorObject