### PR TITLE
signer: enable schnorrkel/getrandom feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,7 +155,7 @@ bip39 = { version = "2.1.0", default-features = false }
 bip32 = { version = "0.5.2", default-features = false }
 hmac = { version = "0.12.1", default-features = false }
 pbkdf2 = { version = "0.12.2", default-features = false }
-schnorrkel = { version = "0.11.4", default-features = false }
+schnorrkel = { version = "0.11.4", default-features = false, features = ["getrandom"] }
 secp256k1 = { version = "0.30.0", default-features = false }
 keccak-hash = { version = "0.11.0", default-features = false }
 secrecy = "0.10.3"


### PR DESCRIPTION
Without this I get a https://github.com/burdges/getrandom_or_panic/blob/8dc0f4d43c9aebfefcd0b8a226b40ef33e56f9c0/src/lib.rs#L21 from `getrandom_or_panic` crate in both wasm and regular no-std builds that try to sign something.