### PR TITLE
refactor: make `ExtrinsicEvents::new` public for external access

### DIFF
--- a/subxt/src/blocks/extrinsic_types.rs
+++ b/subxt/src/blocks/extrinsic_types.rs
@@ -278,7 +278,9 @@ pub struct ExtrinsicEvents<T: Config> {
 }
 
 impl<T: Config> ExtrinsicEvents<T> {
-    pub(crate) fn new(ext_hash: T::Hash, idx: u32, events: events::Events<T>) -> Self {
+    /// Creates a new instance of `ExtrinsicEvents`.
+    #[doc(hidden)]
+    pub fn new(ext_hash: T::Hash, idx: u32, events: events::Events<T>) -> Self {
         Self {
             ext_hash,
             idx,


### PR DESCRIPTION
Simple change making the `new` method of `ExtrinsicEvents` public. Currently, it is marked as `pub(crate)`, which makes it inaccessible outside the crate.

We are integrating this functionality into [pop-cli](https://github.com/r0gue-io/pop-cli) and need to parse extrinsic events. For our tests, we need to mock `ExtrinsicEvents`, but since the new function is not public, we are unable to instantiate it directly.

Closes https://github.com/paritytech/subxt/issues/1932.