### PR TITLE
Fix 'subxt explore storage': don't turn keys to bytes

### DIFF
--- a/cli/src/commands/explore/pallets/storage.rs
+++ b/cli/src/commands/explore/pallets/storage.rs
@@ -1,6 +1,5 @@
 use clap::Args;
 use color_eyre::{
-    eyre::Context,
     eyre::{bail, eyre},
     owo_colors::OwoColorize,
 };
@@ -9,13 +8,9 @@ use scale_typegen_description::type_description;
 use scale_value::Value;
 use std::fmt::Write;
 use std::write;
-
-use subxt::{
-    ext::scale_encode::EncodeAsType,
-    metadata::{
-        Metadata,
-        types::{PalletMetadata, StorageEntryType, StorageMetadata},
-    },
+use subxt::metadata::{
+    Metadata,
+    types::{PalletMetadata, StorageEntryType, StorageMetadata},
 };
 
 use crate::utils::{

--- a/cli/src/commands/explore/pallets/storage.rs
+++ b/cli/src/commands/explore/pallets/storage.rs
@@ -1,8 +1,8 @@
 use clap::Args;
 use color_eyre::{
+    eyre::Context,
     eyre::{bail, eyre},
     owo_colors::OwoColorize,
-    eyre::Context
 };
 use indoc::{formatdoc, writedoc};
 use scale_typegen_description::type_description;
@@ -181,7 +181,7 @@ pub async fn explore_storage(
                 .collect::<Vec<_>>()
                 .join("\n");
             let value_str = values_str.indent(4);
-            
+
             writedoc! {output, "
 
             You submitted the following {key_value_placeholder}:


### PR DESCRIPTION
This command failed with talk about issues converting keys to the right type:

```
cargo run --bin subxt -- explore --url wss://rpc.polkadot.io  pallet system storage BlockHash --execute 26788173
```

The reason is because, for some reason, keys were converted to bytes before being passed to the storage function. Possibly a legacy thing that we forgot to update when we changed an API.

Now, each trailing argument to the command is parsed into a separate `Value` and used as a separate key. The commadn above works (though we could probably format the output more nicely eg hex).