### PR TITLE
chore: remove redundant backtick in comment

### DIFF
--- a/subxt/src/book/setup/config.rs
+++ b/subxt/src/book/setup/config.rs
@@ -144,7 +144,7 @@
 //!
 //! ### Implementing [`crate::config::ExtrinsicParams`] from scratch
 //!
-//! Alternately, you are free to implement [`crate::config::ExtrinsicParams`] entirely from scratch if you know exactly what "extra" and`
+//! Alternately, you are free to implement [`crate::config::ExtrinsicParams`] entirely from scratch if you know exactly what "extra" and
 //! "additional" data your node needs and would prefer to craft your own interface.
 //!
 //! Let's see what this looks like (this config won't work on any real node):


### PR DESCRIPTION
remove redundant backtick in comment