### PR TITLE
Re-enable WASM signer tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -412,12 +412,11 @@ jobs:
           pkill substrate-node
         working-directory: testing/wasm-lightclient-tests
 
-      # TODO: WASM tests for the subxt-signer is currently broken https://github.com/paritytech/subxt/issues/1861.
-      #- name: Run subxt-signer WASM tests
-      #  run: |
-      #    wasm-pack test --headless --firefox
-      #    wasm-pack test --headless --chrome
-      #  working-directory: signer/wasm-tests
+      - name: Run subxt-signer WASM tests
+        run: |
+          wasm-pack test --headless --firefox
+          wasm-pack test --headless --chrome
+        working-directory: signer/wasm-tests
 
       - if: "failure()"
         uses: "andymckay/cancel-action@a955d435292c0d409d104b57d8e78435a93a6ef1" # v0.5


### PR DESCRIPTION
The Chrome WASM tests work ok for me locally, but the firefox ones fail owing to https://github.com/rustwasm/wasm-pack/issues/1449. Attempting to re-enable them to see if they pass again in CI

Close #1861 