### PR TITLE
Update native test timeout to 45 mins

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -286,7 +286,7 @@ jobs:
     name: "Test (Native)"
     runs-on: parity-large
     needs: [clippy, wasm_clippy, check, wasm_check, docs]
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4


### PR DESCRIPTION
The native tests are starting to be cancelled a bunch, causing CI failures. Increasing the timeout to give it some leeway.