### PR TITLE
subxt: when native feature is enabled, we need polkadot-sdk/std for eg examples to work

### DIFF
--- a/subxt/Cargo.toml
+++ b/subxt/Cargo.toml
@@ -31,6 +31,7 @@ native = [
     "subxt-lightclient?/native",
     "tokio-util",
     "tokio?/sync",
+    "polkadot-sdk/std",
 ]
 
 # Enable this for web/wasm builds.


### PR DESCRIPTION
Without this, commands like the following will fail:

```
cd subxt && cargo run --example light_client_local_node --features unstable-light-client    
```

This because when "std" is not enabled on "polkadot-sdk", it assumes it's compiling for WASM