### PR TITLE
Prepare for 0.43.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,7 +464,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "artifacts"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "substrate-runner",
 ]
@@ -2106,7 +2106,7 @@ dependencies = [
 
 [[package]]
 name = "generate-custom-metadata"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "frame-metadata 23.0.0",
  "parity-scale-codec",
@@ -2727,7 +2727,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "assert_matches",
  "cfg_aliases",
@@ -5534,7 +5534,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-runner"
-version = "0.42.1"
+version = "0.43.0"
 
 [[package]]
 name = "subtle"
@@ -5544,7 +5544,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "subxt"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -5589,7 +5589,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-cli"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "clap",
  "color-eyre",
@@ -5621,7 +5621,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-codegen"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "frame-metadata 23.0.0",
  "getrandom 0.2.16",
@@ -5638,7 +5638,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-core"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "assert_matches",
  "base58",
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-lightclient"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "futures",
  "futures-timer",
@@ -5697,7 +5697,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "darling",
  "parity-scale-codec",
@@ -5717,7 +5717,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-metadata"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "bitvec",
  "criterion",
@@ -5733,7 +5733,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-rpcs"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "derive-where",
  "finito",
@@ -5762,7 +5762,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-signer"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "base64 0.22.1",
  "bip32",
@@ -5795,7 +5795,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-test-macro"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "quote",
  "syn 2.0.101",
@@ -5803,7 +5803,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-utils-fetchmetadata"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "frame-metadata 23.0.0",
  "hex",
@@ -5816,7 +5816,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-utils-stripmetadata"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "either",
  "frame-metadata 23.0.0",
@@ -5899,7 +5899,7 @@ dependencies = [
 
 [[package]]
 name = "test-runtime"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "hex",
  "impl-serde",
@@ -6325,7 +6325,7 @@ checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "ui-tests"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "frame-metadata 23.0.0",
  "generate-custom-metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ resolver = "2"
 [workspace.package]
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2024"
-version = "0.42.1"
+version = "0.43.0"
 rust-version = "1.85.0"
 license = "Apache-2.0 OR GPL-3.0"
 repository = "https://github.com/paritytech/subxt"
@@ -153,16 +153,16 @@ sp-state-machine = { version = "0.45.0", default-features = false }
 sp-runtime = { version = "41.1.0", default-features = false }
 
 # Subxt workspace crates:
-subxt = { version = "0.42.1", path = "subxt", default-features = false }
-subxt-core = { version = "0.42.1", path = "core", default-features = false }
-subxt-macro = { version = "0.42.1", path = "macro" }
-subxt-metadata = { version = "0.42.1", path = "metadata", default-features = false }
-subxt-codegen = { version = "0.42.1", path = "codegen" }
-subxt-signer = { version = "0.42.1", path = "signer", default-features = false }
-subxt-rpcs = { version = "0.42.1", path = "rpcs", default-features = false }
-subxt-lightclient = { version = "0.42.1", path = "lightclient", default-features = false }
-subxt-utils-fetchmetadata = { version = "0.42.1", path = "utils/fetch-metadata", default-features = false }
-subxt-utils-stripmetadata = { version = "0.42.1", path = "utils/strip-metadata", default-features = false }
+subxt = { version = "0.43.0", path = "subxt", default-features = false }
+subxt-core = { version = "0.43.0", path = "core", default-features = false }
+subxt-macro = { version = "0.43.0", path = "macro" }
+subxt-metadata = { version = "0.43.0", path = "metadata", default-features = false }
+subxt-codegen = { version = "0.43.0", path = "codegen" }
+subxt-signer = { version = "0.43.0", path = "signer", default-features = false }
+subxt-rpcs = { version = "0.43.0", path = "rpcs", default-features = false }
+subxt-lightclient = { version = "0.43.0", path = "lightclient", default-features = false }
+subxt-utils-fetchmetadata = { version = "0.43.0", path = "utils/fetch-metadata", default-features = false }
+subxt-utils-stripmetadata = { version = "0.43.0", path = "utils/strip-metadata", default-features = false }
 test-runtime = { path = "testing/test-runtime" }
 substrate-runner = { path = "testing/substrate-runner" }
 

--- a/examples/ffi-example/Cargo.lock
+++ b/examples/ffi-example/Cargo.lock
@@ -2684,7 +2684,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "subxt"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "async-trait",
  "derive-where",
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-codegen"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "heck",
  "parity-scale-codec",
@@ -2734,7 +2734,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-core"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "base58",
  "blake2",
@@ -2772,7 +2772,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-lightclient"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "futures",
  "futures-util",
@@ -2787,7 +2787,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "darling",
  "parity-scale-codec",
@@ -2802,7 +2802,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-metadata"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "frame-decode",
  "frame-metadata",
@@ -2815,7 +2815,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-rpcs"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "derive-where",
  "frame-metadata",
@@ -2837,7 +2837,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-signer"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "base64",
  "bip39",
@@ -2863,7 +2863,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-utils-fetchmetadata"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "hex",
  "parity-scale-codec",


### PR DESCRIPTION
## [0.43.0] - 2025-07-17

This is a reasonably small release which is mainly bug fixing, but has a couple of changes I'd like to elaborate on:

### Remove `codec::Encode` and `codec::Decode` derives from generated APIs by default ([#2008](https://github.com/paritytech/subxt/pull/2008))

When generating an API using the `#[subxt::subxt(...)]` macro (or programatically via `subxt-codegen`), we had always previously added `parity_scale_codec::Encode` and `parity_scale_codec::Decode` derives to all of the generated types. Most places in Subxt have not made use of these for a long time (relying instead on `scale_encode::EncodeAsType` and `scale_decode::DecodeAsType`, since they allow encoding and encoding which takes the type information into account and can more gracefully handle incompatibilities).

We eventually [hit an issue](https://github.com/paritytech/subxt/issues/2006) to which the most appropriate fix was just to remove these derives.

If you still need the `parity_scale_codec::Encode` or `parity_scale_codec::Decode` derives on certain types, you have two options:

1. Use the [`derive_for_type`](https://docs.rs/subxt/latest/subxt/attr.subxt.html#derive_for_typepath---derive--) attr to add them back where needed, eg:
   ```rust
   #[subxt::subxt(
     ...
     derive_for_type(
       path = "staging_xcm::v3::multilocation::MultiLocation",
       derive = "parity_scale_codec::Encode, parity_scale_codec::Decode",
       recursive
     )
   )]
   ```
2. Use the [`derive_for_all_types`](https://docs.rs/subxt/latest/subxt/attr.subxt.html#derive_for_all_types--) attr to add them back everywhere, eg:
   ```
   #[subxt::subxt(
     ...
     derive_for_all_types = "parity_scale_codec::Encode, parity_scale_codec::Decode"
   )]
   ```

Prefer (1) where possible to reduce the amount of generated code, and reduce the likelihood of running into [issues](https://github.com/paritytech/subxt/issues/2006) around those derives in certain edge cases.

This PR changes some things around storage keys to remove one last requirement for `Encode` and `Decode` derives, and also as a side effect changes `api.storage().call_raw()` slightly to no longer also try to decode the resulting type via `Decode`, leaving this to the user (and also meaning it's much easier now for the user to obtain the raw bytes for some storage entry).

In other words, instead of doing something like:

```rust
let (compact_len, metadata) = rt
        .call_raw::<(Compact<u32>, frame_metadata::RuntimeMetadataPrefixed)>(
            "Metadata_metadata",
            None,
        )
        .await?;
```

You would now do:

```rust
let meta_bytes = rt.call_raw("Metadata_metadata", None).await?;
let (compact_len, metadata): (Compact<u32>, frame_metadata::RuntimeMetadataPrefixed) =
    Decode::decode(&mut &*meta_bytes)?;
```

### Address some issues around tx mortality ([#2025](https://github.com/paritytech/subxt/pull/2025))

Prior to this change, the intended behavior was that any transaction submitted via an `OnlineClient` would have a mortality of 32 blocks by default, and any transaction submitted via an `OfflineClient` would be immortal by default. A couple of issues were present or cropped up however:
- If you explicitly configure the mortality via setting params like `PolkadotExtrinsicParamsBuilder::new().mortal(32).build()`, the `OfflineClient` transaction would _still_ be immortal, because it didn't have enough information to properly configure the mortality as asked for (by virtue of being offline and unable to fetch it).
- The intended behaviour turned out to have been broken, and transactions were being submitted as immortal even via the `OnlineClient` by default, unless mortality was explicitly configured.
- There was no easy way to actually set the mortality for an `OfflineClient` transaction; you'd have to do something like this:
  ```rust
  let params = DefaultExtrinsicParamsBuilder::new();
  params.5 = CheckMortalityParams::mortal_from_unchecked(for_n_blocks, from_block_n, from_block_hash);
  ```

With this PR, transactions _are_ now mortal by default using the `OnlineClient`, we now return an error if you try to construct a transaction with the `OfflineClient` and try to use `params.mortal(..)` when configuring it, and we expose `params.mortal_from_unchecked(..)` to allow configuration for offline transactions without the ugly code above.

In this PR, we also discovered an issue decoding `Eras` and fixed this, so that decoding the mortality of a transaction when it is mortal should now work. 

### Add FFI example ([#2037](https://github.com/paritytech/subxt/pull/2037))

I'd like to do a quick shoutout to @wassimans, who submitted an excellent example for how to interact with Subxt via the C FFI in Python and Node.JS. This is something I've wanted to add for a while, so it's lovely to see this new example which highlights one of the strengths of Subxt over Javascript based compatitors in the space.

All of the non-trivial changes in this release are listed below:

### Added

- Add FFI example ([#2037](https://github.com/paritytech/subxt/pull/2037))

### Changed

- Remove `codec::Encode` and `codec::Decode` derives from generated APIs by default ([#2008](https://github.com/paritytech/subxt/pull/2008))
- Address some issues around tx mortality ([#2025](https://github.com/paritytech/subxt/pull/2025))

### Fixed

- Fix 'subxt explore storage': don't turn keys to bytes ([#2038](https://github.com/paritytech/subxt/pull/2038))
- Refactor: improve nonce and block injection in extrinsic params ([#2032](https://github.com/paritytech/subxt/pull/2032))
- Improve docs for `at_latest` ([#2035](https://github.com/paritytech/subxt/pull/2035))
- Clippy fixes for latest Rustc ([#2033](https://github.com/paritytech/subxt/pull/2033))
- docs: fix minor comment typos ([#2027](https://github.com/paritytech/subxt/pull/2027))
- chore: remove redundant backtick in comment ([#2020](https://github.com/paritytech/subxt/pull/2020))
- Keep codec attrs even when Encode/Decode not used ([#2023](https://github.com/paritytech/subxt/pull/2023))
- Run CI on v0.N.x branches or PRs to them for ease of backporting ([#2017](https://github.com/paritytech/subxt/pull/2017))
- De-dup types early in CLI/macro so that derives/substitutes work for de-duped types ([#2015](https://github.com/paritytech/subxt/pull/2015))
- If only one hasher, always treat any key as a single and not NMap key, even if it's a tuple. ([#2010](https://github.com/paritytech/subxt/pull/2010))