### PR TITLE
Add DefaultParams to allow more transaction extensions to be used when calling _default() methods

### DIFF
--- a/core/src/config/extrinsic_params.rs
+++ b/core/src/config/extrinsic_params.rs
@@ -113,6 +113,11 @@ const _: () = {
     impl_tuples!(A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8, J 9, K 10, L 11, M 12, N 13, O 14, P 15, Q 16);
     impl_tuples!(A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8, J 9, K 10, L 11, M 12, N 13, O 14, P 15, Q 16, R 17);
     impl_tuples!(A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8, J 9, K 10, L 11, M 12, N 13, O 14, P 15, Q 16, R 17, S 18);
-    impl_tuples!(A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8, J 9, K 10, L 11, M 12, N 13, O 14, P 15, Q 16, R 17, S 18, U 19);
-    impl_tuples!(A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8, J 9, K 10, L 11, M 12, N 13, O 14, P 15, Q 16, R 17, S 18, U 19, V 20);
+    impl_tuples!(A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8, J 9, K 10, L 11, M 12, N 13, O 14, P 15, Q 16, R 17, S 18, T 19);
+    impl_tuples!(A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8, J 9, K 10, L 11, M 12, N 13, O 14, P 15, Q 16, R 17, S 18, T 19, U 20);
+    impl_tuples!(A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8, J 9, K 10, L 11, M 12, N 13, O 14, P 15, Q 16, R 17, S 18, T 19, U 20, V 21);
+    impl_tuples!(A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8, J 9, K 10, L 11, M 12, N 13, O 14, P 15, Q 16, R 17, S 18, T 19, U 20, V 21, W 22);
+    impl_tuples!(A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8, J 9, K 10, L 11, M 12, N 13, O 14, P 15, Q 16, R 17, S 18, T 19, U 20, V 21, W 22, X 23);
+    impl_tuples!(A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8, J 9, K 10, L 11, M 12, N 13, O 14, P 15, Q 16, R 17, S 18, T 19, U 20, V 21, W 22, X 23, Y 24);
+    impl_tuples!(A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8, J 9, K 10, L 11, M 12, N 13, O 14, P 15, Q 16, R 17, S 18, T 19, U 20, V 21, W 22, X 23, Y 24, Z 25);
 };

--- a/core/src/config/extrinsic_params.rs
+++ b/core/src/config/extrinsic_params.rs
@@ -81,11 +81,11 @@ impl<T: Config> Params<T> for () {}
 
 macro_rules! impl_tuples {
     ($($ident:ident $index:tt),+) => {
-        impl <T: Config, $($ident : Params<T>),+> Params<T> for ($($ident,)+){
+        impl <Conf: Config, $($ident : Params<Conf>),+> Params<Conf> for ($($ident,)+){
             fn inject_account_nonce(&mut self, nonce: u64) {
                 $(self.$index.inject_account_nonce(nonce);)+
             }
-            fn inject_block(&mut self, number: u64, hash: T::Hash) {
+            fn inject_block(&mut self, number: u64, hash: Conf::Hash) {
                 $(self.$index.inject_block(number, hash);)+
             }
         }

--- a/core/src/config/extrinsic_params.rs
+++ b/core/src/config/extrinsic_params.rs
@@ -81,7 +81,6 @@ impl<T: Config> Params<T> for () {}
 
 macro_rules! impl_tuples {
     ($($ident:ident $index:tt),+) => {
-
         impl <T: Config, $($ident : Params<T>),+> Params<T> for ($($ident,)+){
             fn inject_account_nonce(&mut self, nonce: u64) {
                 $(self.$index.inject_account_nonce(nonce);)+

--- a/subxt/src/tx/mod.rs
+++ b/subxt/src/tx/mod.rs
@@ -15,7 +15,7 @@ mod tx_progress;
 pub use subxt_core::tx::payload::{dynamic, DefaultPayload, DynamicPayload, Payload};
 pub use subxt_core::tx::signer::{self, Signer};
 pub use tx_client::{
-    PartialTransaction, SubmittableTransaction, TransactionInvalid, TransactionUnknown, TxClient,
-    ValidationResult,
+    DefaultParams, PartialTransaction, SubmittableTransaction, TransactionInvalid,
+    TransactionUnknown, TxClient, ValidationResult,
 };
 pub use tx_progress::{TxInBlock, TxProgress, TxStatus};

--- a/subxt/src/tx/tx_client.rs
+++ b/subxt/src/tx/tx_client.rs
@@ -281,9 +281,9 @@ where
     where
         Call: Payload,
         Signer: SignerT<T>,
-        <T::ExtrinsicParams as ExtrinsicParams<T>>::Params: Default,
+        <T::ExtrinsicParams as ExtrinsicParams<T>>::Params: DefaultParams,
     {
-        self.sign_and_submit_then_watch(call, signer, Default::default())
+        self.sign_and_submit_then_watch(call, signer, DefaultParams::default_params())
             .await
     }
 
@@ -325,9 +325,10 @@ where
     where
         Call: Payload,
         Signer: SignerT<T>,
-        <T::ExtrinsicParams as ExtrinsicParams<T>>::Params: Default,
+        <T::ExtrinsicParams as ExtrinsicParams<T>>::Params: DefaultParams,
     {
-        self.sign_and_submit(call, signer, Default::default()).await
+        self.sign_and_submit(call, signer, DefaultParams::default_params())
+            .await
     }
 
     /// Creates and signs an transaction and submits to the chain for block inclusion.
@@ -753,6 +754,66 @@ pub enum TransactionInvalid {
     /// The sending address is disabled or known to be invalid.
     BadSigner,
 }
+
+/// This trait is used to create default values for extrinsic params. We use this instead of
+/// [`Default`] because we want to be able to support params which are tuples of more than 12
+/// entries (which is the maximum tuple size Rust currently implements [`Default`] for on tuples),
+/// given that we aren't far off having more than 12 transaction extensions already.
+///
+/// If you have params which are _not_ a tuple and which you'd like to be instantiated automatically
+/// when calling [`TxClient::sign_and_submit_default()`] or [`TxClient::sign_and_submit_then_watch_default()`],
+/// then you'll need to implement this trait for them.
+pub trait DefaultParams: Sized {
+    /// Instantiate a default instance of the parameters.
+    fn default_params() -> Self;
+}
+
+impl<const N: usize, P: Default> DefaultParams for [P; N] {
+    fn default_params() -> Self {
+        core::array::from_fn(|_| P::default())
+    }
+}
+
+macro_rules! impl_default_params_for_tuple {
+    ($($ident:ident),+) => {
+        impl <$($ident : Default),+> DefaultParams for ($($ident,)+){
+            fn default_params() -> Self {
+                (
+                    $($ident::default(),)+
+                )
+            }
+        }
+    }
+}
+
+#[rustfmt::skip]
+const _: () = {
+    impl_default_params_for_tuple!(A);
+    impl_default_params_for_tuple!(A, B);
+    impl_default_params_for_tuple!(A, B, C);
+    impl_default_params_for_tuple!(A, B, C, D);
+    impl_default_params_for_tuple!(A, B, C, D, E);
+    impl_default_params_for_tuple!(A, B, C, D, E, F);
+    impl_default_params_for_tuple!(A, B, C, D, E, F, G);
+    impl_default_params_for_tuple!(A, B, C, D, E, F, G, H);
+    impl_default_params_for_tuple!(A, B, C, D, E, F, G, H, I);
+    impl_default_params_for_tuple!(A, B, C, D, E, F, G, H, I, J);
+    impl_default_params_for_tuple!(A, B, C, D, E, F, G, H, I, J, K);
+    impl_default_params_for_tuple!(A, B, C, D, E, F, G, H, I, J, K, L);
+    impl_default_params_for_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M);
+    impl_default_params_for_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N);
+    impl_default_params_for_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O);
+    impl_default_params_for_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P);
+    impl_default_params_for_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q);
+    impl_default_params_for_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R);
+    impl_default_params_for_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S);
+    impl_default_params_for_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, U);
+    impl_default_params_for_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, U, V);
+    impl_default_params_for_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, U, V, W);
+    impl_default_params_for_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, U, V, W, X);
+    impl_default_params_for_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, U, V, W, X, Y);
+    impl_default_params_for_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, U, V, W, X, Y, Z);
+};
 
 #[cfg(test)]
 mod test {

--- a/subxt/src/tx/tx_client.rs
+++ b/subxt/src/tx/tx_client.rs
@@ -807,12 +807,13 @@ const _: () = {
     impl_default_params_for_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q);
     impl_default_params_for_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R);
     impl_default_params_for_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S);
-    impl_default_params_for_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, U);
-    impl_default_params_for_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, U, V);
-    impl_default_params_for_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, U, V, W);
-    impl_default_params_for_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, U, V, W, X);
-    impl_default_params_for_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, U, V, W, X, Y);
-    impl_default_params_for_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, U, V, W, X, Y, Z);
+    impl_default_params_for_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T);
+    impl_default_params_for_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U);
+    impl_default_params_for_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V);
+    impl_default_params_for_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W);
+    impl_default_params_for_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X);
+    impl_default_params_for_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y);
+    impl_default_params_for_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z);
 };
 
 #[cfg(test)]

--- a/subxt/src/tx/tx_client.rs
+++ b/subxt/src/tx/tx_client.rs
@@ -515,7 +515,7 @@ where
         match sub.next().await {
             Some(Ok(status)) => match status {
                 TransactionStatus::Validated
-                | TransactionStatus::Broadcasted { .. }
+                | TransactionStatus::Broadcasted
                 | TransactionStatus::InBestBlock { .. }
                 | TransactionStatus::NoLongerInBestBlock
                 | TransactionStatus::InFinalizedBlock { .. } => Ok(ext_hash),


### PR DESCRIPTION
We currently rely on extrinsic parameters implementing `Default` on these two methods of `TxClient`:

```rust
    pub async fn sign_and_submit_then_watch_default<Call, Signer>(
        &mut self,
        call: &Call,
        signer: &Signer,
    ) -> Result<TxProgress<T, C>, Error>
    where
        Call: Payload,
        Signer: SignerT<T>,
        <T::ExtrinsicParams as ExtrinsicParams<T>>::Params: Default, // <-- here
    {
        self.sign_and_submit_then_watch(call, signer, DefaultParams::default_params())
            .await
    }

    pub async fn sign_and_submit_default<Call, Signer>(
        &mut self,
        call: &Call,
        signer: &Signer,
    ) -> Result<T::Hash, Error>
    where
        Call: Payload,
        Signer: SignerT<T>,
        <T::ExtrinsicParams as ExtrinsicParams<T>>::Params: Default, // <-- here
    {
        self.sign_and_submit(call, signer, DefaultParams::default_params())
            .await
    }
```

Extrinsic params are, by default, a tuple containing an entry for each transaction extension configured via `AnyOf`. Our default transaction extensions are this:

```rust
transaction_extensions::AnyOf<
    T,
    (
        transaction_extensions::VerifySignature<T>,
        transaction_extensions::CheckSpecVersion,
        transaction_extensions::CheckTxVersion,
        transaction_extensions::CheckNonce,
        transaction_extensions::CheckGenesis<T>,
        transaction_extensions::CheckMortality<T>,
        transaction_extensions::ChargeAssetTxPayment<T>,
        transaction_extensions::ChargeTransactionPayment,
        transaction_extensions::CheckMetadataHash,
    ),
>;
```

And `AnyOf` is implemented such that the parameters to configure each extension are expected in a tuple with a size matching the extensions above. 

We currently have support for 9 default transaction extensions above, but if this number were to exceed 12 (which is the max tuple size that Rust implements `Default` for), then we could no longer use `AnyOf` in conjunction with our `_default` methods, since the parameters would no longer implement `Default`.

So, we add a `DefaultParams` trait instead, which supports up to 26 entries in the tuple (as long as each of those impls `Default`), matching the number of tuple entries `AnyOf` supports.

The downside is that a user going off the beaten path will need to implement `DefaultParams` instead of `Default` for their own params if they want to use the `_default` methods, but this is likely to be a rare case. 

Closes #1975.