### PR TITLE
Keep codec attrs even when Encode/Decode not used

### DIFF
--- a/testing/substrate-runner/src/lib.rs
+++ b/testing/substrate-runner/src/lib.rs
@@ -301,8 +301,7 @@ fn try_find_substrate_port_from_output(r: impl Read + Send + 'static) -> Substra
                 // `start tcp transport listen_addresses=["/ip6/::/tcp/30333", "/ip4/0.0.0.0/tcp/30333"]`
                 // we'll split once to find the line itself and then again to find the ipv4 port.
                 line.rsplit_once("start tcp transport listen_addresses=")
-                    .map(|(_, after)| after.split_once("/ip4/0.0.0.0/tcp/"))
-                    .flatten()
+                    .and_then(|(_, after)| after.split_once("/ip4/0.0.0.0/tcp/"))
             })
             .map(|(_, address_str)| address_str);
 


### PR DESCRIPTION
`scale-typegen` inserts some `__ignore` fields when it needs to represent some generic type that isn't used in a field, so that it can add a `PhantomData<T>` to make this valid.

Perhaps (probably, I think) wrongly, `scale-typegen` only adds `#[codec(skip)]` if `insert_codec_attributes: true`. So, let's just always set this to true for now to avoid issues decoding things into structs with `__ignore` fields. This also adds `#[codec(index = N)]` attrs, but these are harmless anyway.

The failing example in #2021 no longer fails with this change.

Closes #2021 