### PR TITLE
Update to 2024 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,9 +35,9 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Parity Technologies <admin@parity.io>"]
-edition = "2021"
+edition = "2024"
 version = "0.41.0"
-rust-version = "1.81.0"
+rust-version = "1.86.0"
 license = "Apache-2.0 OR GPL-3.0"
 repository = "https://github.com/paritytech/subxt"
 documentation = "https://docs.rs/subxt"

--- a/cli/src/commands/codegen.rs
+++ b/cli/src/commands/codegen.rs
@@ -2,7 +2,7 @@
 // This file is dual-licensed as Apache-2.0 or GPL-3.0.
 // see LICENSE for license details.
 
-use crate::utils::{validate_url_security, FileOrUrl};
+use crate::utils::{FileOrUrl, validate_url_security};
 use clap::Parser as ClapParser;
 use codec::Decode;
 use color_eyre::eyre::eyre;

--- a/cli/src/commands/diff.rs
+++ b/cli/src/commands/diff.rs
@@ -5,11 +5,11 @@ use frame_metadata::RuntimeMetadataPrefixed;
 use std::collections::HashMap;
 use std::hash::Hash;
 
-use crate::utils::{validate_url_security, FileOrUrl};
+use crate::utils::{FileOrUrl, validate_url_security};
 use color_eyre::owo_colors::OwoColorize;
 
-use scale_info::form::PortableForm;
 use scale_info::Variant;
+use scale_info::form::PortableForm;
 
 use subxt_metadata::{
     ConstantMetadata, Metadata, PalletMetadata, RuntimeApiMetadata, StorageEntryMetadata,
@@ -441,7 +441,7 @@ fn diff<T, C: PartialEq, I: Hash + PartialEq + Eq + Ord>(
 
 #[cfg(test)]
 mod test {
-    use crate::commands::diff::{diff, Diff};
+    use crate::commands::diff::{Diff, diff};
 
     #[test]
     fn test_diff_fn() {

--- a/cli/src/commands/explore/mod.rs
+++ b/cli/src/commands/explore/mod.rs
@@ -1,6 +1,6 @@
-use crate::utils::validate_url_security;
 use crate::utils::FileOrUrl;
-use clap::{command, Parser, Subcommand};
+use crate::utils::validate_url_security;
+use clap::{Parser, Subcommand, command};
 use codec::Decode;
 use color_eyre::eyre::eyre;
 use color_eyre::owo_colors::OwoColorize;
@@ -447,18 +447,22 @@ pub mod tests {
         run("--url wss://rpc.polkadot.io:443").await.unwrap();
 
         // Errors, because the --allow-insecure is not set:
-        assert!(run("--url ws://rpc.polkadot.io:443")
-            .await
-            .unwrap_err()
-            .to_string()
-            .contains("is not secure"));
+        assert!(
+            run("--url ws://rpc.polkadot.io:443")
+                .await
+                .unwrap_err()
+                .to_string()
+                .contains("is not secure")
+        );
 
         // This checks, that we never prevent (insecure) requests to localhost, even if the `--allow-insecure` flag is not set.
         // It errors, because there is no node running locally, which results in the "Request error".
-        assert!(run("--url ws://localhost")
-            .await
-            .unwrap_err()
-            .to_string()
-            .contains("Request error"));
+        assert!(
+            run("--url ws://localhost")
+                .await
+                .unwrap_err()
+                .to_string()
+                .contains("Request error")
+        );
     }
 }

--- a/cli/src/commands/explore/pallets/calls.rs
+++ b/cli/src/commands/explore/pallets/calls.rs
@@ -10,14 +10,14 @@ use std::str::FromStr;
 use subxt::tx;
 use subxt::utils::H256;
 use subxt::{
-    config::SubstrateConfig,
-    metadata::{types::PalletMetadata, Metadata},
     OfflineClient,
+    config::SubstrateConfig,
+    metadata::{Metadata, types::PalletMetadata},
 };
 
 use crate::utils::{
-    fields_composite_example, fields_description, parse_string_into_scale_value, Indent,
-    SyntaxHighlight,
+    Indent, SyntaxHighlight, fields_composite_example, fields_description,
+    parse_string_into_scale_value,
 };
 
 #[derive(Debug, Clone, Args)]

--- a/cli/src/commands/explore/pallets/constants.rs
+++ b/cli/src/commands/explore/pallets/constants.rs
@@ -2,9 +2,9 @@ use clap::Args;
 use color_eyre::eyre::eyre;
 use indoc::{formatdoc, writedoc};
 use scale_typegen_description::type_description;
-use subxt::metadata::{types::PalletMetadata, Metadata};
+use subxt::metadata::{Metadata, types::PalletMetadata};
 
-use crate::utils::{first_paragraph_of_docs, format_scale_value, Indent, SyntaxHighlight};
+use crate::utils::{Indent, SyntaxHighlight, first_paragraph_of_docs, format_scale_value};
 
 #[derive(Debug, Clone, Args)]
 pub struct ConstantsSubcommand {

--- a/cli/src/commands/explore/pallets/events.rs
+++ b/cli/src/commands/explore/pallets/events.rs
@@ -1,10 +1,10 @@
 use clap::Args;
 use color_eyre::eyre::eyre;
 use indoc::{formatdoc, writedoc};
-use scale_info::{form::PortableForm, Variant};
-use subxt::metadata::{types::PalletMetadata, Metadata};
+use scale_info::{Variant, form::PortableForm};
+use subxt::metadata::{Metadata, types::PalletMetadata};
 
-use crate::utils::{fields_description, first_paragraph_of_docs, Indent};
+use crate::utils::{Indent, fields_description, first_paragraph_of_docs};
 
 #[derive(Debug, Clone, Args)]
 pub struct EventsSubcommand {

--- a/cli/src/commands/explore/pallets/mod.rs
+++ b/cli/src/commands/explore/pallets/mod.rs
@@ -4,12 +4,12 @@ use indoc::writedoc;
 use subxt::Metadata;
 use subxt_metadata::PalletMetadata;
 
-use crate::utils::{first_paragraph_of_docs, FileOrUrl, Indent};
+use crate::utils::{FileOrUrl, Indent, first_paragraph_of_docs};
 
 use self::{
     calls::CallsSubcommand,
     constants::ConstantsSubcommand,
-    events::{explore_events, EventsSubcommand},
+    events::{EventsSubcommand, explore_events},
     storage::StorageSubcommand,
 };
 

--- a/cli/src/commands/explore/pallets/storage.rs
+++ b/cli/src/commands/explore/pallets/storage.rs
@@ -12,14 +12,14 @@ use std::write;
 use subxt::{
     ext::scale_encode::EncodeAsType,
     metadata::{
-        types::{PalletMetadata, StorageEntryType, StorageMetadata},
         Metadata,
+        types::{PalletMetadata, StorageEntryType, StorageMetadata},
     },
 };
 
 use crate::utils::{
-    create_client, first_paragraph_of_docs, parse_string_into_scale_value, type_example, FileOrUrl,
-    Indent, SyntaxHighlight,
+    FileOrUrl, Indent, SyntaxHighlight, create_client, first_paragraph_of_docs,
+    parse_string_into_scale_value, type_example,
 };
 
 #[derive(Debug, Clone, Args)]
@@ -151,7 +151,9 @@ pub async fn explore_storage(
 
     let storage_entry_keys: Vec<Value> = match (trailing_args.is_empty(), key_ty_id) {
         (false, None) => {
-            let warning = format!("Warning: You submitted a key, but no key is needed: \"{trailing_args}\". To access the storage value, please do not provide any key.");
+            let warning = format!(
+                "Warning: You submitted a key, but no key is needed: \"{trailing_args}\". To access the storage value, please do not provide any key."
+            );
             writeln!(output, "{}", warning.yellow())?;
             return Ok(());
         }

--- a/cli/src/commands/explore/runtime_apis/mod.rs
+++ b/cli/src/commands/explore/runtime_apis/mod.rs
@@ -1,6 +1,6 @@
 use crate::utils::{
-    create_client, fields_composite_example, fields_description, first_paragraph_of_docs,
-    parse_string_into_scale_value, FileOrUrl, Indent, SyntaxHighlight,
+    FileOrUrl, Indent, SyntaxHighlight, create_client, fields_composite_example,
+    fields_description, first_paragraph_of_docs, parse_string_into_scale_value,
 };
 
 use color_eyre::{
@@ -12,8 +12,8 @@ use indoc::{formatdoc, writedoc};
 use scale_typegen_description::type_description;
 use scale_value::Value;
 use subxt::{
-    ext::{scale_decode::DecodeAsType, scale_encode::EncodeAsType},
     Metadata,
+    ext::{scale_decode::DecodeAsType, scale_encode::EncodeAsType},
 };
 use subxt_metadata::RuntimeApiMetadata;
 
@@ -144,7 +144,10 @@ pub async fn run<'a>(
     }
 
     if trailing_args.len() != method.inputs().len() {
-        bail!("The number of trailing arguments you provided after the `execute` flag does not match the expected number of inputs!\n{}", execute_usage());
+        bail!(
+            "The number of trailing arguments you provided after the `execute` flag does not match the expected number of inputs!\n{}",
+            execute_usage()
+        );
     }
 
     // encode each provided input as bytes of the correct type:

--- a/cli/src/commands/metadata.rs
+++ b/cli/src/commands/metadata.rs
@@ -2,7 +2,7 @@
 // This file is dual-licensed as Apache-2.0 or GPL-3.0.
 // see LICENSE for license details.
 
-use crate::utils::{validate_url_security, FileOrUrl};
+use crate::utils::{FileOrUrl, validate_url_security};
 use clap::Parser as ClapParser;
 use codec::{Decode, Encode};
 use color_eyre::eyre::{self, bail};
@@ -62,7 +62,9 @@ pub async fn run(opts: Opts, output: &mut impl Write) -> color_eyre::Result<()> 
             RuntimeMetadata::V15(md) => md.strip_metadata(keep_pallets_fn, keep_runtime_apis_fn),
             RuntimeMetadata::V16(md) => md.strip_metadata(keep_pallets_fn, keep_runtime_apis_fn),
             _ => {
-                bail!("Unsupported metadata version for stripping pallets/runtime APIs: V14, V15 or V16 metadata is expected.")
+                bail!(
+                    "Unsupported metadata version for stripping pallets/runtime APIs: V14, V15 or V16 metadata is expected."
+                )
             }
         }
     }

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -313,7 +313,9 @@ pub fn validate_url_security(url: Option<&Url>, allow_insecure: bool) -> color_e
     match subxt::utils::url_is_secure(url.as_str()) {
         Ok(is_secure) => {
             if !allow_insecure && !is_secure {
-                bail!("URL {url} is not secure!\nIf you are really want to use this URL, try using --allow-insecure (-a)");
+                bail!(
+                    "URL {url} is not secure!\nIf you are really want to use this URL, try using --allow-insecure (-a)"
+                );
             }
         }
         Err(err) => {

--- a/codegen/src/api/calls.rs
+++ b/codegen/src/api/calls.rs
@@ -7,7 +7,7 @@ use heck::{ToSnakeCase as _, ToUpperCamelCase as _};
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
 use scale_typegen::typegen::ir::ToTokensWithSettings;
-use scale_typegen::{typegen::ir::type_ir::CompositeIRKind, TypeGenerator};
+use scale_typegen::{TypeGenerator, typegen::ir::type_ir::CompositeIRKind};
 use subxt_metadata::PalletMetadata;
 
 /// Generate calls from the provided pallet's metadata. Each call returns a `StaticPayload`
@@ -53,7 +53,7 @@ pub fn generate_calls(
                     .unzip(),
                 CompositeIRKind::NoFields => Default::default(),
                 CompositeIRKind::Unnamed(_) => {
-                    return Err(CodegenError::InvalidCallVariant(call_ty))
+                    return Err(CodegenError::InvalidCallVariant(call_ty));
                 }
             };
 

--- a/codegen/src/api/constants.rs
+++ b/codegen/src/api/constants.rs
@@ -5,8 +5,8 @@
 use heck::ToSnakeCase as _;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
-use scale_typegen::typegen::ir::ToTokensWithSettings;
 use scale_typegen::TypeGenerator;
+use scale_typegen::typegen::ir::ToTokensWithSettings;
 use subxt_metadata::PalletMetadata;
 
 use super::CodegenError;

--- a/codegen/src/api/custom_values.rs
+++ b/codegen/src/api/custom_values.rs
@@ -3,8 +3,8 @@
 // see LICENSE for license details.
 
 use heck::ToSnakeCase as _;
-use scale_typegen::typegen::ir::ToTokensWithSettings;
 use scale_typegen::TypeGenerator;
+use scale_typegen::typegen::ir::ToTokensWithSettings;
 use std::collections::HashSet;
 use subxt_metadata::{CustomValueMetadata, Metadata};
 

--- a/codegen/src/api/events.rs
+++ b/codegen/src/api/events.rs
@@ -5,8 +5,8 @@
 use super::CodegenError;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
-use scale_typegen::typegen::ir::ToTokensWithSettings;
 use scale_typegen::TypeGenerator;
+use scale_typegen::typegen::ir::ToTokensWithSettings;
 use subxt_metadata::PalletMetadata;
 
 /// Generate events from the provided pallet metadata.

--- a/codegen/src/api/mod.rs
+++ b/codegen/src/api/mod.rs
@@ -13,13 +13,13 @@ mod pallet_view_functions;
 mod runtime_apis;
 mod storage;
 
-use scale_typegen::typegen::ir::type_ir::{CompositeFieldIR, CompositeIR, CompositeIRKind};
+use scale_typegen::TypeGenerator;
 use scale_typegen::typegen::ir::ToTokensWithSettings;
+use scale_typegen::typegen::ir::type_ir::{CompositeFieldIR, CompositeIR, CompositeIRKind};
 use scale_typegen::typegen::type_params::TypeParameters;
 use scale_typegen::typegen::type_path::TypePath;
-use scale_typegen::TypeGenerator;
 use subxt_metadata::Metadata;
-use syn::{parse_quote, Ident};
+use syn::{Ident, parse_quote};
 
 use crate::error::CodegenError;
 use crate::subxt_type_gen_settings;

--- a/codegen/src/api/pallet_view_functions.rs
+++ b/codegen/src/api/pallet_view_functions.rs
@@ -7,8 +7,8 @@ use heck::ToUpperCamelCase as _;
 use crate::CodegenError;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
-use scale_typegen::typegen::ir::ToTokensWithSettings;
 use scale_typegen::TypeGenerator;
+use scale_typegen::typegen::ir::ToTokensWithSettings;
 use std::collections::HashSet;
 use subxt_metadata::{PalletMetadata, ViewFunctionMetadata};
 

--- a/codegen/src/api/runtime_apis.rs
+++ b/codegen/src/api/runtime_apis.rs
@@ -7,8 +7,8 @@ use std::collections::HashSet;
 use heck::ToSnakeCase as _;
 use heck::ToUpperCamelCase as _;
 
-use scale_typegen::typegen::ir::ToTokensWithSettings;
 use scale_typegen::TypeGenerator;
+use scale_typegen::typegen::ir::ToTokensWithSettings;
 use subxt_metadata::{Metadata, RuntimeApiMetadata};
 
 use proc_macro2::TokenStream as TokenStream2;

--- a/codegen/src/api/storage.rs
+++ b/codegen/src/api/storage.rs
@@ -6,7 +6,7 @@ use heck::{ToSnakeCase as _, ToUpperCamelCase};
 use proc_macro2::{Ident, TokenStream as TokenStream2, TokenStream};
 use quote::{format_ident, quote};
 use scale_info::TypeDef;
-use scale_typegen::{typegen::type_path::TypePath, TypeGenerator};
+use scale_typegen::{TypeGenerator, typegen::type_path::TypePath};
 use subxt_metadata::{
     PalletMetadata, StorageEntryMetadata, StorageEntryModifier, StorageEntryType, StorageHasher,
 };
@@ -322,7 +322,7 @@ mod tests {
     use frame_metadata::v15;
     use heck::ToUpperCamelCase;
     use quote::{format_ident, quote};
-    use scale_info::{meta_type, MetaType};
+    use scale_info::{MetaType, meta_type};
 
     use std::borrow::Cow;
 

--- a/codegen/src/error.rs
+++ b/codegen/src/error.rs
@@ -15,34 +15,52 @@ pub enum CodegenError {
     #[error("Could not decode metadata, only V14 and V15 metadata are supported: {0}")]
     Decode(#[from] codec::Error),
     /// Out of line modules are not supported.
-    #[error("Out-of-line subxt modules are not supported, make sure you are providing a body to your module: pub mod polkadot {{ ... }}")]
+    #[error(
+        "Out-of-line subxt modules are not supported, make sure you are providing a body to your module: pub mod polkadot {{ ... }}"
+    )]
     InvalidModule(Span),
     /// Invalid type path.
     #[error("Invalid type path {0}: {1}")]
     InvalidTypePath(String, syn::Error),
     /// Metadata for constant could not be found.
-    #[error("Metadata for constant entry {0}_{1} could not be found. Make sure you are providing a valid substrate-based metadata")]
+    #[error(
+        "Metadata for constant entry {0}_{1} could not be found. Make sure you are providing a valid substrate-based metadata"
+    )]
     MissingConstantMetadata(String, String),
     /// Metadata for storage could not be found.
-    #[error("Metadata for storage entry {0}_{1} could not be found. Make sure you are providing a valid substrate-based metadata")]
+    #[error(
+        "Metadata for storage entry {0}_{1} could not be found. Make sure you are providing a valid substrate-based metadata"
+    )]
     MissingStorageMetadata(String, String),
     /// Metadata for call could not be found.
-    #[error("Metadata for call entry {0}_{1} could not be found. Make sure you are providing a valid substrate-based metadata")]
+    #[error(
+        "Metadata for call entry {0}_{1} could not be found. Make sure you are providing a valid substrate-based metadata"
+    )]
     MissingCallMetadata(String, String),
     /// Metadata for call could not be found.
-    #[error("Metadata for runtime API entry {0}_{1} could not be found. Make sure you are providing a valid substrate-based metadata")]
+    #[error(
+        "Metadata for runtime API entry {0}_{1} could not be found. Make sure you are providing a valid substrate-based metadata"
+    )]
     MissingRuntimeApiMetadata(String, String),
     /// Call variant must have all named fields.
-    #[error("Call variant for type {0} must have all named fields. Make sure you are providing a valid substrate-based metadata")]
+    #[error(
+        "Call variant for type {0} must have all named fields. Make sure you are providing a valid substrate-based metadata"
+    )]
     InvalidCallVariant(u32),
     /// Type should be an variant/enum.
-    #[error("{0} type should be an variant/enum type. Make sure you are providing a valid substrate-based metadata")]
+    #[error(
+        "{0} type should be an variant/enum type. Make sure you are providing a valid substrate-based metadata"
+    )]
     InvalidType(String),
     /// Extrinsic call type could not be found.
-    #[error("Extrinsic call type could not be found. Make sure you are providing a valid substrate-based metadata")]
+    #[error(
+        "Extrinsic call type could not be found. Make sure you are providing a valid substrate-based metadata"
+    )]
     MissingCallType,
     /// There are too many or too few hashers.
-    #[error("Could not generate functions for storage entry {storage_entry_name}. There are {key_count} keys, but only {hasher_count} hashers. The number of hashers must equal the number of keys or be exactly 1.")]
+    #[error(
+        "Could not generate functions for storage entry {storage_entry_name}. There are {key_count} keys, but only {hasher_count} hashers. The number of hashers must equal the number of keys or be exactly 1."
+    )]
     InvalidStorageHasherCount {
         /// The name of the storage entry
         storage_entry_name: String,

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -20,8 +20,8 @@ use api::RuntimeGenerator;
 use proc_macro2::TokenStream as TokenStream2;
 use scale_typegen::typegen::settings::AllocCratePath;
 use scale_typegen::{
-    typegen::settings::substitutes::absolute_path, DerivesRegistry, TypeGeneratorSettings,
-    TypeSubstitutes, TypegenError,
+    DerivesRegistry, TypeGeneratorSettings, TypeSubstitutes, TypegenError,
+    typegen::settings::substitutes::absolute_path,
 };
 use std::collections::HashMap;
 use syn::parse_quote;
@@ -225,7 +225,9 @@ impl CodegenBuilder {
         if absolute_path(crate_path.clone()).is_err() {
             // Throw an error here, because otherwise we end up with a harder to comprehend error when
             // substitute types don't begin with an absolute path.
-            panic!("The provided crate path must be an absolute path, ie prefixed with '::' or 'crate'");
+            panic!(
+                "The provided crate path must be an absolute path, ie prefixed with '::' or 'crate'"
+            );
         }
         self.crate_path = crate_path;
     }

--- a/core/src/blocks/extrinsic_transaction_extensions.rs
+++ b/core/src/blocks/extrinsic_transaction_extensions.rs
@@ -2,12 +2,12 @@
 // This file is dual-licensed as Apache-2.0 or GPL-3.0.
 // see LICENSE for license details.
 
+use crate::config::TransactionExtension;
 use crate::config::transaction_extensions::{
     ChargeAssetTxPayment, ChargeTransactionPayment, CheckNonce,
 };
-use crate::config::TransactionExtension;
 use crate::dynamic::Value;
-use crate::{config::Config, error::Error, Metadata};
+use crate::{Metadata, config::Config, error::Error};
 use frame_decode::extrinsics::ExtrinsicExtensions;
 use scale_decode::DecodeAsType;
 
@@ -35,7 +35,7 @@ impl<'a, T: Config> ExtrinsicTransactionExtensions<'a, T> {
     }
 
     /// Returns an iterator over each of the signed extension details of the extrinsic.
-    pub fn iter(&self) -> impl Iterator<Item = ExtrinsicTransactionExtension<T>> {
+    pub fn iter(&self) -> impl Iterator<Item = ExtrinsicTransactionExtension<'a, T>> + use<'a, T> {
         self.decoded_info
             .iter()
             .map(|s| ExtrinsicTransactionExtension {

--- a/core/src/blocks/extrinsics.rs
+++ b/core/src/blocks/extrinsics.rs
@@ -5,9 +5,9 @@
 use super::BlockError;
 use crate::blocks::extrinsic_transaction_extensions::ExtrinsicTransactionExtensions;
 use crate::{
+    Metadata,
     config::{Config, HashFor, Hasher},
     error::{Error, MetadataError},
-    Metadata,
 };
 use alloc::sync::Arc;
 use alloc::vec::Vec;
@@ -106,7 +106,7 @@ impl<T: Config> Extrinsics<T> {
     /// If an error occurs, all subsequent iterations return `None`.
     pub fn find<E: StaticExtrinsic>(
         &self,
-    ) -> impl Iterator<Item = Result<FoundExtrinsic<T, E>, Error>> + '_ {
+    ) -> impl Iterator<Item = Result<FoundExtrinsic<T, E>, Error>> {
         self.iter().filter_map(|details| {
             match details.as_extrinsic::<E>() {
                 // Failed to decode extrinsic:
@@ -367,10 +367,10 @@ mod tests {
     use codec::{Decode, Encode};
     use frame_metadata::v15::{CustomMetadata, OuterEnums};
     use frame_metadata::{
-        v15::{ExtrinsicMetadata, PalletCallMetadata, PalletMetadata, RuntimeMetadataV15},
         RuntimeMetadataPrefixed,
+        v15::{ExtrinsicMetadata, PalletCallMetadata, PalletMetadata, RuntimeMetadataV15},
     };
-    use scale_info::{meta_type, TypeInfo};
+    use scale_info::{TypeInfo, meta_type};
     use scale_value::Value;
 
     // Extrinsic needs to contain at least the generic type parameter "Call"

--- a/core/src/blocks/mod.rs
+++ b/core/src/blocks/mod.rs
@@ -68,9 +68,9 @@ mod extrinsic_transaction_extensions;
 mod extrinsics;
 mod static_extrinsic;
 
+use crate::Metadata;
 use crate::config::Config;
 use crate::error::Error;
-use crate::Metadata;
 use alloc::vec::Vec;
 
 pub use crate::error::BlockError;

--- a/core/src/config/default_extrinsic_params.rs
+++ b/core/src/config/default_extrinsic_params.rs
@@ -3,7 +3,7 @@
 // see LICENSE for license details.
 
 use super::Config;
-use super::{transaction_extensions, ExtrinsicParams};
+use super::{ExtrinsicParams, transaction_extensions};
 
 /// The default [`super::ExtrinsicParams`] implementation understands common signed extensions
 /// and how to apply them to a given chain.

--- a/core/src/config/mod.rs
+++ b/core/src/config/mod.rs
@@ -19,7 +19,7 @@ use codec::{Decode, Encode};
 use core::fmt::Debug;
 use scale_decode::DecodeAsType;
 use scale_encode::EncodeAsType;
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{Serialize, de::DeserializeOwned};
 use subxt_metadata::Metadata;
 
 pub use default_extrinsic_params::{DefaultExtrinsicParams, DefaultExtrinsicParamsBuilder};

--- a/core/src/constants/mod.rs
+++ b/core/src/constants/mod.rs
@@ -43,7 +43,7 @@ pub mod address;
 use address::Address;
 use alloc::borrow::ToOwned;
 
-use crate::{error::MetadataError, metadata::DecodeWithMetadata, Error, Metadata};
+use crate::{Error, Metadata, error::MetadataError, metadata::DecodeWithMetadata};
 
 /// When the provided `address` is statically generated via the `#[subxt]` macro, this validates
 /// that the shape of the constant value is the same as the shape expected by the static address.

--- a/core/src/custom_values/mod.rs
+++ b/core/src/custom_values/mod.rs
@@ -33,7 +33,7 @@
 pub mod address;
 
 use crate::utils::Yes;
-use crate::{error::MetadataError, metadata::DecodeWithMetadata, Error, Metadata};
+use crate::{Error, Metadata, error::MetadataError, metadata::DecodeWithMetadata};
 use address::Address;
 use alloc::vec::Vec;
 
@@ -96,8 +96,8 @@ mod tests {
     use alloc::collections::BTreeMap;
     use codec::Encode;
     use scale_decode::DecodeAsType;
-    use scale_info::form::PortableForm;
     use scale_info::TypeInfo;
+    use scale_info::form::PortableForm;
 
     use alloc::borrow::ToOwned;
     use alloc::string::String;

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -53,7 +53,9 @@ impl From<codec::Error> for Error {
 #[derive(Debug, DeriveError)]
 pub enum BlockError {
     /// Leftover bytes found after decoding the extrinsic.
-    #[error("After decoding the extrinsic at index {extrinsic_index}, {num_leftover_bytes} bytes were left, suggesting that decoding may have failed")]
+    #[error(
+        "After decoding the extrinsic at index {extrinsic_index}, {num_leftover_bytes} bytes were left, suggesting that decoding may have failed"
+    )]
     LeftoverBytes {
         /// Index of the extrinsic that failed to decode.
         extrinsic_index: usize,
@@ -153,10 +155,14 @@ pub enum StorageAddressError {
     #[error("We have leftover bytes after decoding the storage address")]
     TooManyBytes,
     /// The bytes of a storage address are not the expected address for decoding the storage keys of the address.
-    #[error("Storage address bytes are not the expected format. Addresses need to be at least 16 bytes (pallet ++ entry) and follow a structure given by the hashers defined in the metadata")]
+    #[error(
+        "Storage address bytes are not the expected format. Addresses need to be at least 16 bytes (pallet ++ entry) and follow a structure given by the hashers defined in the metadata"
+    )]
     UnexpectedAddressBytes,
     /// An invalid hasher was used to reconstruct a value from a chunk of bytes that is part of a storage address. Hashers where the hash does not contain the original value are invalid for this purpose.
-    #[error("An invalid hasher was used to reconstruct a value with type ID {ty_id} from a hash formed by a {hasher:?} hasher. This is only possible for concat-style hashers or the identity hasher")]
+    #[error(
+        "An invalid hasher was used to reconstruct a value with type ID {ty_id} from a hash formed by a {hasher:?} hasher. This is only possible for concat-style hashers or the identity hasher"
+    )]
     HasherCannotReconstructKey {
         /// Type id of the key's type.
         ty_id: u32,

--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -46,9 +46,9 @@ use scale_decode::{DecodeAsFields, DecodeAsType};
 use subxt_metadata::PalletMetadata;
 
 use crate::{
+    Error, Metadata,
     config::{Config, HashFor},
     error::MetadataError,
-    Error, Metadata,
 };
 
 /// Create a new [`Events`] instance from the given bytes.
@@ -184,7 +184,7 @@ impl<T: Config> Events<T> {
     /// Iterate through the events using metadata to dynamically decode and skip
     /// them, and return only those which should decode to the provided `Ev` type.
     /// If an error occurs, all subsequent iterations return `None`.
-    pub fn find<Ev: StaticEvent>(&self) -> impl Iterator<Item = Result<Ev, Error>> + '_ {
+    pub fn find<Ev: StaticEvent>(&self) -> impl Iterator<Item = Result<Ev, Error>> {
         self.iter()
             .filter_map(|ev| ev.and_then(|ev| ev.as_event::<Ev>()).transpose())
     }
@@ -437,13 +437,13 @@ pub(crate) mod test_utils {
     use crate::config::{HashFor, SubstrateConfig};
     use codec::Encode;
     use frame_metadata::{
+        RuntimeMetadataPrefixed,
         v15::{
             CustomMetadata, ExtrinsicMetadata, OuterEnums, PalletEventMetadata, PalletMetadata,
             RuntimeMetadataV15,
         },
-        RuntimeMetadataPrefixed,
     };
-    use scale_info::{meta_type, TypeInfo};
+    use scale_info::{TypeInfo, meta_type};
 
     /// An "outer" events enum containing exactly one event.
     #[derive(
@@ -587,7 +587,7 @@ pub(crate) mod test_utils {
 #[cfg(test)]
 mod tests {
     use super::{
-        test_utils::{event_record, events, events_raw, AllEvents, EventRecord},
+        test_utils::{AllEvents, EventRecord, event_record, events, events_raw},
         *,
     };
     use crate::config::SubstrateConfig;

--- a/core/src/runtime_api/payload.rs
+++ b/core/src/runtime_api/payload.rs
@@ -14,9 +14,9 @@ use derive_where::derive_where;
 use scale_encode::EncodeAsFields;
 use scale_value::Composite;
 
+use crate::Error;
 use crate::dynamic::DecodedValueThunk;
 use crate::error::MetadataError;
-use crate::Error;
 
 use crate::metadata::{DecodeWithMetadata, Metadata};
 

--- a/core/src/storage/mod.rs
+++ b/core/src/storage/mod.rs
@@ -46,7 +46,7 @@ mod utils;
 
 pub mod address;
 
-use crate::{error::MetadataError, metadata::DecodeWithMetadata, Error, Metadata};
+use crate::{Error, Metadata, error::MetadataError, metadata::DecodeWithMetadata};
 use address::Address;
 use alloc::vec::Vec;
 

--- a/core/src/storage/storage_key.rs
+++ b/core/src/storage/storage_key.rs
@@ -193,7 +193,7 @@ impl<K: codec::Decode> StaticStorageKey<K> {
 impl<K: ?Sized> StaticStorageKey<K> {
     /// Returns the scale-encoded bytes that make up this key
     pub fn bytes(&self) -> &[u8] {
-        &self.bytes.0 .0
+        &self.bytes.0.0
     }
 }
 
@@ -361,7 +361,7 @@ const _: () = {
 mod tests {
 
     use codec::Encode;
-    use scale_info::{meta_type, PortableRegistry, Registry, TypeInfo};
+    use scale_info::{PortableRegistry, Registry, TypeInfo, meta_type};
     use subxt_metadata::StorageHasher;
 
     use crate::utils::Era;
@@ -463,15 +463,15 @@ mod tests {
                                 .unwrap();
 
                         assert_eq!(keys_a.1.decoded().unwrap(), 13);
-                        assert_eq!(keys_b.1 .0.decoded().unwrap(), 13);
-                        assert_eq!(keys_c.0 .1.decoded().unwrap(), 13);
+                        assert_eq!(keys_b.1.0.decoded().unwrap(), 13);
+                        assert_eq!(keys_c.0.1.decoded().unwrap(), 13);
 
                         assert_eq!(keys_a.2.decoded().unwrap(), "Hello");
-                        assert_eq!(keys_b.1 .1.decoded().unwrap(), "Hello");
-                        assert_eq!(keys_c.1 .0.decoded().unwrap(), "Hello");
+                        assert_eq!(keys_b.1.1.decoded().unwrap(), "Hello");
+                        assert_eq!(keys_c.1.0.decoded().unwrap(), "Hello");
                         assert_eq!(keys_a.3.decoded().unwrap(), era);
                         assert_eq!(keys_b.2.decoded().unwrap(), era);
-                        assert_eq!(keys_c.1 .1.decoded().unwrap(), era);
+                        assert_eq!(keys_c.1.1.decoded().unwrap(), era);
                     }
                 }
             }

--- a/core/src/tx/payload.rs
+++ b/core/src/tx/payload.rs
@@ -5,9 +5,9 @@
 //! This module contains the trait and types used to represent
 //! transactions that can be submitted.
 
+use crate::Error;
 use crate::error::MetadataError;
 use crate::metadata::Metadata;
-use crate::Error;
 use alloc::borrow::{Cow, ToOwned};
 use alloc::boxed::Box;
 use alloc::string::String;

--- a/core/src/utils/bits.rs
+++ b/core/src/utils/bits.rs
@@ -9,8 +9,8 @@ use alloc::vec::Vec;
 use codec::{Compact, Input};
 use core::marker::PhantomData;
 use scale_bits::{
-    scale::format::{Format, OrderFormat, StoreFormat},
     Bits,
+    scale::format::{Format, OrderFormat, StoreFormat},
 };
 use scale_decode::{IntoVisitor, TypeResolver};
 

--- a/core/src/utils/static_type.rs
+++ b/core/src/utils/static_type.rs
@@ -3,7 +3,7 @@
 // see LICENSE for license details.
 
 use codec::{Decode, Encode};
-use scale_decode::{visitor::DecodeAsTypeResult, IntoVisitor, TypeResolver, Visitor};
+use scale_decode::{IntoVisitor, TypeResolver, Visitor, visitor::DecodeAsTypeResult};
 use scale_encode::EncodeAsType;
 
 use alloc::vec::Vec;
@@ -44,7 +44,7 @@ impl<T: Decode, R: TypeResolver> Visitor for StaticDecodeAsTypeVisitor<T, R> {
         _type_id: R::TypeId,
         _types: &'info R,
     ) -> DecodeAsTypeResult<Self, Result<Self::Value<'scale, 'info>, Self::Error>> {
-        use scale_decode::{visitor::DecodeError, Error};
+        use scale_decode::{Error, visitor::DecodeError};
         let decoded = T::decode(input)
             .map(Static)
             .map_err(|e| Error::new(DecodeError::CodecError(e).into()));

--- a/core/src/utils/unchecked_extrinsic.rs
+++ b/core/src/utils/unchecked_extrinsic.rs
@@ -12,7 +12,7 @@
 use core::marker::PhantomData;
 
 use codec::{Decode, Encode};
-use scale_decode::{visitor::DecodeAsTypeResult, DecodeAsType, IntoVisitor, TypeResolver, Visitor};
+use scale_decode::{DecodeAsType, IntoVisitor, TypeResolver, Visitor, visitor::DecodeAsTypeResult};
 
 use super::{Encoded, Static};
 use alloc::vec::Vec;
@@ -32,7 +32,7 @@ impl<Address, Call, Signature, Extra> UncheckedExtrinsic<Address, Call, Signatur
 
     /// Get the bytes of the encoded extrinsic.
     pub fn bytes(&self) -> &[u8] {
-        self.0 .0 .0.as_slice()
+        self.0.0.0.as_slice()
     }
 }
 
@@ -75,7 +75,7 @@ impl<Address, Call, Signature, Extra> From<UncheckedExtrinsic<Address, Call, Sig
     for Vec<u8>
 {
     fn from(bytes: UncheckedExtrinsic<Address, Call, Signature, Extra>) -> Self {
-        bytes.0 .0 .0
+        bytes.0.0.0
     }
 }
 
@@ -106,8 +106,8 @@ impl<Address, Call, Signature, Extra> IntoVisitor
     type AnyVisitor<R: TypeResolver> =
         UncheckedExtrinsicDecodeAsTypeVisitor<Address, Call, Signature, Extra, R>;
 
-    fn into_visitor<R: TypeResolver>(
-    ) -> UncheckedExtrinsicDecodeAsTypeVisitor<Address, Call, Signature, Extra, R> {
+    fn into_visitor<R: TypeResolver>()
+    -> UncheckedExtrinsicDecodeAsTypeVisitor<Address, Call, Signature, Extra, R> {
         UncheckedExtrinsicDecodeAsTypeVisitor(PhantomData)
     }
 }

--- a/core/src/utils/wrapper_opaque.rs
+++ b/core/src/utils/wrapper_opaque.rs
@@ -5,7 +5,7 @@
 use super::PhantomDataSendSync;
 use codec::{Compact, Decode, DecodeAll, Encode};
 use derive_where::derive_where;
-use scale_decode::{ext::scale_type_resolver::visitor, IntoVisitor, TypeResolver, Visitor};
+use scale_decode::{IntoVisitor, TypeResolver, Visitor, ext::scale_type_resolver::visitor};
 use scale_encode::EncodeAsType;
 
 use alloc::format;
@@ -135,7 +135,9 @@ impl<T, R: TypeResolver> Visitor for WrapperKeepOpaqueVisitor<T, R> {
 
         // Sanity check that the compact length we decoded lines up with the number of bytes encoded in the next field.
         if field.bytes().len() != len as usize {
-            return Err(Error::custom_str("WrapperTypeKeepOpaque compact encoded length doesn't line up with encoded byte len"));
+            return Err(Error::custom_str(
+                "WrapperTypeKeepOpaque compact encoded length doesn't line up with encoded byte len",
+            ));
         }
 
         Ok(WrapperKeepOpaque {
@@ -166,7 +168,7 @@ mod test {
     impl<T: scale_info::TypeInfo + 'static> scale_info::TypeInfo for WrapperKeepOpaque<T> {
         type Identity = Self;
         fn type_info() -> scale_info::Type {
-            use scale_info::{build::Fields, meta_type, Path, Type, TypeParameter};
+            use scale_info::{Path, Type, TypeParameter, build::Fields, meta_type};
 
             Type::builder()
                 .path(Path::new("WrapperKeepOpaque", module_path!()))

--- a/core/src/view_functions/payload.rs
+++ b/core/src/view_functions/payload.rs
@@ -11,9 +11,9 @@ use derive_where::derive_where;
 use scale_encode::EncodeAsFields;
 use scale_value::Composite;
 
+use crate::Error;
 use crate::dynamic::DecodedValueThunk;
 use crate::error::MetadataError;
-use crate::Error;
 
 use crate::metadata::{DecodeWithMetadata, Metadata};
 

--- a/lightclient/src/background.rs
+++ b/lightclient/src/background.rs
@@ -5,7 +5,7 @@
 use crate::rpc::RpcResponse;
 use crate::shared_client::SharedClient;
 use crate::{JsonRpcError, LightClientRpcError};
-use futures::{stream::StreamExt, FutureExt};
+use futures::{FutureExt, stream::StreamExt};
 use serde_json::value::RawValue;
 use smoldot_light::platform::PlatformRef;
 use std::{collections::HashMap, str::FromStr};

--- a/lightclient/src/platform/mod.rs
+++ b/lightclient/src/platform/mod.rs
@@ -11,7 +11,7 @@ mod wasm_platform;
 #[cfg(feature = "web")]
 mod wasm_socket;
 
-pub use helpers::{build_platform, DefaultPlatform};
+pub use helpers::{DefaultPlatform, build_platform};
 
 #[cfg(feature = "native")]
 mod helpers {

--- a/lightclient/src/platform/wasm_helpers.rs
+++ b/lightclient/src/platform/wasm_helpers.rs
@@ -8,7 +8,7 @@
 use super::wasm_socket::WasmSocket;
 
 use core::time::Duration;
-use futures_util::{future, FutureExt};
+use futures_util::{FutureExt, future};
 
 pub fn now_from_unix_epoch() -> Duration {
     web_time::SystemTime::now()

--- a/lightclient/src/platform/wasm_platform.rs
+++ b/lightclient/src/platform/wasm_platform.rs
@@ -141,7 +141,9 @@ impl PlatformRef for SubxtPlatform {
             // The API user of the `PlatformRef` trait is never supposed to open connections of
             // a type that isn't supported.
             _ => {
-                unreachable!("Connecting to an address not supported. This code path indicates a bug in smoldot. Please raise an issue at https://github.com/smol-dot/smoldot/issues")
+                unreachable!(
+                    "Connecting to an address not supported. This code path indicates a bug in smoldot. Please raise an issue at https://github.com/smol-dot/smoldot/issues"
+                )
             }
         };
 
@@ -157,7 +159,9 @@ impl PlatformRef for SubxtPlatform {
     }
 
     fn connect_multistream(&self, _address: MultiStreamAddress) -> Self::MultiStreamConnectFuture {
-        panic!("Multistreams are not currently supported. This code path indicates a bug in smoldot. Please raise an issue at https://github.com/smol-dot/smoldot/issues")
+        panic!(
+            "Multistreams are not currently supported. This code path indicates a bug in smoldot. Please raise an issue at https://github.com/smol-dot/smoldot/issues"
+        )
     }
 
     fn open_out_substream(&self, c: &mut Self::MultiStream) {

--- a/lightclient/src/platform/wasm_socket.rs
+++ b/lightclient/src/platform/wasm_socket.rs
@@ -4,7 +4,7 @@
 
 use futures::{io, prelude::*};
 use send_wrapper::SendWrapper;
-use wasm_bindgen::{prelude::*, JsCast};
+use wasm_bindgen::{JsCast, prelude::*};
 
 use std::{
     collections::VecDeque,

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -5,7 +5,7 @@
 //! Subxt macro for generating Substrate runtime interfaces.
 
 use codec::Decode;
-use darling::{ast::NestedMeta, FromMeta};
+use darling::{FromMeta, ast::NestedMeta};
 use proc_macro::TokenStream;
 use proc_macro_error2::{abort_call_site, proc_macro_error};
 use quote::ToTokens;
@@ -241,7 +241,7 @@ fn fetch_metadata(args: &RuntimeMetadataArgs) -> Result<subxt_codegen::Metadata,
         }
         #[cfg(feature = "runtime-metadata-insecure-url")]
         (None, Some(url_string)) => {
-            use subxt_utils_fetchmetadata::{from_url_blocking, MetadataVersion, Url};
+            use subxt_utils_fetchmetadata::{MetadataVersion, Url, from_url_blocking};
 
             let url = Url::parse(url_string).unwrap_or_else(|_| {
                 abort_call_site!("Cannot download metadata; invalid url: {}", url_string)
@@ -266,8 +266,8 @@ fn fetch_metadata(args: &RuntimeMetadataArgs) -> Result<subxt_codegen::Metadata,
         #[cfg(feature = "runtime-wasm-path")]
         (None, None) => {
             abort_call_site!(
-                    "At least one of 'runtime_metadata_path', 'runtime_metadata_insecure_url'  or  'runtime_path` can be provided"
-                )
+                "At least one of 'runtime_metadata_path', 'runtime_metadata_insecure_url'  or  'runtime_path` can be provided"
+            )
         }
         #[cfg(not(feature = "runtime-wasm-path"))]
         (None, None) => {
@@ -278,8 +278,8 @@ fn fetch_metadata(args: &RuntimeMetadataArgs) -> Result<subxt_codegen::Metadata,
         #[cfg(feature = "runtime-wasm-path")]
         _ => {
             abort_call_site!(
-                    "Only one of 'runtime_metadata_path', 'runtime_metadata_insecure_url'  or  'runtime_path` can be provided"
-                )
+                "Only one of 'runtime_metadata_path', 'runtime_metadata_insecure_url'  or  'runtime_path` can be provided"
+            )
         }
         #[cfg(not(feature = "runtime-wasm-path"))]
         _ => {

--- a/metadata/src/from/v14.rs
+++ b/metadata/src/from/v14.rs
@@ -6,10 +6,10 @@ use super::TryFromError;
 
 use crate::utils::variant_index::VariantIndex;
 use crate::{
-    utils::ordered_map::OrderedMap, ArcStr, ConstantMetadata, CustomMetadataInner,
-    ExtrinsicMetadata, Metadata, OuterEnumsMetadata, PalletMetadataInner, StorageEntryMetadata,
-    StorageEntryModifier, StorageEntryType, StorageHasher, StorageMetadata,
-    TransactionExtensionMetadataInner,
+    ArcStr, ConstantMetadata, CustomMetadataInner, ExtrinsicMetadata, Metadata, OuterEnumsMetadata,
+    PalletMetadataInner, StorageEntryMetadata, StorageEntryModifier, StorageEntryType,
+    StorageHasher, StorageMetadata, TransactionExtensionMetadataInner,
+    utils::ordered_map::OrderedMap,
 };
 use alloc::borrow::ToOwned;
 use alloc::collections::BTreeMap;

--- a/metadata/src/from/v15.rs
+++ b/metadata/src/from/v15.rs
@@ -6,10 +6,10 @@ use super::TryFromError;
 
 use crate::utils::variant_index::VariantIndex;
 use crate::{
-    utils::ordered_map::OrderedMap, ArcStr, ConstantMetadata, ExtrinsicMetadata, Metadata,
-    MethodParamMetadata, OuterEnumsMetadata, PalletMetadataInner, RuntimeApiMetadataInner,
-    RuntimeApiMethodMetadataInner, StorageEntryMetadata, StorageEntryModifier, StorageEntryType,
-    StorageHasher, StorageMetadata, TransactionExtensionMetadataInner,
+    ArcStr, ConstantMetadata, ExtrinsicMetadata, Metadata, MethodParamMetadata, OuterEnumsMetadata,
+    PalletMetadataInner, RuntimeApiMetadataInner, RuntimeApiMethodMetadataInner,
+    StorageEntryMetadata, StorageEntryModifier, StorageEntryType, StorageHasher, StorageMetadata,
+    TransactionExtensionMetadataInner, utils::ordered_map::OrderedMap,
 };
 use alloc::collections::BTreeMap;
 use alloc::vec;

--- a/metadata/src/from/v16.rs
+++ b/metadata/src/from/v16.rs
@@ -6,10 +6,10 @@ use super::TryFromError;
 
 use crate::utils::variant_index::VariantIndex;
 use crate::{
-    utils::ordered_map::OrderedMap, ArcStr, ConstantMetadata, ExtrinsicMetadata, Metadata,
-    MethodParamMetadata, OuterEnumsMetadata, PalletMetadataInner, RuntimeApiMetadataInner,
-    RuntimeApiMethodMetadataInner, StorageEntryMetadata, StorageEntryModifier, StorageEntryType,
-    StorageHasher, StorageMetadata, TransactionExtensionMetadataInner, ViewFunctionMetadataInner,
+    ArcStr, ConstantMetadata, ExtrinsicMetadata, Metadata, MethodParamMetadata, OuterEnumsMetadata,
+    PalletMetadataInner, RuntimeApiMetadataInner, RuntimeApiMethodMetadataInner,
+    StorageEntryMetadata, StorageEntryModifier, StorageEntryType, StorageHasher, StorageMetadata,
+    TransactionExtensionMetadataInner, ViewFunctionMetadataInner, utils::ordered_map::OrderedMap,
 };
 use frame_metadata::{v15, v16};
 use hashbrown::HashMap;

--- a/metadata/src/lib.rs
+++ b/metadata/src/lib.rs
@@ -32,17 +32,17 @@ use frame_decode::extrinsics::{
     ExtrinsicSignatureInfo,
 };
 use hashbrown::HashMap;
-use scale_info::{form::PortableForm, PortableRegistry, Variant};
+use scale_info::{PortableRegistry, Variant, form::PortableForm};
 use utils::{
     ordered_map::OrderedMap,
-    validation::{get_custom_value_hash, HASH_LEN},
+    validation::{HASH_LEN, get_custom_value_hash},
     variant_index::VariantIndex,
 };
 
 type ArcStr = Arc<str>;
 
-pub use from::TryFromError;
 pub use from::SUPPORTED_METADATA_VERSIONS;
+pub use from::TryFromError;
 pub use utils::validation::MetadataHasher;
 
 type CustomMetadataInner = frame_metadata::v15::CustomMetadata<PortableForm>;
@@ -314,7 +314,9 @@ impl<'a> PalletMetadata<'a> {
     }
 
     /// Return an iterator over the View Functions in this pallet, if any.
-    pub fn view_functions(&self) -> impl ExactSizeIterator<Item = ViewFunctionMetadata<'a>> {
+    pub fn view_functions(
+        &self,
+    ) -> impl ExactSizeIterator<Item = ViewFunctionMetadata<'a>> + use<'a> {
         self.inner
             .view_functions
             .values()
@@ -337,7 +339,7 @@ impl<'a> PalletMetadata<'a> {
     }
 
     /// Iterate (in no particular order) over the associated type names and type IDs for this pallet.
-    pub fn associated_types(&self) -> impl ExactSizeIterator<Item = (&str, u32)> {
+    pub fn associated_types(&self) -> impl ExactSizeIterator<Item = (&'a str, u32)> + use<'a> {
         self.inner
             .associated_types
             .iter()
@@ -388,7 +390,7 @@ impl<'a> PalletMetadata<'a> {
     }
 
     /// An iterator over the constants in this pallet.
-    pub fn constants(&self) -> impl ExactSizeIterator<Item = &'a ConstantMetadata> {
+    pub fn constants(&self) -> impl ExactSizeIterator<Item = &'a ConstantMetadata> + use<'a> {
         self.inner.constants.values().iter()
     }
 
@@ -783,7 +785,7 @@ impl<'a> RuntimeApiMetadata<'a> {
         &self.inner.docs
     }
     /// An iterator over the trait methods.
-    pub fn methods(&self) -> impl ExactSizeIterator<Item = RuntimeApiMethodMetadata<'a>> {
+    pub fn methods(&self) -> impl ExactSizeIterator<Item = RuntimeApiMethodMetadata<'a>> + use<'a> {
         self.inner
             .methods
             .values()
@@ -839,7 +841,7 @@ impl<'a> RuntimeApiMethodMetadata<'a> {
         &self.inner.docs
     }
     /// Method inputs.
-    pub fn inputs(&self) -> impl ExactSizeIterator<Item = &MethodParamMetadata> {
+    pub fn inputs(&self) -> impl ExactSizeIterator<Item = &'a MethodParamMetadata> + use<'a> {
         self.inner.inputs.iter()
     }
     /// Method return type.
@@ -887,7 +889,7 @@ impl<'a> ViewFunctionMetadata<'a> {
         &self.inner.docs
     }
     /// Method inputs.
-    pub fn inputs(&self) -> impl ExactSizeIterator<Item = &'a MethodParamMetadata> {
+    pub fn inputs(&self) -> impl ExactSizeIterator<Item = &'a MethodParamMetadata> + use<'a> {
         self.inner.inputs.iter()
     }
     /// Method return type.
@@ -947,7 +949,7 @@ impl<'a> CustomMetadata<'a> {
     }
 
     /// Iterates over names (keys) and associated custom values
-    pub fn iter(&self) -> impl Iterator<Item = CustomValueMetadata> {
+    pub fn iter(&self) -> impl Iterator<Item = CustomValueMetadata<'a>> + use<'a> {
         self.inner.map.iter().map(|(name, e)| CustomValueMetadata {
             types: self.types,
             type_id: e.ty.id,

--- a/metadata/src/utils/validation.rs
+++ b/metadata/src/utils/validation.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use alloc::vec::Vec;
 use hashbrown::HashMap;
-use scale_info::{form::PortableForm, Field, PortableRegistry, TypeDef, TypeDefVariant, Variant};
+use scale_info::{Field, PortableRegistry, TypeDef, TypeDefVariant, Variant, form::PortableForm};
 
 // The number of bytes our `hash` function produces.
 pub(crate) const HASH_LEN: usize = 32;
@@ -604,7 +604,7 @@ mod tests {
     use super::*;
     use bitvec::{order::Lsb0, vec::BitVec};
     use frame_metadata::v15;
-    use scale_info::{meta_type, Registry};
+    use scale_info::{Registry, meta_type};
 
     // Define recursive types.
     #[allow(dead_code)]

--- a/metadata/src/utils/variant_index.rs
+++ b/metadata/src/utils/variant_index.rs
@@ -5,7 +5,7 @@
 use alloc::borrow::ToOwned;
 use alloc::string::String;
 use hashbrown::HashMap;
-use scale_info::{form::PortableForm, PortableRegistry, TypeDef, Variant};
+use scale_info::{PortableRegistry, TypeDef, Variant, form::PortableForm};
 
 /// Given some type ID and type registry, build a couple of
 /// indexes to look up variants by index or name. If the ID provided

--- a/rpcs/src/client/mod.rs
+++ b/rpcs/src/client/mod.rs
@@ -48,5 +48,5 @@ crate::macros::cfg_mock_rpc_client! {
 mod rpc_client;
 mod rpc_client_t;
 
-pub use rpc_client::{rpc_params, RpcClient, RpcParams, RpcSubscription};
+pub use rpc_client::{RpcClient, RpcParams, RpcSubscription, rpc_params};
 pub use rpc_client_t::{RawRpcFuture, RawRpcSubscription, RawValue, RpcClientT};

--- a/rpcs/src/client/rpc_client.rs
+++ b/rpcs/src/client/rpc_client.rs
@@ -5,7 +5,7 @@
 use super::{RawRpcSubscription, RpcClientT};
 use crate::Error;
 use futures::{Stream, StreamExt};
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{Serialize, de::DeserializeOwned};
 use serde_json::value::RawValue;
 use std::{pin::Pin, sync::Arc, task::Poll};
 

--- a/rpcs/src/methods/chain_head.rs
+++ b/rpcs/src/methods/chain_head.rs
@@ -6,8 +6,8 @@
 //! <https://github.com/paritytech/json-rpc-interface-spec/> for details of the API
 //! methods exposed here.
 
-use crate::client::{rpc_params, RpcClient, RpcSubscription};
 use crate::Hash;
+use crate::client::{RpcClient, RpcSubscription, rpc_params};
 use crate::{Error, RpcConfig};
 use derive_where::derive_where;
 use futures::{Stream, StreamExt};

--- a/rpcs/src/methods/legacy.rs
+++ b/rpcs/src/methods/legacy.rs
@@ -4,7 +4,7 @@
 
 //! An interface to call the raw legacy RPC methods.
 
-use crate::client::{rpc_params, RpcClient, RpcSubscription};
+use crate::client::{RpcClient, RpcSubscription, rpc_params};
 use crate::{Error, RpcConfig};
 use codec::Decode;
 use derive_where::derive_where;

--- a/scripts/artifacts/src/main.rs
+++ b/scripts/artifacts/src/main.rs
@@ -54,7 +54,10 @@ fn main() {
     );
 
     // Generate the polkadot chain spec.
-    run_cmd("cargo run --features chain-spec-pruning --bin subxt chain-spec --url wss://rpc.polkadot.io:443 --output-file artifacts/demo_chain_specs/polkadot.json --state-root-hash --remove-substitutes", None);
+    run_cmd(
+        "cargo run --features chain-spec-pruning --bin subxt chain-spec --url wss://rpc.polkadot.io:443 --output-file artifacts/demo_chain_specs/polkadot.json --state-root-hash --remove-substitutes",
+        None,
+    );
 }
 
 fn run_cmd(cmd: &str, out_path: Option<&str>) {

--- a/signer/src/crypto/derive_junction.rs
+++ b/signer/src/crypto/derive_junction.rs
@@ -65,7 +65,7 @@ impl DeriveJunction {
     /// Get a reference to the inner junction id.
     pub fn inner(&self) -> &[u8; JUNCTION_ID_LEN] {
         match self {
-            DeriveJunction::Hard(ref c) | DeriveJunction::Soft(ref c) => c,
+            DeriveJunction::Hard(c) | DeriveJunction::Soft(c) => c,
         }
     }
 
@@ -97,10 +97,6 @@ impl<T: AsRef<str>> From<T> for DeriveJunction {
             DeriveJunction::soft(code)
         };
 
-        if hard {
-            res.harden()
-        } else {
-            res
-        }
+        if hard { res.harden() } else { res }
     }
 }

--- a/signer/src/crypto/mod.rs
+++ b/signer/src/crypto/mod.rs
@@ -12,7 +12,7 @@ mod secret_uri;
 mod seed_from_entropy;
 
 pub use derive_junction::DeriveJunction;
-pub use secret_uri::{SecretUri, SecretUriError, DEV_PHRASE};
+pub use secret_uri::{DEV_PHRASE, SecretUri, SecretUriError};
 
 #[cfg(any(feature = "sr25519", feature = "ecdsa"))]
 pub use seed_from_entropy::seed_from_entropy;

--- a/signer/src/ecdsa.rs
+++ b/signer/src/ecdsa.rs
@@ -5,10 +5,10 @@
 //! An ecdsa keypair implementation.
 use codec::Encode;
 
-use crate::crypto::{seed_from_entropy, DeriveJunction, SecretUri};
+use crate::crypto::{DeriveJunction, SecretUri, seed_from_entropy};
 use core::str::FromStr;
 use hex::FromHex;
-use secp256k1::{ecdsa::RecoverableSignature, Message, Secp256k1, SecretKey};
+use secp256k1::{Message, Secp256k1, SecretKey, ecdsa::RecoverableSignature};
 use secrecy::ExposeSecret;
 
 use thiserror::Error as DeriveError;

--- a/signer/src/eth.rs
+++ b/signer/src/eth.rs
@@ -105,7 +105,7 @@ impl Keypair {
 
     /// Obtain the [`eth::PublicKey`] of this keypair.
     pub fn public_key(&self) -> PublicKey {
-        let uncompressed = self.0 .0.public_key().serialize_uncompressed();
+        let uncompressed = self.0.0.public_key().serialize_uncompressed();
         PublicKey(uncompressed)
     }
 
@@ -450,7 +450,7 @@ mod test {
 
         for (case_idx, (keypair, exp_account_id, exp_priv_key)) in cases.into_iter().enumerate() {
             let act_account_id = keypair.public_key().to_account_id().checksum();
-            let act_priv_key = format!("0x{}", &keypair.0 .0.display_secret());
+            let act_priv_key = format!("0x{}", &keypair.0.0.display_secret());
 
             assert_eq!(
                 exp_account_id, act_account_id,
@@ -563,7 +563,7 @@ mod test {
             (
                 "void come effort suffer camp survey warrior heavy shoot primary clutch crush open amazing screen patrol group space point ten exist slush involve unfold",
                 "01f5bced59dec48e362f2c45b5de68b9fd6c92c6634f44d6d40aab69056506f0e35524a518034ddc1192e1dacd32c1ed3eaa3c3b131c88ed8e7e54c49a5d0998",
-            )
+            ),
         ];
 
         for (idx, (m, s)) in mnemonics_and_seeds.into_iter().enumerate() {

--- a/signer/src/lib.rs
+++ b/signer/src/lib.rs
@@ -52,4 +52,4 @@ pub use secrecy::{ExposeSecret, SecretString};
 
 // SecretUri's can be parsed from strings and used to generate key pairs.
 // DeriveJunctions are the "path" part of these SecretUris.
-pub use crypto::{DeriveJunction, SecretUri, SecretUriError, DEV_PHRASE};
+pub use crypto::{DEV_PHRASE, DeriveJunction, SecretUri, SecretUriError};

--- a/signer/src/polkadot_js_compat.rs
+++ b/signer/src/polkadot_js_compat.rs
@@ -6,8 +6,8 @@
 
 use base64::Engine;
 use crypto_secretbox::{
-    aead::{Aead, KeyInit},
     Key, Nonce, XSalsa20Poly1305,
+    aead::{Aead, KeyInit},
 };
 use serde::Deserialize;
 use subxt_core::utils::AccountId32;

--- a/signer/src/sr25519.rs
+++ b/signer/src/sr25519.rs
@@ -10,12 +10,12 @@
 
 use core::str::FromStr;
 
-use crate::crypto::{seed_from_entropy, DeriveJunction, SecretUri};
+use crate::crypto::{DeriveJunction, SecretUri, seed_from_entropy};
 
 use hex::FromHex;
 use schnorrkel::{
-    derive::{ChainCode, Derivation},
     ExpansionMode, MiniSecretKey,
+    derive::{ChainCode, Derivation},
 };
 use secrecy::ExposeSecret;
 
@@ -292,9 +292,9 @@ mod subxt_compat {
     use super::*;
 
     use subxt_core::{
+        Config,
         tx::signer::Signer as SignerT,
         utils::{AccountId32, MultiAddress, MultiSignature},
-        Config,
     };
 
     impl From<Signature> for MultiSignature {

--- a/subxt/examples/block_decoding_static.rs
+++ b/subxt/examples/block_decoding_static.rs
@@ -1,7 +1,7 @@
 #![allow(missing_docs)]
 use subxt::{
-    utils::{AccountId32, MultiAddress},
     OnlineClient, PolkadotConfig,
+    utils::{AccountId32, MultiAddress},
 };
 
 use codec::Decode;
@@ -47,8 +47,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let nonce = extensions.nonce().expect("Should have nonce");
 
             println!(
-                    "    Transfer of {value} DOT:\n        {sender} (Tip: {tip}, Nonce: {nonce}) ---> {receiver}",
-                );
+                "    Transfer of {value} DOT:\n        {sender} (Tip: {tip}, Nonce: {nonce}) ---> {receiver}",
+            );
         }
     }
 

--- a/subxt/examples/light_client_basic.rs
+++ b/subxt/examples/light_client_basic.rs
@@ -1,6 +1,6 @@
 #![allow(missing_docs)]
 use futures::StreamExt;
-use subxt::{client::OnlineClient, lightclient::LightClient, PolkadotConfig};
+use subxt::{PolkadotConfig, client::OnlineClient, lightclient::LightClient};
 
 // Generate an interface that we can use from the node's metadata.
 #[subxt::subxt(runtime_metadata_path = "../artifacts/polkadot_metadata_small.scale")]

--- a/subxt/examples/light_client_local_node.rs
+++ b/subxt/examples/light_client_local_node.rs
@@ -1,9 +1,9 @@
 #![allow(missing_docs)]
 use subxt::utils::fetch_chainspec_from_rpc_node;
 use subxt::{
+    PolkadotConfig,
     client::OnlineClient,
     lightclient::{ChainConfig, LightClient},
-    PolkadotConfig,
 };
 use subxt_signer::sr25519::dev;
 

--- a/subxt/examples/runtime_apis_dynamic.rs
+++ b/subxt/examples/runtime_apis_dynamic.rs
@@ -1,6 +1,6 @@
 #![allow(missing_docs)]
 use subxt::dynamic::Value;
-use subxt::{config::PolkadotConfig, OnlineClient};
+use subxt::{OnlineClient, config::PolkadotConfig};
 use subxt_signer::sr25519::dev;
 
 #[tokio::main]

--- a/subxt/examples/runtime_apis_static.rs
+++ b/subxt/examples/runtime_apis_static.rs
@@ -1,5 +1,5 @@
 #![allow(missing_docs)]
-use subxt::{config::PolkadotConfig, OnlineClient};
+use subxt::{OnlineClient, config::PolkadotConfig};
 use subxt_signer::sr25519::dev;
 
 #[subxt::subxt(runtime_metadata_path = "../artifacts/polkadot_metadata_small.scale")]

--- a/subxt/examples/setup_client_custom_rpc.rs
+++ b/subxt/examples/setup_client_custom_rpc.rs
@@ -5,8 +5,8 @@ use std::{
     sync::{Arc, Mutex},
 };
 use subxt::{
-    backend::rpc::{RawRpcFuture, RawRpcSubscription, RawValue, RpcClient, RpcClientT},
     OnlineClient, PolkadotConfig,
+    backend::rpc::{RawRpcFuture, RawRpcSubscription, RawValue, RpcClient, RpcClientT},
 };
 
 // A dummy RPC client that doesn't actually handle requests properly

--- a/subxt/examples/setup_client_offline.rs
+++ b/subxt/examples/setup_client_offline.rs
@@ -2,7 +2,7 @@
 use subxt::ext::codec::Decode;
 use subxt::metadata::Metadata;
 use subxt::utils::H256;
-use subxt::{config::PolkadotConfig, OfflineClient};
+use subxt::{OfflineClient, config::PolkadotConfig};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/subxt/examples/setup_config_custom.rs
+++ b/subxt/examples/setup_config_custom.rs
@@ -2,8 +2,8 @@
 use codec::Encode;
 use subxt::client::ClientState;
 use subxt::config::{
-    transaction_extensions::Params, Config, ExtrinsicParams, ExtrinsicParamsEncoder,
-    ExtrinsicParamsError, HashFor,
+    Config, ExtrinsicParams, ExtrinsicParamsEncoder, ExtrinsicParamsError, HashFor,
+    transaction_extensions::Params,
 };
 use subxt_signer::sr25519::dev;
 

--- a/subxt/examples/storage_iterating_dynamic.rs
+++ b/subxt/examples/storage_iterating_dynamic.rs
@@ -1,5 +1,5 @@
 #![allow(missing_docs)]
-use subxt::{dynamic::Value, OnlineClient, PolkadotConfig};
+use subxt::{OnlineClient, PolkadotConfig, dynamic::Value};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/subxt/examples/storage_iterating_partial.rs
+++ b/subxt/examples/storage_iterating_partial.rs
@@ -5,7 +5,7 @@ use polkadot::runtime_types::{
 };
 use subxt::utils::AccountId32;
 use subxt::{OnlineClient, PolkadotConfig};
-use subxt_signer::sr25519::{dev, Keypair};
+use subxt_signer::sr25519::{Keypair, dev};
 
 #[subxt::subxt(runtime_metadata_path = "../artifacts/polkadot_metadata_full.scale")]
 pub mod polkadot {}

--- a/subxt/examples/substrate_compat_signer.rs
+++ b/subxt/examples/substrate_compat_signer.rs
@@ -6,7 +6,7 @@
 
 #![allow(missing_docs, unused)]
 
-use sp_core::{sr25519, Pair as _};
+use sp_core::{Pair as _, sr25519};
 use subxt::config::substrate::MultiAddress;
 use subxt::{Config, OnlineClient, PolkadotConfig};
 
@@ -18,8 +18,8 @@ pub mod polkadot {}
 mod pair_signer {
     use super::*;
     use sp_runtime::{
-        traits::{IdentifyAccount, Verify},
         MultiSignature as SpMultiSignature,
+        traits::{IdentifyAccount, Verify},
     };
     use subxt::{
         config::substrate::{AccountId32, MultiSignature},

--- a/subxt/examples/tx_basic_frontier.rs
+++ b/subxt/examples/tx_basic_frontier.rs
@@ -7,7 +7,7 @@
 
 use subxt::OnlineClient;
 use subxt_core::utils::AccountId20;
-use subxt_signer::eth::{dev, Signature};
+use subxt_signer::eth::{Signature, dev};
 
 #[subxt::subxt(runtime_metadata_path = "../artifacts/frontier_metadata_small.scale")]
 mod eth_runtime {}

--- a/subxt/examples/tx_boxed.rs
+++ b/subxt/examples/tx_boxed.rs
@@ -36,7 +36,7 @@ fn remark() -> Box<dyn subxt::tx::Payload> {
 }
 
 fn dynamic_remark() -> Box<dyn subxt::tx::Payload> {
-    use subxt::dynamic::{tx, Value};
+    use subxt::dynamic::{Value, tx};
     let tx_payload = tx("System", "remark", vec![Value::from_bytes("Hello")]);
 
     Box::new(tx_payload)

--- a/subxt/examples/tx_status_stream.rs
+++ b/subxt/examples/tx_status_stream.rs
@@ -1,5 +1,5 @@
 #![allow(missing_docs)]
-use subxt::{tx::TxStatus, OnlineClient, PolkadotConfig};
+use subxt::{OnlineClient, PolkadotConfig, tx::TxStatus};
 use subxt_signer::sr25519::dev;
 
 // Generate an interface that we can use from the node's metadata.

--- a/subxt/src/backend/chain_head/follow_stream.rs
+++ b/subxt/src/backend/chain_head/follow_stream.rs
@@ -218,8 +218,8 @@ impl<Hash> Stream for FollowStream<Hash> {
 pub(super) mod test_utils {
     use super::*;
     use crate::config::substrate::H256;
-    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use subxt_rpcs::methods::chain_head::{BestBlockChanged, Finalized, Initialized, NewBlock};
 
     /// Given some events, returns a follow stream getter that we can use in

--- a/subxt/src/backend/chain_head/follow_stream.rs
+++ b/subxt/src/backend/chain_head/follow_stream.rs
@@ -313,7 +313,7 @@ pub mod test {
         });
 
         let s = FollowStream::new(stream_getter);
-        let out: Vec<_> = s.filter_map(|e| async move { e.ok() }).collect().await;
+        let out: Vec<_> = s.filter_map(async |e| e.ok()).collect().await;
 
         // The expected response, given the above.
         assert_eq!(

--- a/subxt/src/backend/chain_head/follow_stream_unpin.rs
+++ b/subxt/src/backend/chain_head/follow_stream_unpin.rs
@@ -573,10 +573,7 @@ mod test {
             10,
         );
 
-        let out: Vec<_> = follow_unpin
-            .filter_map(|e| async move { e.ok() })
-            .collect()
-            .await;
+        let out: Vec<_> = follow_unpin.filter_map(async |e| e.ok()).collect().await;
 
         assert_eq!(
             out,

--- a/subxt/src/backend/chain_head/follow_stream_unpin.rs
+++ b/subxt/src/backend/chain_head/follow_stream_unpin.rs
@@ -2,8 +2,8 @@
 // This file is dual-licensed as Apache-2.0 or GPL-3.0.
 // see LICENSE for license details.
 
-use super::follow_stream::FollowStream;
 use super::ChainHeadRpcMethods;
+use super::follow_stream::FollowStream;
 use crate::config::{Config, Hash, HashFor};
 use crate::error::Error;
 use futures::stream::{FuturesUnordered, Stream, StreamExt};
@@ -468,7 +468,7 @@ impl<H: Hash> Drop for BlockRef<H> {
 
 #[cfg(test)]
 pub(super) mod test_utils {
-    use super::super::follow_stream::{test_utils::test_stream_getter, FollowStream};
+    use super::super::follow_stream::{FollowStream, test_utils::test_stream_getter};
     use super::*;
     use crate::config::substrate::H256;
 

--- a/subxt/src/backend/chain_head/mod.rs
+++ b/subxt/src/backend/chain_head/mod.rs
@@ -18,8 +18,8 @@ mod storage_items;
 
 use self::follow_stream_driver::FollowStreamFinalizedHeads;
 use crate::backend::{
-    utils::retry, Backend, BlockRef, BlockRefT, RuntimeVersion, StorageResponse, StreamOf,
-    StreamOfResults, TransactionStatus,
+    Backend, BlockRef, BlockRefT, RuntimeVersion, StorageResponse, StreamOf, StreamOfResults,
+    TransactionStatus, utils::retry,
 };
 use crate::config::{Config, Hash, HashFor};
 use crate::error::{Error, RpcError};
@@ -30,10 +30,10 @@ use futures::{Stream, StreamExt};
 use std::collections::HashMap;
 use std::task::Poll;
 use storage_items::StorageItems;
+use subxt_rpcs::RpcClient;
 use subxt_rpcs::methods::chain_head::{
     FollowEvent, MethodResponse, RuntimeEvent, StorageQuery, StorageQueryType, StorageResultType,
 };
-use subxt_rpcs::RpcClient;
 
 /// Re-export RPC types and methods from [`subxt_rpcs::methods::chain_head`].
 pub mod rpc_methods {
@@ -686,7 +686,7 @@ impl<T: Config + Send + Sync + 'static> Backend<T> for ChainHeadBackend<T> {
                         Poll::Ready(None) => {
                             return Poll::Ready(err_other(
                                 "chainHead_follow stream ended unexpectedly",
-                            ))
+                            ));
                         }
                         Poll::Ready(Some(follow_ev)) => Poll::Ready(follow_ev),
                         Poll::Pending => Poll::Pending,
@@ -722,7 +722,9 @@ impl<T: Config + Send + Sync + 'static> Backend<T> for ChainHeadBackend<T> {
                                 // in which we may lose the finalized block that the TX is in. For now, just error if
                                 // this happens, to prevent the case in which we never see a finalized block and wait
                                 // forever.
-                                return Poll::Ready(err_other("chainHead_follow emitted 'stop' event during transaction submission"));
+                                return Poll::Ready(err_other(
+                                    "chainHead_follow emitted 'stop' event during transaction submission",
+                                ));
                             }
                             _ => {}
                         }
@@ -756,7 +758,11 @@ impl<T: Config + Send + Sync + 'static> Backend<T> for ChainHeadBackend<T> {
                     // If we don't have a finalized block yet, we keep polling for tx progress events.
                     let tx_progress_ev = match tx_progress.poll_next_unpin(cx) {
                         Poll::Pending => return Poll::Pending,
-                        Poll::Ready(None) => return Poll::Ready(err_other("No more transaction progress events, but we haven't seen a Finalized one yet")),
+                        Poll::Ready(None) => {
+                            return Poll::Ready(err_other(
+                                "No more transaction progress events, but we haven't seen a Finalized one yet",
+                            ));
+                        }
                         Poll::Ready(Some(Err(e))) => return Poll::Ready(Some(Err(e.into()))),
                         Poll::Ready(Some(Ok(ev))) => ev,
                     };

--- a/subxt/src/backend/chain_head/mod.rs
+++ b/subxt/src/backend/chain_head/mod.rs
@@ -301,7 +301,7 @@ impl<T: Config + Send + Sync + 'static> Backend<T> for ChainHeadBackend<T> {
                 StorageItems::from_methods(queries, at, &self.follow_handle, self.methods.clone())
                     .await?;
 
-            let stream = storage_items.filter_map(|val| async move {
+            let stream = storage_items.filter_map(async |val| {
                 let val = match val {
                     Ok(val) => val,
                     Err(e) => return Some(Err(e)),
@@ -366,7 +366,7 @@ impl<T: Config + Send + Sync + 'static> Backend<T> for ChainHeadBackend<T> {
             )
             .await?;
 
-            let storage_result_stream = storage_items.filter_map(|val| async move {
+            let storage_result_stream = storage_items.filter_map(async |val| {
                 let val = match val {
                     Ok(val) => val,
                     Err(e) => return Some(Err(e)),

--- a/subxt/src/backend/legacy.rs
+++ b/subxt/src/backend/legacy.rs
@@ -12,12 +12,12 @@ use crate::backend::{
     TransactionStatus,
 };
 use crate::{
-    config::{Config, HashFor, Header},
     Error,
+    config::{Config, HashFor, Header},
 };
 use async_trait::async_trait;
 use futures::TryStreamExt;
-use futures::{future, future::Either, stream, Future, FutureExt, Stream, StreamExt};
+use futures::{Future, FutureExt, Stream, StreamExt, future, future::Either, stream};
 use std::collections::VecDeque;
 use std::pin::Pin;
 use std::task::{Context, Poll};

--- a/subxt/src/backend/legacy.rs
+++ b/subxt/src/backend/legacy.rs
@@ -473,7 +473,7 @@ where
                     Ok::<_, Error>(header)
                 }
             })
-            .filter_map(|h| async { h.transpose() });
+            .filter_map(async |h| h.transpose());
 
         // On the next iteration, we'll get details starting just after this end block.
         last_block_num = Some(end_block_num);

--- a/subxt/src/backend/mod.rs
+++ b/subxt/src/backend/mod.rs
@@ -511,11 +511,11 @@ mod test {
         #[tokio::test]
         async fn storage_fetch_value() {
             let rpc_client = MockRpcClient::builder()
-                .method_handler_once("state_getStorage", move |_params| async move {
+                .method_handler_once("state_getStorage", async move |_params| {
                     // Return "disconnected" error on first call
                     Err::<Infallible, _>(disconnected_will_reconnect())
                 })
-                .method_handler_once("state_getStorage", move |_param| async move {
+                .method_handler_once("state_getStorage", async move |_param| {
                     // Return some hex encoded storage value on the next one
                     Json(hex::encode("Data1"))
                 })
@@ -550,11 +550,11 @@ mod test {
         async fn simple_fetch() {
             let hash = random_hash();
             let rpc_client = MockRpcClient::builder()
-                .method_handler_once("chain_getBlockHash", move |_params| async move {
+                .method_handler_once("chain_getBlockHash", async move |_params| {
                     // Return "disconnected" error on first call
                     Err::<Infallible, _>(disconnected_will_reconnect())
                 })
-                .method_handler_once("chain_getBlockHash", move |_params| async move {
+                .method_handler_once("chain_getBlockHash", async move |_params| {
                     // Return the blockhash on next call
                     Json(hash)
                 })
@@ -870,11 +870,11 @@ mod test {
             let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
 
             let rpc_client = mock_client_builder(rx)
-                .method_handler_once("chainHead_v1_storage", move |_params| async move {
+                .method_handler_once("chainHead_v1_storage", async move |_params| {
                     // First call; return DisconnectedWillReconnect
                     Err::<Infallible, _>(disconnected_will_reconnect())
                 })
-                .method_handler_once("chainHead_v1_storage", move |_params| async move {
+                .method_handler_once("chainHead_v1_storage", async move |_params| {
                     // Otherwise, return that we'll start sending a response, and spawn
                     // task to send the relevant response via chainHead_follow.
                     tokio::spawn(async move {
@@ -927,11 +927,11 @@ mod test {
             let tx2 = tx.clone();
 
             let rpc_client = mock_client_builder(rx)
-                .method_handler_once("chainHead_v1_storage", move |_params| async move {
+                .method_handler_once("chainHead_v1_storage", async move |_params| {
                     // First call; return DisconnectedWillReconnect
                     Err::<Infallible, _>(disconnected_will_reconnect())
                 })
-                .method_handler_once("chainHead_v1_storage", move |_params| async move {
+                .method_handler_once("chainHead_v1_storage", async move |_params| {
                     // Next call, return a storage item and then a "waiting for continue".
                     tokio::spawn(async move {
                         tx.send(storage_items("Id1", &[storage_result("ID1", "Data1")]))
@@ -940,11 +940,11 @@ mod test {
                     });
                     Ok(Json(response_started("Id1")))
                 })
-                .method_handler_once("chainHead_v1_continue", move |_params| async move {
+                .method_handler_once("chainHead_v1_continue", async move |_params| {
                     // First call; return DisconnectedWillReconnect
                     Err::<Infallible, _>(disconnected_will_reconnect())
                 })
-                .method_handler_once("chainHead_v1_continue", move |_params| async move {
+                .method_handler_once("chainHead_v1_continue", async move |_params| {
                     // Next call; acknowledge the "continue" and return reamining storage items.
                     tokio::spawn(async move {
                         tx2.send(storage_items("Id1", &[storage_result("ID2", "Data2")]))
@@ -988,11 +988,11 @@ mod test {
             let hash = random_hash();
             let (_tx, rx) = tokio::sync::mpsc::unbounded_channel();
             let rpc_client = mock_client_builder(rx)
-                .method_handler_once("chainSpec_v1_genesisHash", move |_params| async move {
+                .method_handler_once("chainSpec_v1_genesisHash", async move |_params| {
                     // First call, return disconnected error.
                     Err::<Infallible, _>(disconnected_will_reconnect())
                 })
-                .method_handler_once("chainSpec_v1_genesisHash", move |_params| async move {
+                .method_handler_once("chainSpec_v1_genesisHash", async move |_params| {
                     // Next call, return the hash.
                     Ok(Json(hash))
                 })

--- a/subxt/src/backend/mod.rs
+++ b/subxt/src/backend/mod.rs
@@ -388,10 +388,10 @@ mod test {
     use primitive_types::H256;
     use rpc::RpcClientT;
     use std::collections::{HashMap, VecDeque};
-    use subxt_core::{config::DefaultExtrinsicParams, Config};
+    use subxt_core::{Config, config::DefaultExtrinsicParams};
     use subxt_rpcs::client::{
-        mock_rpc_client::{Json, MockRpcClientBuilder},
         MockRpcClient,
+        mock_rpc_client::{Json, MockRpcClientBuilder},
     };
 
     fn random_hash() -> H256 {
@@ -427,7 +427,7 @@ mod test {
     mod legacy {
         use super::*;
         use crate::{
-            backend::legacy::{rpc_methods::RuntimeVersion, LegacyBackend},
+            backend::legacy::{LegacyBackend, rpc_methods::RuntimeVersion},
             error::RpcError,
         };
 
@@ -854,11 +854,13 @@ mod test {
                 .await
                 .unwrap();
 
-            assert!(response
-                .next()
-                .await
-                .unwrap()
-                .is_err_and(|e| matches!(e, Error::Other(e) if e == "error")));
+            assert!(
+                response
+                    .next()
+                    .await
+                    .unwrap()
+                    .is_err_and(|e| matches!(e, Error::Other(e) if e == "error"))
+            );
             assert!(response.next().await.is_none());
         }
 

--- a/subxt/src/backend/utils.rs
+++ b/subxt/src/backend/utils.rs
@@ -246,7 +246,7 @@ mod tests {
     #[tokio::test]
     async fn retry_sub_err_terminates_stream() {
         let stream = futures::stream::iter([Ok(1)]);
-        let resubscribe = Box::new(move || async move { Err(custom_err()) }.boxed());
+        let resubscribe = Box::new(|| async move { Err(custom_err()) }.boxed());
 
         let retry_stream = RetrySubscription {
             state: Some(PendingOrStream::Stream(StreamOf::new(Box::pin(stream)))),
@@ -259,7 +259,7 @@ mod tests {
     #[tokio::test]
     async fn retry_sub_resubscribe_err() {
         let stream = futures::stream::iter([Ok(1), Err(disconnect_err())]);
-        let resubscribe = Box::new(move || async move { Err(custom_err()) }.boxed());
+        let resubscribe = Box::new(|| async move { Err(custom_err()) }.boxed());
 
         let retry_stream = RetrySubscription {
             state: Some(PendingOrStream::Stream(StreamOf::new(Box::pin(stream)))),

--- a/subxt/src/blocks/block_types.rs
+++ b/subxt/src/blocks/block_types.rs
@@ -161,7 +161,12 @@ where
         2 => u16::decode(cursor)?.into(),
         4 => u32::decode(cursor)?.into(),
         8 => u64::decode(cursor)?,
-        _ => return Err(Error::Decode(DecodeError::custom_string(format!("state call AccountNonceApi_account_nonce returned an unexpected number of bytes: {} (expected 2, 4 or 8)", account_nonce_bytes.len()))))
+        _ => {
+            return Err(Error::Decode(DecodeError::custom_string(format!(
+                "state call AccountNonceApi_account_nonce returned an unexpected number of bytes: {} (expected 2, 4 or 8)",
+                account_nonce_bytes.len()
+            ))));
+        }
     };
     Ok(account_nonce)
 }

--- a/subxt/src/blocks/extrinsic_types.rs
+++ b/subxt/src/blocks/extrinsic_types.rs
@@ -3,7 +3,7 @@
 // see LICENSE for license details.
 
 use crate::{
-    blocks::block_types::{get_events, CachedEvents},
+    blocks::block_types::{CachedEvents, get_events},
     client::{OfflineClientT, OnlineClientT},
     config::{Config, HashFor},
     error::Error,
@@ -81,7 +81,7 @@ where
     /// If an error occurs, all subsequent iterations return `None`.
     pub fn find<E: StaticExtrinsic>(
         &self,
-    ) -> impl Iterator<Item = Result<FoundExtrinsic<T, C, E>, Error>> + '_ {
+    ) -> impl Iterator<Item = Result<FoundExtrinsic<T, C, E>, Error>> {
         self.inner.find::<E>().map(|res| {
             match res {
                 Err(e) => Err(Error::from(e)),
@@ -308,7 +308,7 @@ impl<T: Config> ExtrinsicEvents<T> {
     ///
     /// This works in the same way that [`events::Events::iter()`] does, with the
     /// exception that it filters out events not related to the submitted extrinsic.
-    pub fn iter(&self) -> impl Iterator<Item = Result<events::EventDetails<T>, Error>> + '_ {
+    pub fn iter(&self) -> impl Iterator<Item = Result<events::EventDetails<T>, Error>> {
         self.events.iter().filter(|ev| {
             ev.as_ref()
                 .map(|ev| ev.phase() == events::Phase::ApplyExtrinsic(self.idx))
@@ -320,7 +320,7 @@ impl<T: Config> ExtrinsicEvents<T> {
     ///
     /// This works in the same way that [`events::Events::find()`] does, with the
     /// exception that it filters out events not related to the submitted extrinsic.
-    pub fn find<Ev: events::StaticEvent>(&self) -> impl Iterator<Item = Result<Ev, Error>> + '_ {
+    pub fn find<Ev: events::StaticEvent>(&self) -> impl Iterator<Item = Result<Ev, Error>> {
         self.iter()
             .filter_map(|ev| ev.and_then(|ev| ev.as_event::<Ev>()).transpose())
     }

--- a/subxt/src/client/offline_client.rs
+++ b/subxt/src/client/offline_client.rs
@@ -4,6 +4,7 @@
 
 use crate::custom_values::CustomValuesClient;
 use crate::{
+    Metadata,
     blocks::BlocksClient,
     config::{Config, HashFor},
     constants::ConstantsClient,
@@ -12,7 +13,6 @@ use crate::{
     storage::StorageClient,
     tx::TxClient,
     view_functions::ViewFunctionsClient,
-    Metadata,
 };
 
 use derive_where::derive_where;

--- a/subxt/src/client/online_client.rs
+++ b/subxt/src/client/online_client.rs
@@ -5,7 +5,8 @@
 use super::{OfflineClient, OfflineClientT};
 use crate::custom_values::CustomValuesClient;
 use crate::{
-    backend::{legacy::LegacyBackend, rpc::RpcClient, Backend, BackendExt, StreamOfResults},
+    Metadata,
+    backend::{Backend, BackendExt, StreamOfResults, legacy::LegacyBackend, rpc::RpcClient},
     blocks::{BlockRef, BlocksClient},
     config::{Config, HashFor},
     constants::ConstantsClient,
@@ -15,7 +16,6 @@ use crate::{
     storage::StorageClient,
     tx::TxClient,
     view_functions::ViewFunctionsClient,
-    Metadata,
 };
 use derive_where::derive_where;
 use futures::future;

--- a/subxt/src/constants/constants_client.rs
+++ b/subxt/src/constants/constants_client.rs
@@ -2,7 +2,7 @@
 // This file is dual-licensed as Apache-2.0 or GPL-3.0.
 // see LICENSE for license details.
 
-use crate::{client::OfflineClientT, error::Error, Config};
+use crate::{Config, client::OfflineClientT, error::Error};
 use derive_where::derive_where;
 use subxt_core::constants::address::Address;
 

--- a/subxt/src/constants/mod.rs
+++ b/subxt/src/constants/mod.rs
@@ -8,5 +8,5 @@ mod constants_client;
 
 pub use constants_client::ConstantsClient;
 pub use subxt_core::constants::address::{
-    dynamic, Address, DefaultAddress, DynamicAddress, StaticAddress,
+    Address, DefaultAddress, DynamicAddress, StaticAddress, dynamic,
 };

--- a/subxt/src/custom_values/custom_values_client.rs
+++ b/subxt/src/custom_values/custom_values_client.rs
@@ -50,8 +50,8 @@ mod tests {
     use crate::{Metadata, OfflineClient, SubstrateConfig};
     use codec::Encode;
     use scale_decode::DecodeAsType;
-    use scale_info::form::PortableForm;
     use scale_info::TypeInfo;
+    use scale_info::form::PortableForm;
     use std::collections::BTreeMap;
     use subxt_core::client::RuntimeVersion;
 

--- a/subxt/src/error/dispatch_error.rs
+++ b/subxt/src/error/dispatch_error.rs
@@ -7,7 +7,7 @@
 
 use crate::metadata::{DecodeWithMetadata, Metadata};
 use core::fmt::Debug;
-use scale_decode::{visitor::DecodeAsTypeResult, DecodeAsType, TypeResolver};
+use scale_decode::{DecodeAsType, TypeResolver, visitor::DecodeAsTypeResult};
 
 use std::{borrow::Cow, marker::PhantomData};
 
@@ -73,7 +73,9 @@ pub enum TokenError {
     #[error("Funds are unavailable.")]
     FundsUnavailable,
     /// Some part of the balance gives the only provider reference to the account and thus cannot be (re)moved.
-    #[error("Some part of the balance gives the only provider reference to the account and thus cannot be (re)moved.")]
+    #[error(
+        "Some part of the balance gives the only provider reference to the account and thus cannot be (re)moved."
+    )]
     OnlyProvider,
     /// Account cannot exist with the funds that would be given.
     #[error("Account cannot exist with the funds that would be given.")]
@@ -327,7 +329,9 @@ impl DispatchError {
                         module_bytes[4],
                     ]
                 } else {
-                    tracing::warn!("Can't decode error sp_runtime::DispatchError: bytes do not match known shapes");
+                    tracing::warn!(
+                        "Can't decode error sp_runtime::DispatchError: bytes do not match known shapes"
+                    );
                     // Return _all_ of the bytes; every "unknown" return should be consistent.
                     return Err(super::Error::Unknown(bytes.to_vec()));
                 };

--- a/subxt/src/error/mod.rs
+++ b/subxt/src/error/mod.rs
@@ -170,7 +170,9 @@ pub enum BlockError {
     #[error("Could not find a block with hash {0} (perhaps it was on a non-finalized fork?)")]
     NotFound(String),
     /// Leftover bytes found after decoding the extrinsic.
-    #[error("After decoding the exntrinsic at index {extrinsic_index}, {num_leftover_bytes} bytes were left, suggesting that decoding may have failed")]
+    #[error(
+        "After decoding the exntrinsic at index {extrinsic_index}, {num_leftover_bytes} bytes were left, suggesting that decoding may have failed"
+    )]
     LeftoverBytes {
         /// Index of the extrinsic that failed to decode.
         extrinsic_index: usize,
@@ -222,7 +224,9 @@ impl BlockError {
 pub enum TransactionError {
     /// The block hash that the transaction was added to could not be found.
     /// This is probably because the block was retracted before being finalized.
-    #[error("The block containing the transaction can no longer be found (perhaps it was on a non-finalized fork?)")]
+    #[error(
+        "The block containing the transaction can no longer be found (perhaps it was on a non-finalized fork?)"
+    )]
     BlockNotFound,
     /// An error happened on the node that the transaction was submitted to.
     #[error("Error handling transaction: {0}")]

--- a/subxt/src/events/events_type.rs
+++ b/subxt/src/events/events_type.rs
@@ -1,6 +1,6 @@
 use crate::{
-    config::{Config, HashFor},
     Error, Metadata,
+    config::{Config, HashFor},
 };
 use derive_where::derive_where;
 use scale_decode::DecodeAsType;
@@ -58,7 +58,7 @@ impl<T: Config> Events<T> {
     /// Iterate through the events using metadata to dynamically decode and skip
     /// them, and return only those which should decode to the provided `Ev` type.
     /// If an error occurs, all subsequent iterations return `None`.
-    pub fn find<Ev: StaticEvent>(&self) -> impl Iterator<Item = Result<Ev, Error>> + '_ {
+    pub fn find<Ev: StaticEvent>(&self) -> impl Iterator<Item = Result<Ev, Error>> {
         self.inner.find::<Ev>().map(|item| item.map_err(Into::into))
     }
 

--- a/subxt/src/events/mod.rs
+++ b/subxt/src/events/mod.rs
@@ -9,11 +9,11 @@
 mod events_client;
 mod events_type;
 
-use crate::client::OnlineClientT;
 use crate::Error;
+use crate::client::OnlineClientT;
 use subxt_core::{
-    config::{Config, HashFor},
     Metadata,
+    config::{Config, HashFor},
 };
 
 pub use events_client::EventsClient;

--- a/subxt/src/lib.rs
+++ b/subxt/src/lib.rs
@@ -58,10 +58,10 @@ pub mod view_functions;
 /// Polkadot node.
 pub mod config {
     pub use subxt_core::config::{
-        polkadot, substrate, transaction_extensions, Config, DefaultExtrinsicParams,
-        DefaultExtrinsicParamsBuilder, ExtrinsicParams, ExtrinsicParamsEncoder, Hash, HashFor,
-        Hasher, Header, PolkadotConfig, PolkadotExtrinsicParams, SubstrateConfig,
-        SubstrateExtrinsicParams, TransactionExtension,
+        Config, DefaultExtrinsicParams, DefaultExtrinsicParamsBuilder, ExtrinsicParams,
+        ExtrinsicParamsEncoder, Hash, HashFor, Hasher, Header, PolkadotConfig,
+        PolkadotExtrinsicParams, SubstrateConfig, SubstrateExtrinsicParams, TransactionExtension,
+        polkadot, substrate, transaction_extensions,
     };
     pub use subxt_core::error::ExtrinsicParamsError;
 }
@@ -76,8 +76,8 @@ pub mod metadata {
 /// Submit dynamic transactions.
 pub mod dynamic {
     pub use subxt_core::dynamic::{
-        constant, runtime_api_call, storage, tx, view_function_call, At, DecodedValue,
-        DecodedValueThunk, Value,
+        At, DecodedValue, DecodedValueThunk, Value, constant, runtime_api_call, storage, tx,
+        view_function_call,
     };
 }
 

--- a/subxt/src/runtime_api/mod.rs
+++ b/subxt/src/runtime_api/mod.rs
@@ -10,5 +10,5 @@ mod runtime_types;
 pub use runtime_client::RuntimeApiClient;
 pub use runtime_types::RuntimeApi;
 pub use subxt_core::runtime_api::payload::{
-    dynamic, DefaultPayload, DynamicPayload, Payload, StaticPayload,
+    DefaultPayload, DynamicPayload, Payload, StaticPayload, dynamic,
 };

--- a/subxt/src/runtime_api/runtime_types.rs
+++ b/subxt/src/runtime_api/runtime_types.rs
@@ -50,7 +50,7 @@ where
         &self,
         function: &'a str,
         call_parameters: Option<&'a [u8]>,
-    ) -> impl Future<Output = Result<Res, Error>> + 'a {
+    ) -> impl Future<Output = Result<Res, Error>> + use<'a, Res, Client, T> {
         let client = self.client.clone();
         let block_hash = self.block_ref.hash();
         // Ensure that the returned future doesn't have a lifetime tied to api.runtime_api(),
@@ -68,7 +68,7 @@ where
     pub fn call<Call: Payload>(
         &self,
         payload: Call,
-    ) -> impl Future<Output = Result<Call::ReturnType, Error>> {
+    ) -> impl Future<Output = Result<Call::ReturnType, Error>> + use<Call, Client, T> {
         let client = self.client.clone();
         let block_hash = self.block_ref.hash();
         // Ensure that the returned future doesn't have a lifetime tied to api.runtime_api(),

--- a/subxt/src/storage/mod.rs
+++ b/subxt/src/storage/mod.rs
@@ -10,5 +10,5 @@ mod storage_type;
 pub use storage_client::StorageClient;
 pub use storage_type::{Storage, StorageKeyValuePair};
 pub use subxt_core::storage::address::{
-    dynamic, Address, DefaultAddress, DynamicAddress, StaticAddress, StaticStorageKey, StorageKey,
+    Address, DefaultAddress, DynamicAddress, StaticAddress, StaticStorageKey, StorageKey, dynamic,
 };

--- a/subxt/src/storage/storage_type.rs
+++ b/subxt/src/storage/storage_type.rs
@@ -113,7 +113,7 @@ where
     pub fn fetch<'address, Addr>(
         &self,
         address: &'address Addr,
-    ) -> impl Future<Output = Result<Option<Addr::Target>, Error>> + 'address
+    ) -> impl Future<Output = Result<Option<Addr::Target>, Error>> + use<'address, Addr, Client, T>
     where
         Addr: Address<IsFetchable = Yes> + 'address,
     {
@@ -142,7 +142,7 @@ where
     pub fn fetch_or_default<'address, Addr>(
         &self,
         address: &'address Addr,
-    ) -> impl Future<Output = Result<Addr::Target, Error>> + 'address
+    ) -> impl Future<Output = Result<Addr::Target, Error>> + use<'address, Addr, Client, T>
     where
         Addr: Address<IsFetchable = Yes, IsDefaultable = Yes> + 'address,
     {

--- a/subxt/src/tx/mod.rs
+++ b/subxt/src/tx/mod.rs
@@ -12,7 +12,7 @@
 mod tx_client;
 mod tx_progress;
 
-pub use subxt_core::tx::payload::{dynamic, DefaultPayload, DynamicPayload, Payload};
+pub use subxt_core::tx::payload::{DefaultPayload, DynamicPayload, Payload, dynamic};
 pub use subxt_core::tx::signer::{self, Signer};
 pub use tx_client::{
     DefaultParams, PartialTransaction, SubmittableTransaction, TransactionInvalid,

--- a/subxt/src/tx/tx_progress.rs
+++ b/subxt/src/tx/tx_progress.rs
@@ -89,10 +89,10 @@ where
                 // Error scenarios; return the error.
                 TxStatus::Error { message } => return Err(TransactionError::Error(message).into()),
                 TxStatus::Invalid { message } => {
-                    return Err(TransactionError::Invalid(message).into())
+                    return Err(TransactionError::Invalid(message).into());
                 }
                 TxStatus::Dropped { message } => {
-                    return Err(TransactionError::Dropped(message).into())
+                    return Err(TransactionError::Dropped(message).into());
                 }
                 // Ignore and wait for next status event:
                 _ => continue,
@@ -321,11 +321,11 @@ mod test {
     use subxt_core::client::RuntimeVersion;
 
     use crate::{
+        Error, SubstrateConfig,
         backend::{StreamOfResults, TransactionStatus},
         client::{OfflineClientT, OnlineClientT},
         config::{Config, HashFor},
         tx::TxProgress,
-        Error, SubstrateConfig,
     };
 
     type MockTxProgress = TxProgress<SubstrateConfig, MockClient>;

--- a/subxt/src/utils/mod.rs
+++ b/subxt/src/utils/mod.rs
@@ -7,9 +7,9 @@
 use crate::macros::cfg_jsonrpsee;
 
 pub use subxt_core::utils::{
-    bits, strip_compact_prefix, to_hex, AccountId32, Encoded, Era, KeyedVec, MultiAddress,
-    MultiSignature, PhantomDataSendSync, Static, UncheckedExtrinsic, WrapperKeepOpaque, Yes, H160,
-    H256, H512,
+    AccountId32, Encoded, Era, H160, H256, H512, KeyedVec, MultiAddress, MultiSignature,
+    PhantomDataSendSync, Static, UncheckedExtrinsic, WrapperKeepOpaque, Yes, bits,
+    strip_compact_prefix, to_hex,
 };
 
 pub use subxt_rpcs::utils::url_is_secure;

--- a/subxt/src/view_functions/mod.rs
+++ b/subxt/src/view_functions/mod.rs
@@ -8,7 +8,7 @@ mod view_function_types;
 mod view_functions_client;
 
 pub use subxt_core::view_functions::payload::{
-    dynamic, DefaultPayload, DynamicPayload, Payload, StaticPayload,
+    DefaultPayload, DynamicPayload, Payload, StaticPayload, dynamic,
 };
 pub use view_function_types::ViewFunctionsApi;
 pub use view_functions_client::ViewFunctionsClient;

--- a/subxt/src/view_functions/view_function_types.rs
+++ b/subxt/src/view_functions/view_function_types.rs
@@ -48,7 +48,7 @@ where
     pub fn call<Call: Payload>(
         &self,
         payload: Call,
-    ) -> impl Future<Output = Result<Call::ReturnType, Error>> {
+    ) -> impl Future<Output = Result<Call::ReturnType, Error>> + use<Call, Client, T> {
         let client = self.client.clone();
         let block_hash = self.block_ref.hash();
         // Ensure that the returned future doesn't have a lifetime tied to api.view_functions(),

--- a/testing/generate-custom-metadata/src/dispatch_error.rs
+++ b/testing/generate-custom-metadata/src/dispatch_error.rs
@@ -3,8 +3,8 @@
 // see LICENSE for license details.
 
 use scale_info::{
-    build::{Fields, Variants},
     Path, Type, TypeInfo,
+    build::{Fields, Variants},
 };
 
 /// See the `ModuleErrorType` in `subxt_codegen` for more info on the different DispatchError

--- a/testing/generate-custom-metadata/src/lib.rs
+++ b/testing/generate-custom-metadata/src/lib.rs
@@ -3,12 +3,12 @@
 // see LICENSE for license details.
 
 use codec::Encode;
-use frame_metadata::v15::{CustomMetadata, ExtrinsicMetadata, OuterEnums, RuntimeMetadataV15};
 use frame_metadata::RuntimeMetadataPrefixed;
+use frame_metadata::v15::{CustomMetadata, ExtrinsicMetadata, OuterEnums, RuntimeMetadataV15};
 
-use scale_info::form::PortableForm;
 use scale_info::TypeInfo;
-use scale_info::{meta_type, IntoPortable};
+use scale_info::form::PortableForm;
+use scale_info::{IntoPortable, meta_type};
 use std::collections::BTreeMap;
 
 pub mod dispatch_error;

--- a/testing/integration-tests/src/full_client/blocks.rs
+++ b/testing/integration-tests/src/full_client/blocks.rs
@@ -12,8 +12,8 @@ use crate::utils::node_runtime;
 #[cfg(fullclient)]
 use subxt::{
     config::{
-        transaction_extensions::{ChargeAssetTxPayment, CheckMortality, CheckNonce},
         DefaultExtrinsicParamsBuilder, SubstrateConfig,
+        transaction_extensions::{ChargeAssetTxPayment, CheckMortality, CheckNonce},
     },
     utils::Era,
 };
@@ -213,15 +213,19 @@ async fn fetch_block_and_decode_extrinsic_details() {
     assert_eq!(extrinsics.block_hash(), block_hash);
 
     // `.has` should work and find a transfer call.
-    assert!(extrinsics
-        .has::<node_runtime::balances::calls::types::TransferAllowDeath>()
-        .unwrap());
+    assert!(
+        extrinsics
+            .has::<node_runtime::balances::calls::types::TransferAllowDeath>()
+            .unwrap()
+    );
 
     // `.find_first` should similarly work to find the transfer call:
-    assert!(extrinsics
-        .find_first::<node_runtime::balances::calls::types::TransferAllowDeath>()
-        .unwrap()
-        .is_some());
+    assert!(
+        extrinsics
+            .find_first::<node_runtime::balances::calls::types::TransferAllowDeath>()
+            .unwrap()
+            .is_some()
+    );
 
     let block_extrinsics = extrinsics.iter().collect::<Vec<_>>();
 

--- a/testing/integration-tests/src/full_client/client/archive_rpcs.rs
+++ b/testing/integration-tests/src/full_client/client/archive_rpcs.rs
@@ -7,7 +7,7 @@
 
 use crate::{
     subxt_test, test_context,
-    utils::{node_runtime, TestNodeProcess},
+    utils::{TestNodeProcess, node_runtime},
 };
 use codec::Encode;
 use futures::{Stream, StreamExt};
@@ -110,7 +110,9 @@ async fn archive_v1_finalized_height() {
         // if the height we fetch has grown by more than 1.
         if let Some(last) = last_block_height {
             if archive_block_height != last && archive_block_height != last + 1 {
-                panic!("Archive block height should increase 1 at a time, but jumped from {last} to {archive_block_height}");
+                panic!(
+                    "Archive block height should increase 1 at a time, but jumped from {last} to {archive_block_height}"
+                );
             }
         }
 

--- a/testing/integration-tests/src/full_client/client/mod.rs
+++ b/testing/integration-tests/src/full_client/client/mod.rs
@@ -40,7 +40,7 @@ async fn storage_fetch_raw_keys() {
         .fetch_raw_keys(addr.to_root_bytes())
         .await
         .unwrap()
-        .filter_map(|r| async move { r.ok() })
+        .filter_map(async |r| r.ok())
         .count()
         .await;
 
@@ -65,7 +65,7 @@ async fn storage_iter() {
         .iter(addr)
         .await
         .unwrap()
-        .filter_map(|r| async move { r.ok() })
+        .filter_map(async |r| r.ok())
         .count()
         .await;
 

--- a/testing/integration-tests/src/full_client/client/mod.rs
+++ b/testing/integration-tests/src/full_client/client/mod.rs
@@ -150,7 +150,7 @@ async fn transaction_validation() {
 #[subxt_test]
 async fn validation_fails() {
     use std::str::FromStr;
-    use subxt_signer::{sr25519::Keypair, SecretUri};
+    use subxt_signer::{SecretUri, sr25519::Keypair};
 
     let ctx = test_context().await;
     let api = ctx.client();

--- a/testing/integration-tests/src/full_client/codegen/documentation.rs
+++ b/testing/integration-tests/src/full_client/codegen/documentation.rs
@@ -4,7 +4,7 @@
 
 use codec::Decode;
 use regex::Regex;
-use subxt_codegen::{syn, CodegenBuilder};
+use subxt_codegen::{CodegenBuilder, syn};
 use subxt_metadata::Metadata;
 
 fn load_test_metadata() -> Metadata {

--- a/testing/integration-tests/src/full_client/frame/contracts.rs
+++ b/testing/integration-tests/src/full_client/frame/contracts.rs
@@ -3,20 +3,21 @@
 // see LICENSE for license details.
 
 use crate::{
+    TestClient, TestConfig, TestContext,
     node_runtime::{
         self,
         contracts::events,
         runtime_types::{pallet_contracts::wasm::Determinism, sp_weights::weight_v2::Weight},
         system,
     },
-    subxt_test, test_context, TestClient, TestConfig, TestContext,
+    subxt_test, test_context,
 };
 use subxt::ext::futures::StreamExt;
 use subxt::{
+    Error,
     config::{Config, HashFor},
     tx::TxProgress,
     utils::MultiAddress,
-    Error,
 };
 use subxt_signer::sr25519::{self, dev};
 

--- a/testing/integration-tests/src/full_client/frame/staking.rs
+++ b/testing/integration-tests/src/full_client/frame/staking.rs
@@ -16,8 +16,8 @@ use crate::{
 use assert_matches::assert_matches;
 use subxt::error::{DispatchError, Error};
 use subxt_signer::{
-    sr25519::{self, dev},
     SecretUri,
+    sr25519::{self, dev},
 };
 
 /// Helper function to generate a crypto pair from seed

--- a/testing/integration-tests/src/full_client/metadata_validation.rs
+++ b/testing/integration-tests/src/full_client/metadata_validation.rs
@@ -2,19 +2,20 @@
 // This file is dual-licensed as Apache-2.0 or GPL-3.0.
 // see LICENSE for license details.
 
-use crate::{node_runtime, subxt_test, test_context, TestContext};
+use crate::{TestContext, node_runtime, subxt_test, test_context};
 use codec::Decode;
 use frame_metadata::{
+    RuntimeMetadata, RuntimeMetadataPrefixed,
     v15::{
         CustomMetadata, ExtrinsicMetadata, OuterEnums, PalletCallMetadata, PalletMetadata,
         PalletStorageMetadata, RuntimeMetadataV15, StorageEntryMetadata, StorageEntryModifier,
         StorageEntryType,
     },
-    RuntimeMetadata, RuntimeMetadataPrefixed,
 };
 use scale_info::{
+    Path, Type, TypeInfo,
     build::{Fields, Variants},
-    meta_type, Path, Type, TypeInfo,
+    meta_type,
 };
 use subxt::{Metadata, OfflineClient, OnlineClient, SubstrateConfig};
 
@@ -147,10 +148,12 @@ async fn constant_values_are_not_validated() {
     let deposit_addr = node_runtime::constants().balances().existential_deposit();
 
     // Retrieve existential deposit to validate it and confirm that it's OK.
-    assert!(api_from_original_metadata
-        .constants()
-        .at(&deposit_addr)
-        .is_ok());
+    assert!(
+        api_from_original_metadata
+            .constants()
+            .at(&deposit_addr)
+            .is_ok()
+    );
 
     // Modify the metadata.
     let existential = v15_metadata
@@ -175,10 +178,12 @@ async fn constant_values_are_not_validated() {
     assert!(node_runtime::is_codegen_valid_for(
         &api_from_modified_metadata.metadata()
     ));
-    assert!(api_from_modified_metadata
-        .constants()
-        .at(&deposit_addr)
-        .is_ok());
+    assert!(
+        api_from_modified_metadata
+            .constants()
+            .at(&deposit_addr)
+            .is_ok()
+    );
 }
 
 #[subxt_test]

--- a/testing/integration-tests/src/utils/context.rs
+++ b/testing/integration-tests/src/utils/context.rs
@@ -4,8 +4,8 @@
 
 pub(crate) use crate::{node_runtime, utils::TestNodeProcess};
 
-use subxt::client::OnlineClient;
 use subxt::SubstrateConfig;
+use subxt::client::OnlineClient;
 
 use super::node_proc::RpcClientKind;
 

--- a/testing/integration-tests/src/utils/node_proc.rs
+++ b/testing/integration-tests/src/utils/node_proc.rs
@@ -9,8 +9,8 @@ use std::time::Duration;
 use substrate_runner::SubstrateNode;
 use subxt::backend::rpc::reconnecting_rpc_client::{ExponentialBackoff, RpcClientBuilder};
 use subxt::{
-    backend::{chain_head, legacy, rpc},
     Config, OnlineClient,
+    backend::{chain_head, legacy, rpc},
 };
 
 // The URL that we'll connect to for our tests comes from SUBXT_TEXT_HOST env var,
@@ -62,7 +62,7 @@ where
 
     pub async fn restart(mut self) -> Self {
         tokio::task::spawn_blocking(move || {
-            if let Some(ref mut proc) = &mut self.proc {
+            if let Some(proc) = &mut self.proc {
                 proc.restart().unwrap();
             }
             self

--- a/testing/integration-tests/src/utils/wait_for_blocks.rs
+++ b/testing/integration-tests/src/utils/wait_for_blocks.rs
@@ -3,8 +3,8 @@
 // see LICENSE for license details.
 
 use subxt::{
-    backend::StreamOf, blocks::Block, client::OnlineClientT, Config, Error, OnlineClient,
-    SubstrateConfig,
+    Config, Error, OnlineClient, SubstrateConfig, backend::StreamOf, blocks::Block,
+    client::OnlineClientT,
 };
 
 /// Wait for blocks to be produced before running tests. Specifically, we
@@ -34,7 +34,7 @@ pub async fn wait_for_number_of_blocks<C: Config>(
 pub async fn consume_initial_blocks(
     blocks: &mut StreamOf<Result<Block<SubstrateConfig, OnlineClient<SubstrateConfig>>, Error>>,
 ) {
-    use tokio::time::{interval_at, Duration, Instant};
+    use tokio::time::{Duration, Instant, interval_at};
     const MAX_DURATION: Duration = Duration::from_millis(200);
 
     let mut now = interval_at(Instant::now() + MAX_DURATION, MAX_DURATION);

--- a/testing/integration-tests/subxt-test-macro/src/lib.rs
+++ b/testing/integration-tests/subxt-test-macro/src/lib.rs
@@ -7,8 +7,8 @@ use proc_macro::TokenStream;
 
 use quote::{format_ident, quote};
 use syn::{
-    parse::{Parse, ParseStream},
     Error,
+    parse::{Parse, ParseStream},
 };
 
 /// Environment variable for setting the timeout for the test.

--- a/utils/fetch-metadata/src/error.rs
+++ b/utils/fetch-metadata/src/error.rs
@@ -17,7 +17,9 @@ pub enum Error {
     #[error("Request error: {0}")]
     RequestError(#[from] jsonrpsee::core::ClientError),
     /// Failed IO when fetching from a file.
-    #[error("Failed IO for {0}, make sure that you are providing the correct file path for metadata: {1}")]
+    #[error(
+        "Failed IO for {0}, make sure that you are providing the correct file path for metadata: {1}"
+    )]
     Io(String, std::io::Error),
     /// URL scheme is not http, https, ws or wss.
     #[error("'{0}' not supported, supported URI schemes are http, https, ws or wss.")]


### PR DESCRIPTION
I went round all uses of `impl Trait` that I could find, added appropriate `+ use<..>` syntax for them, ran a cargo fmt, removed uses of `ref` and converted some closures returning async blocks into async closures.