### PR TITLE
Tweak reconnecting-rpc-client test 

### DIFF
--- a/rpcs/Cargo.toml
+++ b/rpcs/Cargo.toml
@@ -93,6 +93,7 @@ wasm-bindgen-futures = { workspace = true, optional = true }
 tower = { workspace = true }
 hyper = { workspace = true }
 http-body = { workspace = true }
+jsonrpsee = { workspace = true, features = ["server"] }
 
 [package.metadata.docs.rs]
 default-features = true


### PR DESCRIPTION
This started off as a PR to get #2053 over the finish line, but in the end I reverted most of the changes there and just improved an existing test to be less likely to fail sporadically. Based on this test, `master` is already handling reconnecting via the reconnecting rpc client as expected.