### PR TITLE
Prep to release 0.39.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,72 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.39.0] - 2025-02-04
+
+This release is mostly bug fixes and changes. The only change that should be a breaking change is removing the `substrate-compat` feature flag (see [#1850](https://github.com/paritytech/subxt/pull/1850)), which we'll go into more detail about.
+
+### The `substrate-compat` feature flag has been removed.
+
+The `substrate-compat` feature flag essentially provided:
+1. An implementation of the `subxt::config::Header` trait for anything implementing `sp_runtime::traits::Header` ([here](https://github.com/paritytech/subxt/pull/1850/files#diff-26ab583bc154fdb10c63d7cc90045a6026ad6497efe790fe257b60ceb1a15ea7L137)).
+2. Same for `subxt::config::Hasher` and anything implementing `sp_runtime::traits::Hasher` ([here](https://github.com/paritytech/subxt/pull/1850/files#diff-26ab583bc154fdb10c63d7cc90045a6026ad6497efe790fe257b60ceb1a15ea7L149)).
+3. A `subxt_core::tx::PairSigner` type which could be given something implementing `sp_core::Pair` and then be used to sign transactions ([here](https://github.com/paritytech/subxt/pull/1850/files#diff-fe5469ea5a4788ffac7607c8d25f9d17c232c703f2d38ffe593cb6e87662a0afL46)).
+4. From impls for `sp_runtime::AccountId32` and related for `subxt::utils::AccountId32` ([here](https://github.com/paritytech/subxt/pull/1850/files#diff-61f12204f1b6828f829ea82da72826674e8f6c35943795258860b25ce59fc692L169)).
+5. Likewise for `sp_runtime::MultiAddress` and `subxt::utils::MultiAddress` ([here](https://github.com/paritytech/subxt/pull/1850/files#diff-956118f361c3e5fbdd6974d6f23f40fd0050714cd6bfdfe0f6624d883a2d0c7cL53)).
+6. Likewise for `sp_runtime::MultiSignature` and `subxt::utils::MultiSignature` ([here](https://github.com/paritytech/subxt/pull/1850/files#diff-590233f1bae2f8031dfb010e9c35ba04bb700539d8b067daa7477a0a3f14e38dL29)).
+
+While useful, providing these features in Subxt is almost impossible to maintain: we can only support a single version of `sp_runtime`/`sp_core` at a time, but many versions are in use in the wild. This led to various issues regarding the mismatch between `sp_*` crates in use and a given version of Subxt. More generally, the goal of Subxt is to be independent from any specific version of Substrate, and communicate via the exposed RPC APIs in order to work across any compatible Substrate version (or indeed, alternative implementations that follow things like [the RPC spec](https://github.com/paritytech/json-rpc-interface-spec)).  
+
+As a result, we've taken the decision to remove this compatibility layer from Subxt itself. To migrate away from this feature, we suggest:
+1. Using the example [here](https://github.com/paritytech/subxt/blob/d924ece39a5cb369ba5ccde3dc160b5ee006271b/subxt/examples/substrate_compat_signer.rs) to see how to use a Substrate signer to sign Subxt transactions.
+2. Looking at `subxt_signer` instead, if it's a viable alternative in your case.
+3. Following the "here" links above to see what impls were removed. Impls can generally be recreated as needed using wrapper types which allow converting between Substrate and Subxt types/traits, for instance:
+
+```rust
+struct SubxtHeader<T>(pub T);
+
+// This basically copies the code removed from Subxt, but on a wrapper type:
+impl <T> subxt::config::Header for SubxtHeader<T>
+where
+    T: sp_runtime::traits::Header,
+    <T as sp_runtime::traits::Header>::Number: Into<u64>,
+{
+    type Number = T::Number;
+    type Hasher = T::Hashing;
+
+    fn number(&self) -> Self::Number {
+        *self.0.number()
+    }
+}
+```
+
+The hope is that this pattern is applicable to any such types that you find useful to share between Substrate and Subxt code.
+
+The result of this is that your code will work against whichever Substrate crate versions you are using, at the cost of this code no longer being included behind the `substrate-compat` feature flag.
+
+A full list of relevant changes and fixes (nothing was added in this release) is as follows:
+
+### Changed
+
+- remove substrate compat ([#1850](https://github.com/paritytech/subxt/pull/1850))
+- migrate custom error trait impls to `thiserror` ([#1856](https://github.com/paritytech/subxt/pull/1856))
+- re-export `jsonrpsee` in `subxt::ext` ([#1843](https://github.com/paritytech/subxt/pull/1843))
+
+### Fixed
+
+- don't double hash: use the same hash in ExtrinsicDetails and ExtrinsicDetails ([#1917](https://github.com/paritytech/subxt/pull/1917))
+- fix and test sr25519 signing in nostd ([#1872](https://github.com/paritytech/subxt/pull/1872))
+- preserve custom metadata when converting between Subxt metadata and frame_metadata ([#1914](https://github.com/paritytech/subxt/pull/1914))
+- fix: don't wrap rpc error in DisconnectedWillReconnect in reconnecting rpc client ([#1904](https://github.com/paritytech/subxt/pull/1904))
+- fix: substrate runner, support new libp2p addr log ([#1892](https://github.com/paritytech/subxt/pull/1892))
+- update Artifacts (auto-generated) ([#1874](https://github.com/paritytech/subxt/pull/1874))
+- bump frame-decode and frame-metadata to latest ([#1870](https://github.com/paritytech/subxt/pull/1870))
+- fix unstable-light-client + ChainHeadBackend tx events ([#1865](https://github.com/paritytech/subxt/pull/1865))
+- when native feature is enabled, we need polkadot-sdk/std for eg examples to work ([#1864](https://github.com/paritytech/subxt/pull/1864))
+- load latest metadata version from Wasm blobs. ([#1859](https://github.com/paritytech/subxt/pull/1859))
+- minor fix - Yew example ([#1852](https://github.com/paritytech/subxt/pull/1852))
+- update the release notes to work for current releases ([#1842](https://github.com/paritytech/subxt/pull/1842))
+
 ## [0.38.0] - 2024-10-24
 
 This release doesn't introduce any substantial breaking changes and focuses primarily on incremental improvements, testing and bug fixes. A few of the highlights include:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ As a result, we've taken the decision to remove this compatibility layer from Su
 3. Following the "here" links above to see what impls were removed. Impls can generally be recreated as needed using wrapper types which allow converting between Substrate and Subxt types/traits, for instance:
 
 ```rust
+// Wrap a substrate header type in this to impl the subxt Header trait:
 struct SubxtHeader<T>(pub T);
 
 // This basically copies the code removed from Subxt, but on a wrapper type:
@@ -43,7 +44,7 @@ where
 }
 ```
 
-The hope is that this pattern is applicable to any such types that you find useful to share between Substrate and Subxt code.
+The hope is that this pattern is applicable to any such types that you find useful to share between Substrate and Subxt code. Please raise an issue if you can't find a solution in your case, and we'll endeavour to help!
 
 The result of this is that your code will work against whichever Substrate crate versions you are using, at the cost of this code no longer being included behind the `substrate-compat` feature flag.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,7 +600,7 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "artifacts"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "substrate-runner",
 ]
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "generate-custom-metadata"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "frame-metadata 18.0.0",
  "parity-scale-codec",
@@ -3960,7 +3960,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "assert_matches",
  "cfg_aliases",
@@ -10513,7 +10513,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-runner"
-version = "0.38.0"
+version = "0.39.0"
 
 [[package]]
 name = "substrate-wasm-builder"
@@ -10544,7 +10544,7 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "subxt"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -10588,7 +10588,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-cli"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "clap",
  "color-eyre",
@@ -10618,7 +10618,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-codegen"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "frame-metadata 18.0.0",
  "getrandom",
@@ -10635,7 +10635,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-core"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "assert_matches",
  "base58",
@@ -10667,7 +10667,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-lightclient"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "futures",
  "futures-timer",
@@ -10692,7 +10692,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "darling",
  "parity-scale-codec",
@@ -10707,7 +10707,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-metadata"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "bitvec",
  "criterion",
@@ -10722,7 +10722,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-signer"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "base64 0.22.1",
  "bip32",
@@ -10753,7 +10753,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-test-macro"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "quote",
  "syn 2.0.87",
@@ -10761,7 +10761,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-utils-fetchmetadata"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "frame-metadata 18.0.0",
  "hex",
@@ -10853,7 +10853,7 @@ dependencies = [
 
 [[package]]
 name = "test-runtime"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "hex",
  "impl-serde 0.5.0",
@@ -11296,7 +11296,7 @@ checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "ui-tests"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "frame-metadata 18.0.0",
  "generate-custom-metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ resolver = "2"
 [workspace.package]
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
-version = "0.38.0"
+version = "0.39.0"
 rust-version = "1.81.0"
 license = "Apache-2.0 OR GPL-3.0"
 repository = "https://github.com/paritytech/subxt"
@@ -139,14 +139,14 @@ tokio-util = "0.7.12"
 polkadot-sdk = { version = "0.7", default-features = false }
 
 # Subxt workspace crates:
-subxt = { version = "0.38.0", path = "subxt", default-features = false }
-subxt-core = { version = "0.38.0", path = "core", default-features = false }
-subxt-macro = { version = "0.38.0", path = "macro" }
-subxt-metadata = { version = "0.38.0", path = "metadata", default-features = false }
-subxt-codegen = { version = "0.38.0", path = "codegen" }
-subxt-signer = { version = "0.38.0", path = "signer", default-features = false }
-subxt-lightclient = { version = "0.38.0", path = "lightclient", default-features = false }
-subxt-utils-fetchmetadata = { version = "0.38.0", path = "utils/fetch-metadata", default-features = false }
+subxt = { version = "0.39.0", path = "subxt", default-features = false }
+subxt-core = { version = "0.39.0", path = "core", default-features = false }
+subxt-macro = { version = "0.39.0", path = "macro" }
+subxt-metadata = { version = "0.39.0", path = "metadata", default-features = false }
+subxt-codegen = { version = "0.39.0", path = "codegen" }
+subxt-signer = { version = "0.39.0", path = "signer", default-features = false }
+subxt-lightclient = { version = "0.39.0", path = "lightclient", default-features = false }
+subxt-utils-fetchmetadata = { version = "0.39.0", path = "utils/fetch-metadata", default-features = false }
 test-runtime = { path = "testing/test-runtime" }
 substrate-runner = { path = "testing/substrate-runner" }
 

--- a/examples/parachain-example/Cargo.lock
+++ b/examples/parachain-example/Cargo.lock
@@ -10097,7 +10097,7 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "subxt"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "derive-where",
@@ -10132,7 +10132,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-codegen"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "heck 0.5.0",
  "parity-scale-codec",
@@ -10147,7 +10147,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-core"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "base58",
  "blake2",
@@ -10175,7 +10175,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-lightclient"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "futures",
  "futures-util",
@@ -10190,7 +10190,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "darling",
  "parity-scale-codec",
@@ -10204,7 +10204,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-metadata"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "frame-decode",
  "frame-metadata 18.0.0",
@@ -10217,7 +10217,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-signer"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "base64 0.22.1",
  "bip39",
@@ -10243,7 +10243,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-utils-fetchmetadata"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "hex",
  "parity-scale-codec",

--- a/examples/wasm-example/Cargo.lock
+++ b/examples/wasm-example/Cargo.lock
@@ -2480,7 +2480,7 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "subxt"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "derive-where",
@@ -2516,7 +2516,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-codegen"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "getrandom",
  "heck",
@@ -2532,7 +2532,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-core"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "base58",
  "blake2",
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-lightclient"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "futures",
  "futures-timer",
@@ -2585,7 +2585,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "darling",
  "parity-scale-codec",
@@ -2599,7 +2599,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-metadata"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "frame-decode",
  "frame-metadata",
@@ -2612,7 +2612,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-utils-fetchmetadata"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "hex",
  "parity-scale-codec",

--- a/testing/no-std-tests/Cargo.lock
+++ b/testing/no-std-tests/Cargo.lock
@@ -963,7 +963,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "subxt-codegen"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "heck",
  "parity-scale-codec",
@@ -978,7 +978,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-core"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "base58",
  "blake2",
@@ -1018,7 +1018,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "darling",
  "parity-scale-codec",
@@ -1032,7 +1032,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-metadata"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "frame-decode",
  "frame-metadata",
@@ -1045,7 +1045,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-signer"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "bip39",
  "cfg-if",
@@ -1065,7 +1065,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-utils-fetchmetadata"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "hex",
  "parity-scale-codec",

--- a/testing/wasm-lightclient-tests/Cargo.lock
+++ b/testing/wasm-lightclient-tests/Cargo.lock
@@ -2008,7 +2008,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "subxt"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "derive-where",
@@ -2044,7 +2044,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-codegen"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "getrandom",
  "heck",
@@ -2060,7 +2060,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-core"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "base58",
  "blake2",
@@ -2087,7 +2087,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-lightclient"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "futures",
  "futures-timer",
@@ -2112,7 +2112,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "darling",
  "parity-scale-codec",
@@ -2126,7 +2126,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-metadata"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "frame-decode",
  "frame-metadata",
@@ -2138,7 +2138,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-utils-fetchmetadata"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "hex",
  "parity-scale-codec",

--- a/testing/wasm-rpc-tests/Cargo.lock
+++ b/testing/wasm-rpc-tests/Cargo.lock
@@ -2008,7 +2008,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "subxt"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "derive-where",
@@ -2044,7 +2044,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-codegen"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "getrandom",
  "heck",
@@ -2060,7 +2060,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-core"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "base58",
  "blake2",
@@ -2087,7 +2087,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-lightclient"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "futures",
  "futures-timer",
@@ -2112,7 +2112,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "darling",
  "parity-scale-codec",
@@ -2126,7 +2126,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-metadata"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "frame-decode",
  "frame-metadata",
@@ -2138,7 +2138,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-utils-fetchmetadata"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "hex",
  "parity-scale-codec",


### PR DESCRIPTION
## [0.39.0] - 2025-02-04

This release is mostly bug fixes and changes. The only change that should be a breaking change is removing the `substrate-compat` feature flag (see [#1850](https://github.com/paritytech/subxt/pull/1850)), which we'll go into more detail about.

### The `substrate-compat` feature flag has been removed.

The `substrate-compat` feature flag essentially provided:
1. An implementation of the `subxt::config::Header` trait for anything implementing `sp_runtime::traits::Header` ([here](https://github.com/paritytech/subxt/pull/1850/files#diff-26ab583bc154fdb10c63d7cc90045a6026ad6497efe790fe257b60ceb1a15ea7L137)).
2. Same for `subxt::config::Hasher` and anything implementing `sp_runtime::traits::Hasher` ([here](https://github.com/paritytech/subxt/pull/1850/files#diff-26ab583bc154fdb10c63d7cc90045a6026ad6497efe790fe257b60ceb1a15ea7L149)).
3. A `subxt_core::tx::PairSigner` type which could be given something implementing `sp_core::Pair` and then be used to sign transactions ([here](https://github.com/paritytech/subxt/pull/1850/files#diff-fe5469ea5a4788ffac7607c8d25f9d17c232c703f2d38ffe593cb6e87662a0afL46)).
4. From impls for `sp_runtime::AccountId32` and related for `subxt::utils::AccountId32` ([here](https://github.com/paritytech/subxt/pull/1850/files#diff-61f12204f1b6828f829ea82da72826674e8f6c35943795258860b25ce59fc692L169)).
5. Likewise for `sp_runtime::MultiAddress` and `subxt::utils::MultiAddress` ([here](https://github.com/paritytech/subxt/pull/1850/files#diff-956118f361c3e5fbdd6974d6f23f40fd0050714cd6bfdfe0f6624d883a2d0c7cL53)).
6. Likewise for `sp_runtime::MultiSignature` and `subxt::utils::MultiSignature` ([here](https://github.com/paritytech/subxt/pull/1850/files#diff-590233f1bae2f8031dfb010e9c35ba04bb700539d8b067daa7477a0a3f14e38dL29)).

While useful, providing these features in Subxt is almost impossible to maintain: we can only support a single version of `sp_runtime`/`sp_core` at a time, but many versions are in use in the wild. This led to various issues regarding the mismatch between `sp_*` crates in use and a given version of Subxt. More generally, the goal of Subxt is to be independent from any specific version of Substrate, and communicate via the exposed RPC APIs in order to work across any compatible Substrate version (or indeed, alternative implementations that follow things like [the RPC spec](https://github.com/paritytech/json-rpc-interface-spec)).  

As a result, we've taken the decision to remove this compatibility layer from Subxt itself. To migrate away from this feature, we suggest:
1. Using the example [here](https://github.com/paritytech/subxt/blob/d924ece39a5cb369ba5ccde3dc160b5ee006271b/subxt/examples/substrate_compat_signer.rs) to see how to use a Substrate signer to sign Subxt transactions.
2. Looking at `subxt_signer` instead, if it's a viable alternative in your case.
3. Following the "here" links above to see what impls were removed. Impls can generally be recreated as needed using wrapper types which allow converting between Substrate and Subxt types/traits, for instance:

```rust
// Wrap a substrate header type in this to impl the subxt Header trait:
struct SubxtHeader<T>(pub T);

// This basically copies the code removed from Subxt, but on a wrapper type:
impl <T> subxt::config::Header for SubxtHeader<T>
where
    T: sp_runtime::traits::Header,
    <T as sp_runtime::traits::Header>::Number: Into<u64>,
{
    type Number = T::Number;
    type Hasher = T::Hashing;

    fn number(&self) -> Self::Number {
        *self.0.number()
    }
}
```

The hope is that this pattern is applicable to any such types that you find useful to share between Substrate and Subxt code. Please raise an issue if you can't find a solution in your case, and we'll endeavour to help!

The result of this is that your code will work against whichever Substrate crate versions you are using, at the cost of this code no longer being included behind the `substrate-compat` feature flag.

A full list of relevant changes and fixes (nothing was added in this release) is as follows:

### Changed

- remove substrate compat ([#1850](https://github.com/paritytech/subxt/pull/1850))
- migrate custom error trait impls to `thiserror` ([#1856](https://github.com/paritytech/subxt/pull/1856))
- re-export `jsonrpsee` in `subxt::ext` ([#1843](https://github.com/paritytech/subxt/pull/1843))

### Fixed

- don't double hash: use the same hash in ExtrinsicDetails and ExtrinsicDetails ([#1917](https://github.com/paritytech/subxt/pull/1917))
- fix and test sr25519 signing in nostd ([#1872](https://github.com/paritytech/subxt/pull/1872))
- preserve custom metadata when converting between Subxt metadata and frame_metadata ([#1914](https://github.com/paritytech/subxt/pull/1914))
- fix: don't wrap rpc error in DisconnectedWillReconnect in reconnecting rpc client ([#1904](https://github.com/paritytech/subxt/pull/1904))
- fix: substrate runner, support new libp2p addr log ([#1892](https://github.com/paritytech/subxt/pull/1892))
- update Artifacts (auto-generated) ([#1874](https://github.com/paritytech/subxt/pull/1874))
- bump frame-decode and frame-metadata to latest ([#1870](https://github.com/paritytech/subxt/pull/1870))
- fix unstable-light-client + ChainHeadBackend tx events ([#1865](https://github.com/paritytech/subxt/pull/1865))
- when native feature is enabled, we need polkadot-sdk/std for eg examples to work ([#1864](https://github.com/paritytech/subxt/pull/1864))
- load latest metadata version from Wasm blobs. ([#1859](https://github.com/paritytech/subxt/pull/1859))
- minor fix - Yew example ([#1852](https://github.com/paritytech/subxt/pull/1852))
- update the release notes to work for current releases ([#1842](https://github.com/paritytech/subxt/pull/1842))