### PR TITLE
De-dup types early to enable derives for them

### DIFF
--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -102,7 +102,7 @@ fn subxt_inner(args: TokenStream, item_mod: syn::ItemMod) -> Result<TokenStream,
         .map_err(|e| TokenStream::from(e.write_errors()))?;
 
     // Fetch metadata first, because we need it to validate some of the chosen codegen options.
-    let metadata = fetch_metadata(&args)?;
+    let mut metadata = fetch_metadata(&args)?;
 
     let mut codegen = CodegenBuilder::new();
 
@@ -135,6 +135,10 @@ fn subxt_inner(args: TokenStream, item_mod: syn::ItemMod) -> Result<TokenStream,
             .into_iter()
             .collect(),
     );
+
+    // De-dup early so de-duped types can be provided with derives (see #2011)
+    scale_typegen::utils::ensure_unique_type_paths(metadata.types_mut())
+        .expect("Duplicate type paths in metadata; this is bug please file an issue.");
     for d in args.derive_for_type {
         validate_type_path(&d.path.path, &metadata);
         codegen.add_derives_for_type(d.path, d.derive.into_iter(), d.recursive);


### PR DESCRIPTION
This seems to do the trick for #2011 though it is a dirty-ish fix.

A better one would involve something like:
* `ensure_unique_type_paths` returning the de-duped types 
* said types kept by the `RuntimeGenerator`
* `DeriveRegistry` gets manipulated to replace the non-de-duped types with the de-duped ones

If you would be so kind, I'd appreciate a backport of this fix to version 0.40, I can help if needed