### PR TITLE
Run CI on v0.N.x branches or PRs to them for ease of backporting

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,11 +6,16 @@ on:
     # master or release-like branches:
     branches:
       - master
+      # If we want to backport changes to an old release, push a branch
+      # eg v0.40.x and CI will run on it. PRs merging to such branches 
+      # will also trigger CI.
+      - v0.[0-9]+.x
   pull_request:
     # Run jobs for any external PR that wants
     # to merge to master, too:
     branches:
       - master
+      - v0.[0-9]+.x
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}


### PR DESCRIPTION
For instance, to backport some fixes to 0.40 branch (which hasn't had any to date, we would:

- `git checkout v0.40.0`
- `git checkout -b v0.40.x`
- `git cherry-pick $commitHash`
- `git push --set-upstream v0.40.x`

CI would then run on this branch in Github, and PRs with a base set to v0.40.x would be checked in CI so that we can ensure backports are passing.

I'll cherry-pick this PR to backport chanegs to versions before it to get CI running for versions we're pushing backports too (`git cherry-pick 05339a180eb6a05ffe5dda8d83ab0a9651961ae1` to take this change to an old version)