### PR TITLE
Attempt to quickfix flaky legacy_and_unstable_block_subscription_reconnect

### DIFF
--- a/testing/integration-tests/src/full_client/client/mod.rs
+++ b/testing/integration-tests/src/full_client/client/mod.rs
@@ -412,7 +412,7 @@ async fn partial_fee_estimate_correct() {
     assert_eq!(partial_fee_1, partial_fee_2);
 }
 
-#[subxt_test]
+#[subxt_test(timeout = 120)]
 async fn legacy_and_unstable_block_subscription_reconnect() {
     let ctx = test_context_reconnecting_rpc_client().await;
     let api = ctx.chainhead_backend().await;

--- a/testing/integration-tests/src/full_client/client/mod.rs
+++ b/testing/integration-tests/src/full_client/client/mod.rs
@@ -412,7 +412,7 @@ async fn partial_fee_estimate_correct() {
     assert_eq!(partial_fee_1, partial_fee_2);
 }
 
-#[subxt_test(timeout = 120)]
+#[subxt_test(timeout = 300)]
 async fn chainhead_block_subscription_reconnect() {
     let ctx = test_context_reconnecting_rpc_client().await;
     let api = ctx.chainhead_backend().await;

--- a/testing/integration-tests/src/full_client/client/mod.rs
+++ b/testing/integration-tests/src/full_client/client/mod.rs
@@ -413,7 +413,7 @@ async fn partial_fee_estimate_correct() {
 }
 
 #[subxt_test(timeout = 120)]
-async fn legacy_and_unstable_block_subscription_reconnect() {
+async fn chainhead_block_subscription_reconnect() {
     let ctx = test_context_reconnecting_rpc_client().await;
     let api = ctx.chainhead_backend().await;
     let chainhead_client_blocks = move |num: usize| {


### PR DESCRIPTION
By doubling the timeout.

This test passes locally reliably in 25-30s so maybe just slow runners? 