### PR TITLE
Fix unstable-light-client + ChainHeadBackend tx events

### DIFF
--- a/subxt/src/backend/chain_head/mod.rs
+++ b/subxt/src/backend/chain_head/mod.rs
@@ -682,8 +682,8 @@ impl<T: Config + Send + Sync + 'static> Backend<T> for ChainHeadBackend<T> {
                     rpc_methods::TransactionStatus::BestChainBlockIncluded { block: None } => {
                         TransactionStatus::NoLongerInBestBlock
                     }
-                    rpc_methods::TransactionStatus::Broadcasted { num_peers } => {
-                        TransactionStatus::Broadcasted { num_peers }
+                    rpc_methods::TransactionStatus::Broadcasted => {
+                        TransactionStatus::Broadcasted
                     }
                     rpc_methods::TransactionStatus::Dropped { error, .. } => {
                         TransactionStatus::Dropped { message: error }

--- a/subxt/src/backend/chain_head/mod.rs
+++ b/subxt/src/backend/chain_head/mod.rs
@@ -682,9 +682,7 @@ impl<T: Config + Send + Sync + 'static> Backend<T> for ChainHeadBackend<T> {
                     rpc_methods::TransactionStatus::BestChainBlockIncluded { block: None } => {
                         TransactionStatus::NoLongerInBestBlock
                     }
-                    rpc_methods::TransactionStatus::Broadcasted => {
-                        TransactionStatus::Broadcasted
-                    }
+                    rpc_methods::TransactionStatus::Broadcasted => TransactionStatus::Broadcasted,
                     rpc_methods::TransactionStatus::Dropped { error, .. } => {
                         TransactionStatus::Dropped { message: error }
                     }

--- a/subxt/src/backend/chain_head/rpc_methods.rs
+++ b/subxt/src/backend/chain_head/rpc_methods.rs
@@ -709,6 +709,10 @@ pub enum TransactionStatus<Hash> {
     /// Transaction is part of the future queue.
     Validated,
     /// The transaction has been broadcast to other nodes.
+    /// 
+    /// Note: This event is no longer expected to be returned as of
+    /// the chainHead_v1 spec, but we do so for compatibility with
+    /// older versions of Smoldot, which do return it.
     Broadcasted,
     /// Transaction has been included in block with given details.
     /// Null is returned if the transaction is no longer in any block

--- a/subxt/src/backend/chain_head/rpc_methods.rs
+++ b/subxt/src/backend/chain_head/rpc_methods.rs
@@ -709,10 +709,7 @@ pub enum TransactionStatus<Hash> {
     /// Transaction is part of the future queue.
     Validated,
     /// The transaction has been broadcast to other nodes.
-    Broadcasted {
-        /// Number of peers it's been broadcast to.
-        num_peers: u32,
-    },
+    Broadcasted,
     /// Transaction has been included in block with given details.
     /// Null is returned if the transaction is no longer in any block
     /// of the best chain.
@@ -737,8 +734,6 @@ pub enum TransactionStatus<Hash> {
     },
     /// The transaction was dropped.
     Dropped {
-        /// Was the transaction broadcasted to other nodes before being dropped?
-        broadcasted: bool,
         /// Human readable message; why was it dropped.
         error: String,
     },

--- a/subxt/src/backend/chain_head/rpc_methods.rs
+++ b/subxt/src/backend/chain_head/rpc_methods.rs
@@ -709,7 +709,7 @@ pub enum TransactionStatus<Hash> {
     /// Transaction is part of the future queue.
     Validated,
     /// The transaction has been broadcast to other nodes.
-    /// 
+    ///
     /// Note: This event is no longer expected to be returned as of
     /// the chainHead_v1 spec, but we do so for compatibility with
     /// older versions of Smoldot, which do return it.

--- a/subxt/src/backend/legacy/mod.rs
+++ b/subxt/src/backend/legacy/mod.rs
@@ -354,10 +354,8 @@ impl<T: Config + Send + Sync + 'static> Backend<T> for LegacyBackend<T> {
                         RpcTransactionStatus::Retracted(_) => None,
                         // These roughly map across:
                         RpcTransactionStatus::Ready => Some(TransactionStatus::Validated),
-                        RpcTransactionStatus::Broadcast(peers) => {
-                            Some(TransactionStatus::Broadcasted {
-                                num_peers: peers.len() as u32,
-                            })
+                        RpcTransactionStatus::Broadcast(_peers) => {
+                            Some(TransactionStatus::Broadcasted)
                         }
                         RpcTransactionStatus::InBlock(hash) => {
                             Some(TransactionStatus::InBestBlock {

--- a/subxt/src/backend/mod.rs
+++ b/subxt/src/backend/mod.rs
@@ -290,10 +290,7 @@ pub enum TransactionStatus<Hash> {
     /// Transaction is part of the future queue.
     Validated,
     /// The transaction has been broadcast to other nodes.
-    Broadcasted {
-        /// Number of peers it's been broadcast to.
-        num_peers: u32,
-    },
+    Broadcasted,
     /// Transaction is no longer in a best block.
     NoLongerInBestBlock,
     /// Transaction has been included in block with given hash.

--- a/subxt/src/tx/tx_progress.rs
+++ b/subxt/src/tx/tx_progress.rs
@@ -135,7 +135,7 @@ impl<T: Config, C: Clone> Stream for TxProgress<T, C> {
         sub.poll_next_unpin(cx).map_ok(|status| {
             match status {
                 BackendTxStatus::Validated => TxStatus::Validated,
-                BackendTxStatus::Broadcasted { num_peers } => TxStatus::Broadcasted { num_peers },
+                BackendTxStatus::Broadcasted => TxStatus::Broadcasted,
                 BackendTxStatus::NoLongerInBestBlock => TxStatus::NoLongerInBestBlock,
                 BackendTxStatus::InBestBlock { hash } => {
                     TxStatus::InBestBlock(TxInBlock::new(hash, self.ext_hash, self.client.clone()))
@@ -172,10 +172,7 @@ pub enum TxStatus<T: Config, C> {
     /// Transaction is part of the future queue.
     Validated,
     /// The transaction has been broadcast to other nodes.
-    Broadcasted {
-        /// Number of peers it's been broadcast to.
-        num_peers: u32,
-    },
+    Broadcasted,
     /// Transaction is no longer in a best block.
     NoLongerInBestBlock,
     /// Transaction has been included in block with given hash.
@@ -363,7 +360,7 @@ mod test {
     #[tokio::test]
     async fn wait_for_finalized_returns_err_when_error() {
         let tx_progress = mock_tx_progress(vec![
-            MockSubstrateTxStatus::Broadcasted { num_peers: 2 },
+            MockSubstrateTxStatus::Broadcasted,
             MockSubstrateTxStatus::Error {
                 message: "err".into(),
             },
@@ -378,7 +375,7 @@ mod test {
     #[tokio::test]
     async fn wait_for_finalized_returns_err_when_invalid() {
         let tx_progress = mock_tx_progress(vec![
-            MockSubstrateTxStatus::Broadcasted { num_peers: 2 },
+            MockSubstrateTxStatus::Broadcasted,
             MockSubstrateTxStatus::Invalid {
                 message: "err".into(),
             },
@@ -393,7 +390,7 @@ mod test {
     #[tokio::test]
     async fn wait_for_finalized_returns_err_when_dropped() {
         let tx_progress = mock_tx_progress(vec![
-            MockSubstrateTxStatus::Broadcasted { num_peers: 2 },
+            MockSubstrateTxStatus::Broadcasted,
             MockSubstrateTxStatus::Dropped {
                 message: "err".into(),
             },


### PR DESCRIPTION
- Remove the `numPeers` from the "broadcasted" TX event (the entire event is no longer in the spec but we keep it around for now just because Smoldot still returns it: https://github.com/smol-dot/smoldot/issues/2033)
- Remove `broadcasted` from the "dropped" TX event (also no longer in the spec)

Both of these changes should be backward compatible: it doesn't matter if the JSON returned contains the removed fields.

Oddly, when encountering the error, I was noticing that Smoldot was returning the JSON we expected ie `{"event":"broadcasted","numPeers":1}`. I'm not sure why this wasn't being properly deserialized by us in the first place (we expect `num_peers` but also `rename_all = "camelCase"` so it should line up).

This can be tested by running the following example, which fails prior to this change and passes after it:

```rust
#![allow(missing_docs)]
use subxt::utils::fetch_chainspec_from_rpc_node;
use subxt::{
    client::OnlineClient,
    lightclient::{ChainConfig, LightClient},
    PolkadotConfig,
};
use subxt_signer::sr25519::dev;
use subxt::backend::chain_head::{ChainHeadBackend, ChainHeadBackendBuilder};

// Generate an interface that we can use from the node's metadata.
#[subxt::subxt(runtime_metadata_path = "../artifacts/polkadot_metadata_small.scale")]
pub mod polkadot {}

#[tokio::main]
async fn main() -> Result<(), Box<dyn std::error::Error>> {
    // The smoldot logs are informative:
    tracing_subscriber::fmt::init();

    // Use a utility function to obtain a chain spec from a locally running node:
    let chain_spec = fetch_chainspec_from_rpc_node("ws://127.0.0.1:9944").await?;

    // Configure the bootnodes of this chain spec. In this case, because we start one
    // single node, the bootnodes must be overwritten for the light client to connect
    // to the local node.
    //
    // The `12D3KooWEyoppNCUx8Yx66oV9fJnriXwCcXwDDUA2kj6vnc6iDEp` is the P2P address
    // from a local polkadot node starting with
    // `--node-key 0000000000000000000000000000000000000000000000000000000000000001`
    let chain_config = ChainConfig::chain_spec(chain_spec.get()).set_bootnodes([
        "/ip4/127.0.0.1/tcp/30333/p2p/12D3KooWEyoppNCUx8Yx66oV9fJnriXwCcXwDDUA2kj6vnc6iDEp",
    ])?;

    // Start the light client up, establishing a connection to the local node.
    let (_light_client, chain_rpc) = LightClient::relay_chain(chain_config)?;

    let backend: ChainHeadBackend<PolkadotConfig> =
        ChainHeadBackendBuilder::default().build_with_background_driver(chain_rpc.clone());

    let api = OnlineClient::<PolkadotConfig>::from_backend(backend.into()).await?;

    // Build a balance transfer extrinsic.
    let dest = dev::bob().public_key().into();
    let balance_transfer_tx = polkadot::tx().balances().transfer_allow_death(dest, 10_000);

    // Submit the balance transfer extrinsic from Alice, and wait for it to be successful
    // and in a finalized block. We get back the extrinsic events if all is well.
    let from = dev::alice();
    let events = api
        .tx()
        .sign_and_submit_then_watch_default(&balance_transfer_tx, &from)
        .await?
        .wait_for_finalized_success()
        .await?;

    // Find a Transfer event and print it.
    let transfer_event = events.find_first::<polkadot::balances::events::Transfer>()?;
    if let Some(event) = transfer_event {
        println!("Balance transfer success: {event:?}");
    }

    Ok(())
}

```

Supercedes #1863