### PR TITLE
docs: fix typos in docs

### DIFF
--- a/metadata/src/utils/validation.rs
+++ b/metadata/src/utils/validation.rs
@@ -921,14 +921,14 @@ mod tests {
         // Build metadata with both pallets.
         let metadata_both = pallets_to_metadata(pallets);
 
-        // Hashing will ignore any non-existant pallet and return the same result.
+        // Hashing will ignore any non-existent pallet and return the same result.
         let hash = MetadataHasher::new(&metadata_one)
             .only_these_pallets(&["First", "Second"])
             .hash();
         let hash_rhs = MetadataHasher::new(&metadata_one)
             .only_these_pallets(&["First"])
             .hash();
-        assert_eq!(hash, hash_rhs, "hashing should ignore non-existant pallets");
+        assert_eq!(hash, hash_rhs, "hashing should ignore non-existent pallets");
 
         // Hashing one pallet from metadata with 2 pallets inserted will ignore the second pallet.
         let hash_second = MetadataHasher::new(&metadata_both)

--- a/testing/integration-tests/src/full_client/codegen/polkadot.rs
+++ b/testing/integration-tests/src/full_client/codegen/polkadot.rs
@@ -29847,7 +29847,7 @@ pub mod api {
                 #[encode_as_type(
                     crate_path = ":: subxt :: ext :: subxt_core :: ext :: scale_encode"
                 )]
-                #[doc = "Approve bountry and propose a curator simultaneously."]
+                #[doc = "Approve boundary and propose a curator simultaneously."]
                 #[doc = "This call is a shortcut to calling `approve_bounty` and `propose_curator` separately."]
                 #[doc = ""]
                 #[doc = "May only be called from `T::SpendOrigin`."]
@@ -30165,7 +30165,7 @@ pub mod api {
                         ],
                     )
                 }
-                #[doc = "Approve bountry and propose a curator simultaneously."]
+                #[doc = "Approve boundary and propose a curator simultaneously."]
                 #[doc = "This call is a shortcut to calling `approve_bounty` and `propose_curator` separately."]
                 #[doc = ""]
                 #[doc = "May only be called from `T::SpendOrigin`."]
@@ -54843,7 +54843,7 @@ pub mod api {
                         remark: ::subxt::ext::subxt_core::alloc::vec::Vec<::core::primitive::u8>,
                     },
                     #[codec(index = 9)]
-                    #[doc = "Approve bountry and propose a curator simultaneously."]
+                    #[doc = "Approve boundary and propose a curator simultaneously."]
                     #[doc = "This call is a shortcut to calling `approve_bounty` and `propose_curator` separately."]
                     #[doc = ""]
                     #[doc = "May only be called from `T::SpendOrigin`."]


### PR DESCRIPTION
### Description

This PR corrects several minor typos in comments across the codebase. The changes are non-functional and purely textual to improve clarity and maintain a clean, professional codebase.

### Details

- Corrected misspellings:
  - `non-existant` → `non-existent`
  - `bountry` → `boundary`

These fixes help enhance readability and eliminate minor distractions during development and code reviews.

### Additional Info

No logic or functionality has been modified.