### PR TITLE
Prepare for 0.41.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Custom clients can be implemented if preferred.
 Example usage via `jsonrpsee` feature:
 
 ```rust
-use subxt_rpcs::{ RpcClient, ChainHeadRpcMethods };
+use subxt_rpcs::{RpcClient, ChainHeadRpcMethods};
 
 // Connect to a local node:
 let client = RpcClient::("ws://127.0.0.1:9944").await?;
@@ -64,7 +64,6 @@ A full list of the relevant changes is as follows:
 - Wrap the subxt::events::Events type to avoid exposing subxt_core errors and types unnecessarily ([#1948](https://github.com/paritytech/subxt/pull/1948))
 - Allow transaction timeout in ChainheadBackend to be configured ([#1943](https://github.com/paritytech/subxt/pull/1943))
 - refactor: make ExtrinsicEvents::new public for external access ([#1933](https://github.com/paritytech/subxt/pull/1933))
-- deps: remove polkadot-sdk umbrella crate ([#1926](https://github.com/paritytech/subxt/pull/1926))
 
 ## [0.40.0] - 2025-03-06
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,7 +292,7 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "artifacts"
-version = "0.39.0"
+version = "0.41.0"
 dependencies = [
  "substrate-runner",
 ]
@@ -1904,7 +1904,7 @@ dependencies = [
 
 [[package]]
 name = "generate-custom-metadata"
-version = "0.39.0"
+version = "0.41.0"
 dependencies = [
  "frame-metadata 20.0.0",
  "parity-scale-codec",
@@ -2411,10 +2411,11 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.39.0"
+version = "0.41.0"
 dependencies = [
  "assert_matches",
  "cfg_aliases",
+ "frame-decode",
  "frame-metadata 20.0.0",
  "futures",
  "hex",
@@ -5176,7 +5177,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-runner"
-version = "0.39.0"
+version = "0.41.0"
 
 [[package]]
 name = "subtle"
@@ -5186,7 +5187,7 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "subxt"
-version = "0.39.0"
+version = "0.41.0"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -5231,7 +5232,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-cli"
-version = "0.39.0"
+version = "0.41.0"
 dependencies = [
  "clap",
  "color-eyre",
@@ -5261,7 +5262,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-codegen"
-version = "0.39.0"
+version = "0.41.0"
 dependencies = [
  "frame-metadata 20.0.0",
  "getrandom",
@@ -5278,7 +5279,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-core"
-version = "0.39.0"
+version = "0.41.0"
 dependencies = [
  "assert_matches",
  "base58",
@@ -5312,7 +5313,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-lightclient"
-version = "0.39.0"
+version = "0.41.0"
 dependencies = [
  "futures",
  "futures-timer",
@@ -5337,7 +5338,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.39.0"
+version = "0.41.0"
 dependencies = [
  "darling",
  "parity-scale-codec",
@@ -5356,7 +5357,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-metadata"
-version = "0.39.0"
+version = "0.41.0"
 dependencies = [
  "bitvec",
  "criterion",
@@ -5371,7 +5372,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-rpcs"
-version = "0.39.0"
+version = "0.41.0"
 dependencies = [
  "derive-where",
  "finito",
@@ -5400,7 +5401,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-signer"
-version = "0.39.0"
+version = "0.41.0"
 dependencies = [
  "base64 0.22.1",
  "bip32",
@@ -5433,7 +5434,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-test-macro"
-version = "0.39.0"
+version = "0.41.0"
 dependencies = [
  "quote",
  "syn 2.0.87",
@@ -5441,7 +5442,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-utils-fetchmetadata"
-version = "0.39.0"
+version = "0.41.0"
 dependencies = [
  "frame-metadata 20.0.0",
  "hex",
@@ -5509,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "test-runtime"
-version = "0.39.0"
+version = "0.41.0"
 dependencies = [
  "hex",
  "impl-serde",
@@ -5924,7 +5925,7 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "ui-tests"
-version = "0.39.0"
+version = "0.41.0"
 dependencies = [
  "frame-metadata 20.0.0",
  "generate-custom-metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ resolver = "2"
 [workspace.package]
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
-version = "0.39.0"
+version = "0.41.0"
 rust-version = "1.81.0"
 license = "Apache-2.0 OR GPL-3.0"
 repository = "https://github.com/paritytech/subxt"
@@ -151,15 +151,15 @@ sp-state-machine = { version = "0.44.0", default-features = false }
 sp-runtime = { version = "40.0.1", default-features = false }
 
 # Subxt workspace crates:
-subxt = { version = "0.39.0", path = "subxt", default-features = false }
-subxt-core = { version = "0.39.0", path = "core", default-features = false }
-subxt-macro = { version = "0.39.0", path = "macro" }
-subxt-metadata = { version = "0.39.0", path = "metadata", default-features = false }
-subxt-codegen = { version = "0.39.0", path = "codegen" }
-subxt-signer = { version = "0.39.0", path = "signer", default-features = false }
-subxt-rpcs = { version = "0.39.0", path = "rpcs", default-features = false }
-subxt-lightclient = { version = "0.39.0", path = "lightclient", default-features = false }
-subxt-utils-fetchmetadata = { version = "0.39.0", path = "utils/fetch-metadata", default-features = false }
+subxt = { version = "0.41.0", path = "subxt", default-features = false }
+subxt-core = { version = "0.41.0", path = "core", default-features = false }
+subxt-macro = { version = "0.41.0", path = "macro" }
+subxt-metadata = { version = "0.41.0", path = "metadata", default-features = false }
+subxt-codegen = { version = "0.41.0", path = "codegen" }
+subxt-signer = { version = "0.41.0", path = "signer", default-features = false }
+subxt-rpcs = { version = "0.41.0", path = "rpcs", default-features = false }
+subxt-lightclient = { version = "0.41.0", path = "lightclient", default-features = false }
+subxt-utils-fetchmetadata = { version = "0.41.0", path = "utils/fetch-metadata", default-features = false }
 test-runtime = { path = "testing/test-runtime" }
 substrate-runner = { path = "testing/substrate-runner" }
 


### PR DESCRIPTION
## [0.41.0] - 2025-03-10

This release makes two main changes:

### Add `subxt-rpcs` crate.

Previously, if you wanted to make raw RPC calls but weren't otherwise interested in using the higher level Subxt interface, you still needed to include the entire Subxt crate.

Now, one can depend on `subxt-rpcs` directly. This crate implements the new RPC-V2 `chainHead`/`transaction` endpoints as well as the currently unstable `archive` endpoints. it also implements various legacy endpoints that Subxt uses as a fallback to the modern ones. It also provides several feature gated clients for interacting with them:

- **jsonrpsee**: A `jsonrpsee` based RPC client for connecting to individual RPC nodes.
- **unstable-light-client**: A Smoldot based light client which connects to multiple nodes in chains via p2p and verifies everything handed back, removing the need to trust any individual nodes.
- **reconnecting-rpc-client**: Another `jsonrpsee` based client which handles reconnecting automatically in the event of network issues.
- **mock-rpc-client**: A mock RPC client that can be used in tests.

Custom clients can be implemented if preferred.

Example usage via `jsonrpsee` feature:

```rust
use subxt_rpcs::{RpcClient, ChainHeadRpcMethods};

// Connect to a local node:
let client = RpcClient::("ws://127.0.0.1:9944").await?;
// Use chainHead/archive V2 methods:
let methods = ChainHeadRpcMethods::new(client);

// Call some RPC methods (in this case a subscription):
let mut follow_subscription = methods.chainhead_v1_follow(false).await.unwrap();
while let Some(follow_event) = follow_subscription.next().await {
    // do something with events..
}
```

### Support creating V5 transactions.

Subxt has supported decoding V5 transactions from blocks since 0.38.0, but now it also supports constructing V5 transactions where allowed. Some naming changes have also taken place to align with the Substrate terminology now around transactions (see [#1931](https://github.com/paritytech/subxt/pull/1931) for more!).

The main changes here are:

- `subxt_core` now contains versioned methods for creating each of the possible types of transaction (V4 unsigned, V4 signed, V5 "bare" or V5 "general"), enabling the APIs to be tailored for each case.
- `subxt` exposes higher level wrappers these (ie `api.tx().create_v4_unsigned(..)`, `api.tx().create_v5_bare(..)`), but also continues to expose the same standard APIs for creating transactions which will, under the hood, decide what to create based on the chain we're connected to.
- APIs like `sign_and_submit` now take a `T::AccountId` rather than a `T::Address` since it was found to not be useful to provide the latter, and V5 transactions only expect an `T::AccountId`.
- Signed Extensions are now referred to as _Transaction Extensions_, and we've tweaked the interface around how these work slightly to accomodate the fact that in V5 transactions, the signature is passed into a transaction extension where applicable (`VerifySignature`).
- As a side effect, it's simpler to set mortality on transactions; no more block hash needs to be provided; only the number of blocks you would like a transaction to live for.

A full list of the relevant changes is as follows:

### Added

- Support constructing and submitting V5 transactions ([#1931](https://github.com/paritytech/subxt/pull/1931))
- Add archive RPCs to subxt-rpcs ([#1940](https://github.com/paritytech/subxt/pull/1940))
- Document generating interface from Runtime WASM and change feature to `runtime-wasm-path` ([#1936](https://github.com/paritytech/subxt/pull/1936))
- Split RPCs into a separate crate ([#1910](https://github.com/paritytech/subxt/pull/1910))

### Changed

- Wrap the subxt::events::Events type to avoid exposing subxt_core errors and types unnecessarily ([#1948](https://github.com/paritytech/subxt/pull/1948))
- Allow transaction timeout in ChainheadBackend to be configured ([#1943](https://github.com/paritytech/subxt/pull/1943))
- refactor: make ExtrinsicEvents::new public for external access ([#1933](https://github.com/paritytech/subxt/pull/1933))