### PR TITLE
chore: remove redundant word in comment

### DIFF
--- a/subxt/examples/setup_reconnecting_rpc_client.rs
+++ b/subxt/examples/setup_reconnecting_rpc_client.rs
@@ -20,7 +20,7 @@ pub mod polkadot {}
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
-    // Create a new client with with a reconnecting RPC client.
+    // Create a new client with a reconnecting RPC client.
     let rpc = RpcClient::builder()
         // Reconnect with exponential backoff
         //


### PR DESCRIPTION
remove redundant word in comment