### PR TITLE
If only one hasher, always treat any key as a single and not NMap key, even if it's a tuple.

### DIFF
--- a/testing/integration-tests/src/full_client/storage.rs
+++ b/testing/integration-tests/src/full_client/storage.rs
@@ -72,7 +72,7 @@ async fn storage_n_mapish_key_is_properly_created() -> Result<(), subxt::Error> 
     // This is what the generated code hashes a `session().key_owner(..)` key into:
     let actual_key = node_runtime::storage()
         .session()
-        .key_owner(KeyTypeId([1, 2, 3, 4]), vec![5, 6, 7, 8]);
+        .key_owner((KeyTypeId([1, 2, 3, 4]), vec![5, 6, 7, 8]));
     let actual_key_bytes = api.storage().address_bytes(&actual_key)?;
 
     // Let's manually hash to what we assume it should be and compare:

--- a/testing/integration-tests/src/full_client/storage.rs
+++ b/testing/integration-tests/src/full_client/storage.rs
@@ -80,13 +80,12 @@ async fn storage_n_mapish_key_is_properly_created() -> Result<(), subxt::Error> 
         // Hash the prefix to the storage entry:
         let mut bytes = sp_core::twox_128("Session".as_bytes()).to_vec();
         bytes.extend(&sp_core::twox_128("KeyOwner".as_bytes())[..]);
-        // Both keys, use twox64_concat hashers:
-        let key1 = [1u8, 2, 3, 4].encode();
-        let key2 = vec![5u8, 6, 7, 8].encode();
-        bytes.extend(sp_core::twox_64(&key1));
-        bytes.extend(&key1);
-        bytes.extend(sp_core::twox_64(&key2));
-        bytes.extend(&key2);
+        // Key is a tuple of 2 args, so encode each arg and then hash the concatenation:
+        let mut key_bytes = vec![];
+        [1u8, 2, 3, 4].encode_to(&mut key_bytes);
+        vec![5u8, 6, 7, 8].encode_to(&mut key_bytes);
+        bytes.extend(sp_core::twox_64(&key_bytes));
+        bytes.extend(&key_bytes);
         bytes
     };
 


### PR DESCRIPTION
Before this change, if we saw that a storage key was a tuple in the metadata, we'd treat the storage entry like a `StorageNMap`, allowing iterating over subsets of the tuple and assuming that each element was individually hashed. But, in the case where there is one hasher for the entire key, this is incorrect.

Now, a tuple type is treated as any other type is when there is a single hasher, and if there are multiple hashers then we expect a tuple with a matching number of fields, ie one type per hasher. Only these can be iterated at any level.

Hopefully closes [#1928](https://github.com/paritytech/subxt/issues/1928).