### PR TITLE
Don't double hash: use the same hash in ExtrinsicDetails and ExtrinsicDetails

### DIFF
--- a/subxt/src/blocks/extrinsic_types.rs
+++ b/subxt/src/blocks/extrinsic_types.rs
@@ -250,7 +250,7 @@ where
     /// The events associated with the extrinsic.
     pub async fn events(&self) -> Result<ExtrinsicEvents<T>, Error> {
         let events = get_events(&self.client, self.block_hash, &self.cached_events).await?;
-        let ext_hash = T::Hasher::hash_of(&self.bytes());
+        let ext_hash = self.inner.hash();
         Ok(ExtrinsicEvents::new(ext_hash, self.index(), events))
     }
 }

--- a/subxt/src/blocks/extrinsic_types.rs
+++ b/subxt/src/blocks/extrinsic_types.rs
@@ -5,7 +5,7 @@
 use crate::{
     blocks::block_types::{get_events, CachedEvents},
     client::{OfflineClientT, OnlineClientT},
-    config::{Config, Hasher},
+    config::Config,
     error::Error,
     events,
 };


### PR DESCRIPTION
We were using `hash_of` to hash the extrinsics when passing to ExtrinsicEvents, but `hash_of` will hash the entire thing provided, which ends up hashing the vec rather than the bytes in it. 

Closes #1915.