### PR TITLE
docs: fix typos in comment

### DIFF
--- a/core/src/utils/era.rs
+++ b/core/src/utils/era.rs
@@ -156,7 +156,7 @@ impl<R: TypeResolver> Visitor for EraVisitor<R> {
     type TypeResolver = R;
 
     // Unwrap any newtype wrappers around the era, eg the CheckMortality extension (which actually
-    // has 2 fields, but scale_info seems to autoamtically ignore the PhantomData field). This
+    // has 2 fields, but scale_info seems to automatically ignore the PhantomData field). This
     // allows us to decode directly from CheckMortality into Era.
     fn visit_composite<'scale, 'resolver>(
         self,

--- a/lightclient/src/lib.rs
+++ b/lightclient/src/lib.rs
@@ -189,7 +189,7 @@ pub struct LightClientRpc {
 }
 
 impl LightClientRpc {
-    // Dev note: this would provide a "low leveL" interface if one is needed.
+    // Dev note: this would provide a "low level" interface if one is needed.
     // Do we actually need to provide this, or can we entirely hide Smoldot?
     pub(crate) fn new_raw<TPlat, TChain>(
         client: impl Into<SharedClient<TPlat, TChain>>,

--- a/rpcs/src/client/mock_rpc_client.rs
+++ b/rpcs/src/client/mock_rpc_client.rs
@@ -232,7 +232,7 @@ impl RpcClientT for MockRpcClient {
         }
         drop(handlers_once);
 
-        // Call a specific handler for the subscrpition if one is found.
+        // Call a specific handler for the subscriptions if one is found.
         let mut handlers = self.subscription_handlers.lock().unwrap();
         if let Some(handler) = handlers.get_mut(sub) {
             return handler(sub, params, unsub)

--- a/subxt/src/backend/mod.rs
+++ b/subxt/src/backend/mod.rs
@@ -945,7 +945,7 @@ mod test {
                     Err::<Infallible, _>(disconnected_will_reconnect())
                 })
                 .method_handler_once("chainHead_v1_continue", async move |_params| {
-                    // Next call; acknowledge the "continue" and return reamining storage items.
+                    // Next call; acknowledge the "continue" and return remaining storage items.
                     tokio::spawn(async move {
                         tx2.send(storage_items("Id1", &[storage_result("ID2", "Data2")]))
                             .unwrap();
@@ -959,7 +959,7 @@ mod test {
 
             let backend = build_backend_spawn_background(rpc_client);
 
-            // We should succees, transparently handling `continue`s and `DisconnectWillReconnects`.
+            // We should success, transparently handling `continue`s and `DisconnectWillReconnects`.
             let response = backend
                 .storage_fetch_values(
                     ["ID1".into(), "ID2".into(), "ID3".into()].into(),


### PR DESCRIPTION
### Description

This PR corrects several minor typos in comments and documentation across the codebase. The changes are non-functional and purely textual to improve clarity and maintain a clean, professional codebase.

### Details

- Corrected misspellings such as:
  - `autoamtically` → `automatically`
  - `succes` → `success`
  - `subscripstion` → `subscriptions`
  - `reamining` → `remaining`
  - `leveL` → `level`

These fixes help enhance readability and eliminate minor distractions during development and code reviews.

### Additional Info

No logic or functionality has been modified. All changes are restricted to comments or non-executable doc annotations.