### PR TITLE
Address some issues around tx mortality

### DIFF
--- a/core/src/config/default_extrinsic_params.rs
+++ b/core/src/config/default_extrinsic_params.rs
@@ -57,6 +57,13 @@ impl<T: Config> DefaultExtrinsicParamsBuilder<T> {
         Default::default()
     }
 
+    /// Make the transaction immortal, meaning it will never expire. This means that it could, in
+    /// theory, be pending for a long time and only be included many blocks into the future.
+    pub fn immortal(mut self) -> Self {
+        self.mortality = transaction_extensions::CheckMortalityParams::immortal();
+        self
+    }
+
     /// Make the transaction mortal, given a number of blocks it will be mortal for from
     /// the current block at the time of submission.
     ///

--- a/core/src/config/default_extrinsic_params.rs
+++ b/core/src/config/default_extrinsic_params.rs
@@ -2,7 +2,9 @@
 // This file is dual-licensed as Apache-2.0 or GPL-3.0.
 // see LICENSE for license details.
 
-use super::Config;
+use crate::config::transaction_extensions::CheckMortalityParams;
+
+use super::{Config, HashFor};
 use super::{ExtrinsicParams, transaction_extensions};
 
 /// The default [`super::ExtrinsicParams`] implementation understands common signed extensions
@@ -26,8 +28,8 @@ pub type DefaultExtrinsicParams<T> = transaction_extensions::AnyOf<
 /// [`DefaultExtrinsicParams`]. This may expose methods that aren't applicable to the current
 /// chain; such values will simply be ignored if so.
 pub struct DefaultExtrinsicParamsBuilder<T: Config> {
-    /// `None` means the tx will be immortal, else it's mortal for N blocks (if possible).
-    mortality: Option<u64>,
+    /// `None` means the tx will be immortal, else it's mortality is described.
+    mortality: transaction_extensions::CheckMortalityParams<T>,
     /// `None` means the nonce will be automatically set.
     nonce: Option<u64>,
     /// `None` means we'll use the native token.
@@ -39,7 +41,7 @@ pub struct DefaultExtrinsicParamsBuilder<T: Config> {
 impl<T: Config> Default for DefaultExtrinsicParamsBuilder<T> {
     fn default() -> Self {
         Self {
-            mortality: None,
+            mortality: CheckMortalityParams::default(),
             tip: 0,
             tip_of: 0,
             tip_of_asset_id: None,
@@ -57,8 +59,34 @@ impl<T: Config> DefaultExtrinsicParamsBuilder<T> {
 
     /// Make the transaction mortal, given a number of blocks it will be mortal for from
     /// the current block at the time of submission.
+    ///
+    /// # Warning
+    ///
+    /// This will ultimately return an error if used for creating extrinsic offline, because we need
+    /// additional information in order to set the mortality properly.
+    ///
+    /// When creating offline transactions, you must use [`Self::mortal_from_unchecked`] instead to set
+    /// the mortality. This provides all of the necessary information which we must otherwise be online
+    /// in order to obtain.
     pub fn mortal(mut self, for_n_blocks: u64) -> Self {
-        self.mortality = Some(for_n_blocks);
+        self.mortality = transaction_extensions::CheckMortalityParams::mortal(for_n_blocks);
+        self
+    }
+
+    /// Configure a transaction that will be mortal for the number of blocks given, and from the
+    /// block details provided. Prefer to use [`Self::mortal()`] where possible, which prevents
+    /// the block number and hash from being misaligned.
+    pub fn mortal_from_unchecked(
+        mut self,
+        for_n_blocks: u64,
+        from_block_n: u64,
+        from_block_hash: HashFor<T>,
+    ) -> Self {
+        self.mortality = transaction_extensions::CheckMortalityParams::mortal_from_unchecked(
+            for_n_blocks,
+            from_block_n,
+            from_block_hash,
+        );
         self
     }
 
@@ -88,11 +116,7 @@ impl<T: Config> DefaultExtrinsicParamsBuilder<T> {
 
     /// Build the extrinsic parameters.
     pub fn build(self) -> <DefaultExtrinsicParams<T> as ExtrinsicParams<T>>::Params {
-        let check_mortality_params = if let Some(for_n_blocks) = self.mortality {
-            transaction_extensions::CheckMortalityParams::mortal(for_n_blocks)
-        } else {
-            transaction_extensions::CheckMortalityParams::immortal()
-        };
+        let check_mortality_params = self.mortality;
 
         let charge_asset_tx_params = if let Some(asset_id) = self.tip_of_asset_id {
             transaction_extensions::ChargeAssetTxPaymentParams::tip_of(self.tip, asset_id)

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -208,29 +208,20 @@ pub enum ExtrinsicParamsError {
     UnknownTransactionExtension(String),
     /// Some custom error.
     #[error("Error constructing extrinsic parameters: {0}")]
-    Custom(Box<dyn CustomError>),
+    Custom(Box<dyn core::error::Error + Send + Sync + 'static>),
 }
 
-/// Anything implementing this trait can be used in [`ExtrinsicParamsError::Custom`].
-#[cfg(feature = "std")]
-pub trait CustomError: std::error::Error + Send + Sync + 'static {}
-#[cfg(feature = "std")]
-impl<T: std::error::Error + Send + Sync + 'static> CustomError for T {}
-
-/// Anything implementing this trait can be used in [`ExtrinsicParamsError::Custom`].
-#[cfg(not(feature = "std"))]
-pub trait CustomError: core::fmt::Debug + core::fmt::Display + Send + Sync + 'static {}
-#[cfg(not(feature = "std"))]
-impl<T: core::fmt::Debug + core::fmt::Display + Send + Sync + 'static> CustomError for T {}
+impl ExtrinsicParamsError {
+    /// Create a custom [`ExtrinsicParamsError`] from a string.
+    pub fn custom<S: Into<String>>(error: S) -> Self {
+        let error: String = error.into();
+        let error: Box<dyn core::error::Error + Send + Sync + 'static> = Box::from(error);
+        ExtrinsicParamsError::Custom(error)
+    }
+}
 
 impl From<core::convert::Infallible> for ExtrinsicParamsError {
     fn from(value: core::convert::Infallible) -> Self {
         match value {}
-    }
-}
-
-impl From<Box<dyn CustomError>> for ExtrinsicParamsError {
-    fn from(value: Box<dyn CustomError>) -> Self {
-        ExtrinsicParamsError::Custom(value)
     }
 }

--- a/core/src/utils/era.rs
+++ b/core/src/utils/era.rs
@@ -2,7 +2,12 @@
 // This file is dual-licensed as Apache-2.0 or GPL-3.0.
 // see LICENSE for license details.
 
-use scale_decode::DecodeAsType;
+use codec::{Decode, Encode};
+use scale_decode::{
+    IntoVisitor, TypeResolver, Visitor,
+    ext::scale_type_resolver,
+    visitor::{TypeIdFor, types::Variant},
+};
 use scale_encode::EncodeAsType;
 
 // Dev note: This and related bits taken from `sp_runtime::generic::Era`
@@ -16,8 +21,6 @@ use scale_encode::EncodeAsType;
     Debug,
     serde::Serialize,
     serde::Deserialize,
-    DecodeAsType,
-    EncodeAsType,
     scale_info::TypeInfo,
 )]
 pub enum Era {
@@ -103,5 +106,108 @@ impl codec::Decode for Era {
                 Err("Invalid period and phase".into())
             }
         }
+    }
+}
+
+/// Define manually how to encode an Era given some type information. Here we
+/// basically check that the type we're targeting is called "Era" and then codec::Encode.
+impl EncodeAsType for Era {
+    fn encode_as_type_to<R: TypeResolver>(
+        &self,
+        type_id: R::TypeId,
+        types: &R,
+        out: &mut Vec<u8>,
+    ) -> Result<(), scale_encode::Error> {
+        // Visit the type to check that it is an Era. This is only a rough check.
+        let visitor = scale_type_resolver::visitor::new((), |_, _| false)
+            .visit_variant(|_, path, _variants| path.last().map_or(false, |name| name == "Era"));
+
+        let is_era = types
+            .resolve_type(type_id.clone(), visitor)
+            .unwrap_or_default();
+        if !is_era {
+            return Err(scale_encode::Error::custom_string(format!(
+                "Type {type_id:?} is not a valid Era type; expecting either Immortal or MortalX variant"
+            )));
+        }
+
+        // if the type looks valid then just scale encode our Era.
+        self.encode_to(out);
+        Ok(())
+    }
+}
+
+/// Define manually how to decode an Era given some type information. Here we check that the
+/// variant we're decoding is one of the expected Era variants, and that the field is correct if so,
+/// ensuring that this will fail if trying to decode something that isn't an Era.
+pub struct EraVisitor<R>(core::marker::PhantomData<R>);
+
+impl IntoVisitor for Era {
+    type AnyVisitor<R: TypeResolver> = EraVisitor<R>;
+    fn into_visitor<R: TypeResolver>() -> Self::AnyVisitor<R> {
+        EraVisitor(core::marker::PhantomData)
+    }
+}
+
+impl<R: TypeResolver> Visitor for EraVisitor<R> {
+    type Value<'scale, 'resolver> = Era;
+    type Error = scale_decode::Error;
+    type TypeResolver = R;
+
+    fn visit_variant<'scale, 'resolver>(
+        self,
+        value: &mut Variant<'scale, 'resolver, Self::TypeResolver>,
+        _type_id: TypeIdFor<Self>,
+    ) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
+        let variant = value.name();
+
+        // If the variant is immortal, we know the outcome.
+        if variant == "Immortal" {
+            return Ok(Era::Immortal);
+        }
+
+        // Otherwise, we expect a variant Mortal1..Mortal255 where the number
+        // here is the first byte, and the second byte is conceptually a field of this variant.
+        // This weird encoding is because the Era is compressed to just 1 byte if immortal and
+        // just 2 bytes if mortal.
+        //
+        // Note: We _could_ just assume we'll have 2 bytes to work with and decode the era directly,
+        // but checking the variant names ensures that the thing we think is an Era actually _is_
+        // one, based on the type info for it.
+        let first_byte = variant
+            .strip_prefix("Mortal")
+            .and_then(|s| s.parse::<u8>().ok())
+            .ok_or_else(|| {
+                scale_decode::Error::custom_string(format!(
+                    "Expected MortalX variant, but got {variant}"
+                ))
+            })?;
+
+        // We need 1 field in the MortalN variant containing the second byte.
+        let mortal_fields = value.fields();
+        if mortal_fields.remaining() != 1 {
+            return Err(scale_decode::Error::custom_string(format!(
+                "Expected Mortal{} to have one u8 field, but got {} fields",
+                first_byte,
+                mortal_fields.remaining()
+            )));
+        }
+
+        let second_byte = mortal_fields
+            .decode_item(u8::into_visitor())
+            .expect("At least one field should exist; checked above.")
+            .map_err(|e| {
+                scale_decode::Error::custom_string(format!(
+                    "Expected mortal variant field to be u8, but: {e}"
+                ))
+            })?;
+
+        // Now that we have both bytes we can decode them into the era using
+        // the same logic as the codec::Decode impl does.
+        Era::decode(&mut &[first_byte, second_byte][..]).map_err(|e| {
+            scale_decode::Error::custom_string(format!(
+                "Failed to codec::Decode Era from Mortal bytes: {e}"
+            ))
+        })
     }
 }

--- a/core/src/utils/era.rs
+++ b/core/src/utils/era.rs
@@ -155,8 +155,9 @@ impl<R: TypeResolver> Visitor for EraVisitor<R> {
     type Error = scale_decode::Error;
     type TypeResolver = R;
 
-    // Unwrap any newtype wrappers around the era, eg the CheckMortality extension.
-    // This allows us to decode directly from CheckMortality into Era.
+    // Unwrap any newtype wrappers around the era, eg the CheckMortality extension (which actually
+    // has 2 fields, but scale_info seems to autoamtically ignore the PhantomData field). This
+    // allows us to decode directly from CheckMortality into Era.
     fn visit_composite<'scale, 'resolver>(
         self,
         value: &mut Composite<'scale, 'resolver, Self::TypeResolver>,

--- a/core/src/utils/era.rs
+++ b/core/src/utils/era.rs
@@ -7,7 +7,7 @@ use codec::{Decode, Encode};
 use scale_decode::{
     IntoVisitor, TypeResolver, Visitor,
     ext::scale_type_resolver,
-    visitor::{TypeIdFor, types::Variant, types::Composite},
+    visitor::{TypeIdFor, types::Composite, types::Variant},
 };
 use scale_encode::EncodeAsType;
 
@@ -170,7 +170,9 @@ impl<R: TypeResolver> Visitor for EraVisitor<R> {
             )));
         }
 
-        value.decode_item(self).expect("1 field expected; checked above.")
+        value
+            .decode_item(self)
+            .expect("1 field expected; checked above.")
     }
 
     fn visit_variant<'scale, 'resolver>(

--- a/core/src/utils/era.rs
+++ b/core/src/utils/era.rs
@@ -120,7 +120,7 @@ impl EncodeAsType for Era {
     ) -> Result<(), scale_encode::Error> {
         // Visit the type to check that it is an Era. This is only a rough check.
         let visitor = scale_type_resolver::visitor::new((), |_, _| false)
-            .visit_variant(|_, path, _variants| path.last().map_or(false, |name| name == "Era"));
+            .visit_variant(|_, path, _variants| path.last() == Some("Era"));
 
         let is_era = types
             .resolve_type(type_id.clone(), visitor)

--- a/core/src/utils/era.rs
+++ b/core/src/utils/era.rs
@@ -2,6 +2,7 @@
 // This file is dual-licensed as Apache-2.0 or GPL-3.0.
 // see LICENSE for license details.
 
+use alloc::{format, vec::Vec};
 use codec::{Decode, Encode};
 use scale_decode::{
     IntoVisitor, TypeResolver, Visitor,

--- a/testing/integration-tests/src/full_client/blocks.rs
+++ b/testing/integration-tests/src/full_client/blocks.rs
@@ -375,6 +375,6 @@ async fn decode_transaction_extensions_from_blocks() {
             .find::<CheckMortality<SubstrateConfig>>()
             .unwrap()
             .unwrap();
-        assert_eq!(era, Era::Immortal)
+        assert!(matches!(era, Era::Mortal { .. }));
     }
 }


### PR DESCRIPTION
- Make it a runtime error if you explicitly set an extrinsic to be `.mortal(..)` when providing params to it, but then are constructing it offline which prevents this from working. Previously we'd turn the extrinsic into an immortal one.
- Expose `mortal_from_unchecked` in the `DefaultExtrinsicParamsBuilder` to make it a little more ergonomic to set the relevant mortality params when constructing eg an offline extrinsic. Previously You'd have to do:

   ```rust
   let params = DefaultExtrinsicParamsBuilder::new();
   params.5 = CheckMortalityParams::mortal_from_unchecked(for_n_blocks, from_block_n, from_block_hash);
   ```

- Clarify the docs on these functions to make it clear that you can't use `mortal()` with offline extrinsics.
- Actually construct mortal transactions by default. I think this was the intended behaviour, but it may have been accidentally broken because the default Params actually led to immortal transactions. 
- This led to uncovering an issue decoding Eras, and so now there is a proper implementation of EncodeAsType and DecodeAsType for it.

Closes #2024 