### PR TITLE
subxt-historic: add support for returning the default values of storage entries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1931,9 +1931,9 @@ dependencies = [
 
 [[package]]
 name = "frame-decode"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c470df86cf28818dd3cd2fc4667b80dbefe2236c722c3dc1d09e7c6c82d6dfcd"
+checksum = "641e3739fa708a278d35b008a05244008c221240abc3e1c27138466c13e999ed"
 dependencies = [
  "frame-metadata 23.0.0",
  "parity-scale-codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ darling = "0.20.10"
 derive-where = "1.2.7"
 either = { version = "1.13.0", default-features = false }
 finito = { version = "0.1.0", default-features = false }
-frame-decode = { version = "0.9.0", default-features = false }
+frame-decode = { version = "0.10.0", default-features = false }
 frame-metadata = { version = "23.0.0", default-features = false }
 futures = { version = "0.3.31", default-features = false, features = ["std"] }
 getrandom = { version = "0.2", default-features = false }

--- a/historic/examples/storage.rs
+++ b/historic/examples/storage.rs
@@ -24,6 +24,12 @@ async fn main() -> Result<(), Error> {
             .entry("System", "Account")?
             .into_map()?;
 
+        // We can see the default value for this entry at this block, if one exists.
+        if let Some(default_value) = account_balances.default() {
+            let default_balance_info = default_value.decode::<scale_value::Value>()?;
+            println!("  Default balance info: {default_balance_info}");
+        }
+
         // We can fetch a specific account balance by its key, like so (here I just picked a random key
         // I knew to exist from iterating over storage entries):
         let account_id_hex = "9a4d0faa2ba8c3cc5711852960940793acf55bf195b6eecf88fa78e961d0ce4a";

--- a/historic/src/storage/storage_entry.rs
+++ b/historic/src/storage/storage_entry.rs
@@ -3,6 +3,7 @@ use super::storage_key::StorageKey;
 use super::storage_value::StorageValue;
 use crate::error::{StorageKeyError, StorageValueError};
 use scale_decode::DecodeAsType;
+use std::borrow::Cow;
 
 /// This represents a storage entry, which is a key-value pair in the storage.
 pub struct StorageEntry<'entry, 'atblock> {
@@ -13,7 +14,11 @@ pub struct StorageEntry<'entry, 'atblock> {
 
 impl<'entry, 'atblock> StorageEntry<'entry, 'atblock> {
     /// Create a new storage entry.
-    pub fn new(info: &'entry AnyStorageInfo<'atblock>, key: Vec<u8>, value: Vec<u8>) -> Self {
+    pub fn new(
+        info: &'entry AnyStorageInfo<'atblock>,
+        key: Vec<u8>,
+        value: Cow<'atblock, [u8]>,
+    ) -> Self {
         Self {
             key,
             value: StorageValue::new(info, value),

--- a/historic/src/storage/storage_info.rs
+++ b/historic/src/storage/storage_info.rs
@@ -85,7 +85,7 @@ impl<'atblock> From<StorageInfo<'atblock, u32, scale_info::PortableRegistry>>
 }
 
 pub struct StorageInfo<'atblock, TypeId, Resolver> {
-    pub info: frame_decode::storage::StorageInfo<TypeId>,
+    pub info: frame_decode::storage::StorageInfo<'atblock, TypeId>,
     pub resolver: &'atblock Resolver,
 }
 

--- a/historic/src/storage/storage_value.rs
+++ b/historic/src/storage/storage_value.rs
@@ -2,16 +2,17 @@ use super::storage_info::AnyStorageInfo;
 use super::storage_info::with_info;
 use crate::error::StorageValueError;
 use scale_decode::DecodeAsType;
+use std::borrow::Cow;
 
 /// This represents a storage value.
 pub struct StorageValue<'entry, 'atblock> {
     pub(crate) info: &'entry AnyStorageInfo<'atblock>,
-    bytes: Vec<u8>,
+    bytes: Cow<'atblock, [u8]>,
 }
 
 impl<'entry, 'atblock> StorageValue<'entry, 'atblock> {
     /// Create a new storage value.
-    pub fn new(info: &'entry AnyStorageInfo<'atblock>, bytes: Vec<u8>) -> Self {
+    pub fn new(info: &'entry AnyStorageInfo<'atblock>, bytes: Cow<'atblock, [u8]>) -> Self {
         Self { info, bytes }
     }
 
@@ -22,7 +23,7 @@ impl<'entry, 'atblock> StorageValue<'entry, 'atblock> {
 
     /// Consume this storage value and return the raw bytes.
     pub fn into_bytes(self) -> Vec<u8> {
-        self.bytes
+        self.bytes.to_vec()
     }
 
     /// Decode this storage value.

--- a/testing/integration-tests/src/full_client/blocks.rs
+++ b/testing/integration-tests/src/full_client/blocks.rs
@@ -207,7 +207,7 @@ async fn fetch_block_and_decode_extrinsic_details() {
     let block = api.blocks().at(block_hash).await.unwrap();
 
     // Ensure that we can clone the block.
-    block.clone();
+    let _ = block.clone();
 
     let extrinsics = block.extrinsics().await.unwrap();
 
@@ -295,8 +295,7 @@ async fn submit_extrinsic_and_get_it_back(
     let block_hash = in_block.block_hash();
     let block = api.blocks().at(block_hash).await.unwrap();
     let extrinsics = block.extrinsics().await.unwrap();
-    let extrinsic_details = extrinsics.iter().find(|e| e.is_signed()).unwrap();
-    extrinsic_details
+    extrinsics.iter().find(|e| e.is_signed()).unwrap()
 }
 
 #[cfg(fullclient)]


### PR DESCRIPTION
This involves a tweak and bump to frame-decode and then a couple of additional APIs to allow returning the default value, if one is present, for a storage entry. This was one thing present in subxt and missing in subxt-historic w.r.t storage. 