### PR TITLE
Improve docs for `at_latest`

### DIFF
--- a/subxt/src/blocks/blocks_client.rs
+++ b/subxt/src/blocks/blocks_client.rs
@@ -53,7 +53,7 @@ where
         self.at_or_latest(Some(block_ref.into()))
     }
 
-    /// Obtain block details of the latest block hash.
+    /// Obtain block details of the latest finalized block.
     pub fn at_latest(
         &self,
     ) -> impl Future<Output = Result<Block<T, Client>, Error>> + Send + 'static {

--- a/subxt/src/events/events_client.rs
+++ b/subxt/src/events/events_client.rs
@@ -48,7 +48,7 @@ where
         self.at_or_latest(Some(block_ref.into()))
     }
 
-    /// Obtain events for the latest block.
+    /// Obtain events for the latest finalized block.
     pub fn at_latest(&self) -> impl Future<Output = Result<Events<T>, Error>> + Send + 'static {
         self.at_or_latest(None)
     }

--- a/subxt/src/runtime_api/runtime_client.rs
+++ b/subxt/src/runtime_api/runtime_client.rs
@@ -40,7 +40,7 @@ where
         RuntimeApi::new(self.client.clone(), block_ref.into())
     }
 
-    /// Obtain a runtime API interface at the latest block hash.
+    /// Obtain a runtime API interface at the latest finalized block.
     pub fn at_latest(
         &self,
     ) -> impl Future<Output = Result<RuntimeApi<T, Client>, Error>> + Send + 'static {

--- a/subxt/src/storage/storage_client.rs
+++ b/subxt/src/storage/storage_client.rs
@@ -69,7 +69,7 @@ where
         Storage::new(self.client.clone(), block_ref.into())
     }
 
-    /// Obtain storage at the latest block hash.
+    /// Obtain storage at the latest finalized block.
     pub fn at_latest(
         &self,
     ) -> impl Future<Output = Result<Storage<T, Client>, Error>> + Send + 'static {

--- a/subxt/src/view_functions/view_functions_client.rs
+++ b/subxt/src/view_functions/view_functions_client.rs
@@ -40,7 +40,7 @@ where
         ViewFunctionsApi::new(self.client.clone(), block_ref.into())
     }
 
-    /// Obtain an interface to call View Functions at the latest block hash.
+    /// Obtain an interface to call View Functions at the latest finalized block.
     pub fn at_latest(
         &self,
     ) -> impl Future<Output = Result<ViewFunctionsApi<T, Client>, Error>> + Send + 'static {


### PR DESCRIPTION
Tell the user that these functions operate with the last finalized block.