### PR TITLE
Load latest metadata version from Wasm blobs.

### DIFF
--- a/macro/src/wasm_loader.rs
+++ b/macro/src/wasm_loader.rs
@@ -14,6 +14,8 @@ use polkadot_sdk::{
 };
 use subxt_codegen::{CodegenError, Metadata};
 
+static SUPPORTED_METADATA_VERSIONS: [u32; 2] = [14, 15];
+
 /// Result type shorthand
 pub type WasmMetadataResult<A> = Result<A, CodegenError>;
 
@@ -26,67 +28,133 @@ pub fn from_wasm_file(wasm_file_path: &Path) -> WasmMetadataResult<Metadata> {
 }
 
 fn call_and_decode(wasm_file: Vec<u8>) -> WasmMetadataResult<Metadata> {
-    let mut ext: sp_state_machine::BasicExternalities = Default::default();
+    let mut executor = Executor::new(&wasm_file)?;
 
-    let executor: WasmExecutor<sp_io::SubstrateHostFunctions> = WasmExecutor::builder()
-        .with_execution_method(WasmExecutionMethod::default())
-        .with_offchain_heap_alloc_strategy(sc_executor::HeapAllocStrategy::Dynamic {
-            maximum_pages: Some(64),
-        })
-        .with_max_runtime_instances(1)
-        .with_runtime_cache_size(1)
-        .build();
-
-    let runtime_blob =
-        RuntimeBlob::new(&wasm_file).map_err(|e| CodegenError::Wasm(e.to_string()))?;
-
-    let version = executor
-        .uncached_call(
-            runtime_blob.clone(),
-            &mut ext,
-            true,
-            "Metadata_metadata_versions",
-            &[],
-        )
-        .map_err(|_| {
-            CodegenError::Wasm("method \"Metadata_metadata_versions\" doesnt exist".to_owned())
-        })?;
-    let mut versions = <Vec<u32>>::decode(&mut &version[..]).map_err(CodegenError::Decode)?;
-
-    // Highest version will always be the last one in the vec
-    versions.sort();
-
-    let version = versions
-        .last()
-        .ok_or(CodegenError::Other(
-            "No metadata versions were returned".to_owned(),
-        ))
-        .map(|v| v.encode())?;
-
-    let encoded_metadata = executor
-        .uncached_call(
-            runtime_blob,
-            &mut ext,
-            false,
-            "Metadata_metadata_at_version",
-            &version,
-        )
-        .map_err(|e| {
-            dbg!(e);
-            CodegenError::Wasm("method \"Metadata_metadata_at_version\" doesnt exist".to_owned())
-        })?;
-
-    decode(encoded_metadata)
+    if let Ok(versions) = executor.versions() {
+        executor.load_metadata_at_latest_version(versions)
+    } else {
+        executor.metadata()
+    }
 }
 
 fn decode(encoded_metadata: Vec<u8>) -> WasmMetadataResult<Metadata> {
-    // We slice the first byte from the metadata because it's wrapped inside an option and we know that its always `Some`
-    let metadata = <Vec<u8>>::decode(&mut &encoded_metadata[1..]).map_err(CodegenError::Decode)?;
-    Metadata::decode(&mut metadata.as_ref()).map_err(Into::into)
+    Metadata::decode(&mut encoded_metadata.as_ref()).map_err(Into::into)
 }
 
 fn maybe_decompress(file_contents: Vec<u8>) -> WasmMetadataResult<Vec<u8>> {
     sp_maybe_compressed_blob::decompress(file_contents.as_ref(), CODE_BLOB_BOMB_LIMIT)
         .map_err(|e| CodegenError::Wasm(e.to_string()))
         .map(Cow::into_owned)
+}
+
+struct Executor {
+    runtime_blob: RuntimeBlob,
+    executor: WasmExecutor<sp_io::SubstrateHostFunctions>,
+    externalities: sp_state_machine::BasicExternalities,
+}
+
+impl Executor {
+    fn new(wasm_file: &[u8]) -> WasmMetadataResult<Self> {
+        let externalities: sp_state_machine::BasicExternalities = Default::default();
+
+        let executor: WasmExecutor<sp_io::SubstrateHostFunctions> = WasmExecutor::builder()
+            .with_execution_method(WasmExecutionMethod::default())
+            .with_offchain_heap_alloc_strategy(sc_executor::HeapAllocStrategy::Dynamic {
+                maximum_pages: Some(64),
+            })
+            .with_max_runtime_instances(1)
+            .with_runtime_cache_size(1)
+            .build();
+
+        let runtime_blob =
+            RuntimeBlob::new(wasm_file).map_err(|e| CodegenError::Wasm(e.to_string()))?;
+
+        Ok(Self {
+            runtime_blob,
+            executor,
+            externalities,
+        })
+    }
+
+    fn versions(&mut self) -> WasmMetadataResult<Vec<u32>> {
+        let version = self
+            .executor
+            .uncached_call(
+                self.runtime_blob.clone(),
+                &mut self.externalities,
+                true,
+                "Metadata_metadata_versions",
+                &[],
+            )
+            .map_err(|_| {
+                CodegenError::Wasm("method \"Metadata_metadata_versions\" doesnt exist".to_owned())
+            })?;
+        let versions = <Vec<u32>>::decode(&mut &version[..])
+            .map_err(CodegenError::Decode)
+            .map(|x| {
+                x.into_iter()
+                    .filter(|version| SUPPORTED_METADATA_VERSIONS.contains(version))
+                    .collect::<Vec<u32>>()
+            })?;
+
+        if versions.is_empty() {
+            return Err(CodegenError::Other(
+                "No supported metadata versions were returned".to_owned(),
+            ));
+        }
+
+        Ok(versions)
+    }
+
+    fn metadata(&mut self) -> WasmMetadataResult<Metadata> {
+        let encoded_metadata = self
+            .executor
+            .uncached_call(
+                self.runtime_blob.clone(),
+                &mut self.externalities,
+                false,
+                "Metadata_metadata",
+                &[],
+            )
+            .map_err(|_| {
+                CodegenError::Wasm("method \"Metadata_metadata\" doesnt exist".to_owned())
+            })?;
+        let encoded_metadata =
+            <Vec<u8>>::decode(&mut &encoded_metadata[..]).map_err(CodegenError::Decode)?;
+        decode(encoded_metadata)
+    }
+
+    fn load_metadata_at_latest_version(
+        &mut self,
+        versions: Vec<u32>,
+    ) -> WasmMetadataResult<Metadata> {
+        let version = versions
+            .into_iter()
+            .max()
+            .expect("This is checked earlier and can't fail.");
+
+        let encoded_metadata = self
+            .executor
+            .uncached_call(
+                self.runtime_blob.clone(),
+                &mut self.externalities,
+                false,
+                "Metadata_metadata_at_version",
+                &version.encode(),
+            )
+            .map_err(|e| {
+                dbg!(e);
+                CodegenError::Wasm(
+                    "method \"Metadata_metadata_at_version\" doesnt exist".to_owned(),
+                )
+            })?;
+        let Some(encoded_metadata) =
+            <Option<Vec<u8>>>::decode(&mut &encoded_metadata[..]).map_err(CodegenError::Decode)?
+        else {
+            return Err(CodegenError::Other(
+                format!("Received empty metadata at version: v{version}").to_owned(),
+            ));
+        };
+        decode(encoded_metadata)
+    }
 }


### PR DESCRIPTION
### Description 
> https://github.com/paritytech/subxt/issues/1858#issuecomment-2464516322
> The reason for this is that the WASM loader thing calls `Metadata_metadata`, which only returns V14 metadata. We should use `Metadata_metadata_at_version` and `Metadata_versions` to extract the appropriate metadata (V15 is possible, V14 if not)

closes #1858