### PR TITLE
De-dup types early in CLI/macro so that derives/substitutes work for de-duped types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5602,6 +5602,7 @@ dependencies = [
  "pretty_assertions",
  "quote",
  "scale-info",
+ "scale-typegen",
  "scale-typegen-description",
  "scale-value",
  "serde",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -27,6 +27,7 @@ chain-spec-pruning = ["smoldot"]
 
 [dependencies]
 subxt-codegen = { workspace = true }
+scale-typegen = { workspace = true }
 subxt-utils-fetchmetadata = { workspace = true, features = ["url"] }
 subxt-utils-stripmetadata = { workspace = true }
 subxt-metadata = { workspace = true }

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -102,7 +102,7 @@ fn subxt_inner(args: TokenStream, item_mod: syn::ItemMod) -> Result<TokenStream,
         .map_err(|e| TokenStream::from(e.write_errors()))?;
 
     // Fetch metadata first, because we need it to validate some of the chosen codegen options.
-    let metadata = fetch_metadata(&args)?;
+    let mut metadata = fetch_metadata(&args)?;
 
     let mut codegen = CodegenBuilder::new();
 
@@ -135,6 +135,10 @@ fn subxt_inner(args: TokenStream, item_mod: syn::ItemMod) -> Result<TokenStream,
             .into_iter()
             .collect(),
     );
+
+    // De-dup early so de-duped types can be provided with derives (see #2011)
+    scale_typegen::utils::ensure_unique_type_paths(metadata.types_mut())
+        .expect("Duplicate type paths in metadata; this is bug please file an issue.");
     for d in args.derive_for_type {
         validate_type_path(&d.path.path, &metadata);
         codegen.add_derives_for_type(d.path, d.derive.into_iter(), d.recursive);

--- a/testing/ui-tests/src/incorrect/substitute_at_wrong_path.stderr
+++ b/testing/ui-tests/src/incorrect/substitute_at_wrong_path.stderr
@@ -11,9 +11,7 @@ error: Type `Event` does not exist at path `sp_runtime::multiaddress::Event`
        pallet_grandpa::pallet::Event
        pallet_treasury::pallet::Event
        pallet_conviction_voting::pallet::Event
-       pallet_referenda::pallet::Event
        pallet_ranked_collective::pallet::Event
-       pallet_referenda::pallet::Event
        pallet_whitelist::pallet::Event
        polkadot_runtime_common::claims::pallet::Event
        pallet_utility::pallet::Event


### PR DESCRIPTION
Building on @jmg-duarte's #2014 to also add de-duping in CLI codegen.

Ultimately we should tidy this a bit so that we only run the `ensure_unique_type_paths` function once, but this will do for now!