### PR TITLE
Ignore unnecessary Extra and Call types in UncheckedExtrinsic and validation.

### DIFF
--- a/.github/workflows/build-nodes.yml
+++ b/.github/workflows/build-nodes.yml
@@ -16,8 +16,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: paritytech/polkadot-sdk
-          # TODO: Temporary to pin a specific polkadot commit because of that substrate master doesn't work
-          ref: 356386b56881a7a2cb1b0be5628ad2a97678b34d
 
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler curl gcc make clang cmake

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -351,7 +351,7 @@ fn default_derives(crate_path: &syn::Path) -> DerivesRegistry {
 fn default_substitutes(crate_path: &syn::Path) -> TypeSubstitutes {
     let mut type_substitutes = TypeSubstitutes::new();
 
-    let defaults: [(syn::Path, syn::Path); 13] = [
+    let defaults: [(syn::Path, syn::Path); 14] = [
         (
             parse_quote!(bitvec::order::Lsb0),
             parse_quote!(#crate_path::utils::bits::Lsb0),
@@ -409,10 +409,17 @@ fn default_substitutes(crate_path: &syn::Path) -> TypeSubstitutes {
         // `EncodeAsType` the bytes would be re-encoded. This leads to the bytes
         // being altered by adding the length prefix in front of them.
 
-        // Note: Not sure if this is appropriate or not. The most recent polkadot.rs file does not have these.
+        // This allows things calls that require an `UncheckedExtrinsic` type to be given our
+        // util one, which was be converted from a Vec<u8>:
         (
             parse_quote!(sp_runtime::generic::unchecked_extrinsic::UncheckedExtrinsic),
             parse_quote!(#crate_path::utils::UncheckedExtrinsic),
+        ),
+        // This extends the above to also work with runtimes that set the UncheckedExtrinsic
+        // type to the one from pallet_revive (used for handling EVM transactions):
+        (
+            parse_quote!(pallet_revive::evm::runtime::UncheckedExtrinsic<Address, Call>),
+            parse_quote!(#crate_path::utils::UncheckedExtrinsic<Address, Call, u8, u8>),
         ),
     ];
 

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -351,7 +351,7 @@ fn default_derives(crate_path: &syn::Path) -> DerivesRegistry {
 fn default_substitutes(crate_path: &syn::Path) -> TypeSubstitutes {
     let mut type_substitutes = TypeSubstitutes::new();
 
-    let defaults: [(syn::Path, syn::Path); 14] = [
+    let defaults: [(syn::Path, syn::Path); 13] = [
         (
             parse_quote!(bitvec::order::Lsb0),
             parse_quote!(#crate_path::utils::bits::Lsb0),
@@ -414,12 +414,6 @@ fn default_substitutes(crate_path: &syn::Path) -> TypeSubstitutes {
         (
             parse_quote!(sp_runtime::generic::unchecked_extrinsic::UncheckedExtrinsic),
             parse_quote!(#crate_path::utils::UncheckedExtrinsic),
-        ),
-        // This extends the above to also work with runtimes that set the UncheckedExtrinsic
-        // type to the one from pallet_revive (used for handling EVM transactions):
-        (
-            parse_quote!(pallet_revive::evm::runtime::UncheckedExtrinsic<Address, Call>),
-            parse_quote!(#crate_path::utils::UncheckedExtrinsic<Address, Call, u8, u8>),
         ),
     ];
 

--- a/metadata/src/from_into/v14.rs
+++ b/metadata/src/from_into/v14.rs
@@ -300,10 +300,10 @@ impl ExtrinsicPartTypeIds {
         let extra = find_param(EXTRA);
 
         Ok(ExtrinsicPartTypeIds {
-            address: address,
-            signature: signature,
-            call: call,
-            extra: extra,
+            address,
+            signature,
+            call,
+            extra,
         })
     }
 }

--- a/metadata/src/lib.rs
+++ b/metadata/src/lib.rs
@@ -595,16 +595,21 @@ impl ConstantMetadata {
 pub struct ExtrinsicMetadata {
     /// The type of the address that signs the extrinsic
     address_ty: u32,
-    /// The type of the outermost Call enum.
-    call_ty: u32,
     /// The type of the extrinsic's signature.
     signature_ty: u32,
-    /// The type of the outermost Extra enum.
-    extra_ty: u32,
     /// Extrinsic version.
     version: u8,
     /// The signed extensions in the order they appear in the extrinsic.
     signed_extensions: Vec<SignedExtensionMetadata>,
+
+    /// The type of the outermost Call enum.
+    /// Note: This isn't used in Subxt, and may be a naff value, but is preserved
+    /// where possible to allow converting back into V15 metadata losslessly.
+    call_ty: u32,
+    /// The type of the outermost Extra enum.
+    /// Note: This isn't used in Subxt, and may be a naff value, but is preserved
+    /// where possible to allow converting back into V15 metadata losslessly.
+    extra_ty: u32,
 }
 
 impl ExtrinsicMetadata {
@@ -613,17 +618,9 @@ impl ExtrinsicMetadata {
         self.address_ty
     }
 
-    /// The type of the outermost Call enum.
-    pub fn call_ty(&self) -> u32 {
-        self.call_ty
-    }
     /// The type of the extrinsic's signature.
     pub fn signature_ty(&self) -> u32 {
         self.signature_ty
-    }
-    /// The type of the outermost Extra enum.
-    pub fn extra_ty(&self) -> u32 {
-        self.extra_ty
     }
 
     /// Extrinsic version.

--- a/metadata/src/utils/retain.rs
+++ b/metadata/src/utils/retain.rs
@@ -86,12 +86,7 @@ impl TypeSet {
     }
 
     fn collect_extrinsic_types(&mut self, extrinsic: &ExtrinsicMetadata) {
-        for ty in [
-            extrinsic.address_ty,
-            extrinsic.call_ty,
-            extrinsic.signature_ty,
-            extrinsic.extra_ty,
-        ] {
+        for ty in [extrinsic.address_ty, extrinsic.signature_ty] {
             self.insert(ty);
         }
 
@@ -286,10 +281,8 @@ fn iterate_metadata_types(metadata: &mut Metadata) -> impl Iterator<Item = &mut 
 
     // collect extrinsic type_ids
     for ty in [
-        &mut metadata.extrinsic.extra_ty,
         &mut metadata.extrinsic.address_ty,
         &mut metadata.extrinsic.signature_ty,
-        &mut metadata.extrinsic.call_ty,
     ] {
         types.push(ty);
     }

--- a/metadata/src/utils/validation.rs
+++ b/metadata/src/utils/validation.rs
@@ -291,14 +291,8 @@ fn get_extrinsic_hash(
     let address_hash = get_type_hash(registry, extrinsic.address_ty, outer_enum_hashes);
     // The `RuntimeCall` type is intentionally omitted and hashed by the outer enums instead.
     let signature_hash = get_type_hash(registry, extrinsic.signature_ty, outer_enum_hashes);
-    let extra_hash = get_type_hash(registry, extrinsic.extra_ty, outer_enum_hashes);
 
-    let mut bytes = concat_and_hash4(
-        &address_hash,
-        &signature_hash,
-        &extra_hash,
-        &[extrinsic.version; 32],
-    );
+    let mut bytes = concat_and_hash3(&address_hash, &signature_hash, &[extrinsic.version; 32]);
 
     for signed_extension in extrinsic.signed_extensions.iter() {
         bytes = concat_and_hash4(

--- a/testing/integration-tests/src/full_client/client/mod.rs
+++ b/testing/integration-tests/src/full_client/client/mod.rs
@@ -44,7 +44,7 @@ async fn storage_fetch_raw_keys() {
         .count()
         .await;
 
-    assert_eq!(len, 14)
+    assert_eq!(len, 16)
 }
 
 #[cfg(fullclient)]
@@ -69,7 +69,7 @@ async fn storage_iter() {
         .count()
         .await;
 
-    assert_eq!(len, 14);
+    assert_eq!(len, 16);
 }
 
 #[cfg(fullclient)]


### PR DESCRIPTION
This isn't necessary for working with pallet_revive's `UncheckedExtrinsic` any more, but let's not expose/require types that we don't actually need any more to be a little more toelrant and prepare for V16 metadata which won't have an `extra` type anyway.

Fix number of account IDs from storage tests.

Old description:

1. Make extracting `Call` and `Extra` generic params from the extrinsic type optional. 

   Until now, the extrinsic type was basically always `UncheckedExtrinsic<Address, Call, Signature, Extra>`, and so the TypeInfo of that provided the address, call, signature and extra type IDs, which we'd extract in V14 metadata. (In V15 metadata these Ids are all explicit and we don't need to extract anything from the extrinsic type). 

   Now, we only _need_ `Address` and `Signature` types, making Subxt compatible with eg [`pallet_revive::evm::runtime::UncheckedExtrinsic<Address, Signature, E: EthExtra>`](https://github.com/paritytech/polkadot-sdk/blob/master/substrate/frame/revive/src/evm/runtime.rs#L57). Turns out that Subxt didn't really use the other two types anyway.

2. ~~When generating the Subxt interface from metadata, also find and substitute `pallet_revive::evm::runtime::UncheckedExtrinsic<Address, Signature>` for our `subxt::utile::UncheckedExtrinsic`, so that it's still possible to provide bytes as arguments that ask for that type in the generated APIs.~~