### PR TITLE
chore: release v0.38.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.38.1] - 2025-01-24
+
+This is a bug-fix release that fixes a bug in the `reconnecting-rpc-client` where the error was wrapped in the wrong error variant
+which kept retry logic to keep retrying the same error indefinitely.
+
+### Fixed
+- don't wrap rpc error in DisconnectedWillReconnect in reconnecting rpc client ([#1904](https://github.com/paritytech/subxt/pull/1904))
+
 ## [0.38.0] - 2024-10-24
 
 This release doesn't introduce any substantial breaking changes and focuses primarily on incremental improvements, testing and bug fixes. A few of the highlights include:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,7 +600,7 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "artifacts"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "substrate-runner",
 ]
@@ -3387,7 +3387,7 @@ dependencies = [
 
 [[package]]
 name = "generate-custom-metadata"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "frame-metadata 17.0.0",
  "parity-scale-codec",
@@ -3961,7 +3961,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "assert_matches",
  "cfg_aliases",
@@ -10515,7 +10515,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-runner"
-version = "0.38.0"
+version = "0.38.1"
 
 [[package]]
 name = "substrate-wasm-builder"
@@ -10546,7 +10546,7 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "subxt"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -10590,7 +10590,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-cli"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "clap",
  "color-eyre",
@@ -10620,7 +10620,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-codegen"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "frame-metadata 17.0.0",
  "getrandom",
@@ -10637,7 +10637,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-core"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "assert_matches",
  "base58",
@@ -10668,7 +10668,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-lightclient"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "futures",
  "futures-timer",
@@ -10693,7 +10693,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "darling",
  "parity-scale-codec",
@@ -10708,7 +10708,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-metadata"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "bitvec",
  "criterion",
@@ -10722,7 +10722,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-signer"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "base64 0.22.1",
  "bip32",
@@ -10752,7 +10752,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-test-macro"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "quote",
  "syn 2.0.77",
@@ -10760,7 +10760,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-utils-fetchmetadata"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "frame-metadata 17.0.0",
  "hex",
@@ -10852,7 +10852,7 @@ dependencies = [
 
 [[package]]
 name = "test-runtime"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "hex",
  "impl-serde 0.5.0",
@@ -11275,7 +11275,7 @@ checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "ui-tests"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "frame-metadata 17.0.0",
  "generate-custom-metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ resolver = "2"
 [workspace.package]
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
-version = "0.38.0"
+version = "0.38.1"
 rust-version = "1.74.0"
 license = "Apache-2.0 OR GPL-3.0"
 repository = "https://github.com/paritytech/subxt"


### PR DESCRIPTION
```markdown
## [0.38.1] - 2025-01-24

This is a bug-fix release that fixes a bug in the `reconnecting-rpc-client` where the error was wrapped in the wrong error variant
which kept retry logic to keep retrying the same error indefinitely.

### Fixed
- don't wrap rpc error in DisconnectedWillReconnect in reconnecting rpc client ([#1904](https://github.com/paritytech/subxt/pull/1904))
```