### PR TITLE
Re-export more `scale_value` functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+[Unreleased]
+
+### Added
+- re-export more `scale_value` functionality ([#1877](https://github.com/paritytech/subxt/pull/1877))
+
 ## [0.38.0] - 2024-10-24
 
 This release doesn't introduce any substantial breaking changes and focuses primarily on incremental improvements, testing and bug fixes. A few of the highlights include:

--- a/core/src/dynamic.rs
+++ b/core/src/dynamic.rs
@@ -8,7 +8,7 @@
 use crate::metadata::{DecodeWithMetadata, Metadata};
 use alloc::vec::Vec;
 use scale_decode::DecodeAsType;
-pub use scale_value::{At, Value};
+pub use scale_value::{scale, serde, stringify, At, Value};
 
 /// A [`scale_value::Value`] type endowed with contextual information
 /// regarding what type was used to decode each part of it. This implements


### PR DESCRIPTION
We need access to some more functionality here in ink!.