### PR TITLE
Add docs for subxt-rpcs and fix example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ Example usage via `jsonrpsee` feature:
 use subxt_rpcs::{RpcClient, ChainHeadRpcMethods};
 
 // Connect to a local node:
-let client = RpcClient::("ws://127.0.0.1:9944").await?;
+let client = RpcClient::from_url("ws://127.0.0.1:9944").await?;
 // Use chainHead/archive V2 methods:
 let methods = ChainHeadRpcMethods::new(client);
 

--- a/rpcs/Cargo.toml
+++ b/rpcs/Cargo.toml
@@ -94,5 +94,9 @@ tower = { workspace = true }
 hyper = { workspace = true }
 http-body = { workspace = true }
 
+[package.metadata.docs.rs]
+default-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [lints]
 workspace = true

--- a/rpcs/README.md
+++ b/rpcs/README.md
@@ -1,0 +1,18 @@
+# subxt-rpcs
+
+This crate provides an interface for interacting with Substrate nodes via the available RPC methods.
+
+```rust
+use subxt_rpcs::{RpcClient, ChainHeadRpcMethods};
+
+// Connect to a local node:
+let client = RpcClient::from_url("ws://127.0.0.1:9944").await?;
+// Use a set of methods, here the V2 "chainHead" ones:
+let methods = ChainHeadRpcMethods::new(client);
+
+// Call some RPC methods (in this case a subscription):
+let mut follow_subscription = methods.chainhead_v1_follow(false).await.unwrap();
+while let Some(follow_event) = follow_subscription.next().await {
+    // do something with events..
+}
+```

--- a/rpcs/src/lib.rs
+++ b/rpcs/src/lib.rs
@@ -16,6 +16,8 @@
 //! The provided RPC client implementations can be used natively (with the default `native` feature
 //! flag) or in WASM based web apps (with the `web` feature flag).
 
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 #[cfg(any(
     all(feature = "web", feature = "native"),
     not(any(feature = "web", feature = "native"))

--- a/utils/fetch-metadata/src/lib.rs
+++ b/utils/fetch-metadata/src/lib.rs
@@ -4,6 +4,8 @@
 
 //! Subxt utils fetch metadata.
 
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 // Internal helper macros
 #[macro_use]
 mod macros;


### PR DESCRIPTION
Just a dumb mistake in the CHANGELOG example for the RPC crate, plus adding a README for the subxt-rpcs