### PR TITLE
Map finality timeout to Dropped instead of Invalid

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2415,6 +2415,7 @@ version = "0.39.0"
 dependencies = [
  "assert_matches",
  "cfg_aliases",
+ "frame-decode",
  "frame-metadata 20.0.0",
  "futures",
  "hex",

--- a/subxt/src/backend/legacy.rs
+++ b/subxt/src/backend/legacy.rs
@@ -382,7 +382,7 @@ impl<T: Config + Send + Sync + 'static> Backend<T> for LegacyBackend<T> {
                         }
                         // These 5 mean that the stream will very likely end:
                         RpcTransactionStatus::FinalityTimeout(_) => {
-                            Some(TransactionStatus::Invalid {
+                            Some(TransactionStatus::Dropped {
                                 message: "Finality timeout".into(),
                             })
                         }


### PR DESCRIPTION
This is semantically the better variant to map the legacy `FinalityTimeout` one too (see #1937) 

Closes #1937 