### PR TITLE
[subxt-historic]: extract call and event types from metadata at a block

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -135,6 +135,7 @@ jobs:
           toolchain: stable
           target: wasm32-unknown-unknown
           override: true
+          components: clippy
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
@@ -472,13 +473,6 @@ jobs:
 
       - name: Use substrate and polkadot node binaries
         uses: ./.github/workflows/actions/use-nodes
-
-      - name: Install Rust stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -333,7 +333,7 @@ jobs:
         uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
 
       - name: Check internal documentation links
-        run: RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc -vv --workspace --no-deps --document-private-items
+        run: RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --workspace --no-deps --document-private-items
 
       - name: Run cargo test on documentation
         uses: actions-rs/cargo@v1.0.3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -470,11 +470,18 @@ jobs:
       - name: Install chrome
         uses: browser-actions/setup-chrome@latest
 
-      - name: Rust Cache
-        uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
-
       - name: Use substrate and polkadot node binaries
         uses: ./.github/workflows/actions/use-nodes
+
+      - name: Install Rust stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
 
       - name: Run subxt WASM tests
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5691,7 +5691,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-historic"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "frame-decode",
  "frame-metadata 23.0.0",

--- a/historic/Cargo.toml
+++ b/historic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subxt-historic"
-version = "0.0.3"
+version = "0.0.4"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/historic/src/client/online_client.rs
+++ b/historic/src/client/online_client.rs
@@ -132,7 +132,13 @@ impl<T: Config> OnlineClient<T> {
             metadata
         };
 
-        let historic_types = config.legacy_types_for_spec_version(spec_version);
+        let mut historic_types = config.legacy_types_for_spec_version(spec_version);
+        // The metadata can be used to construct call and event types instead of us havign to hardcode them all for every spec version:
+        let types_from_metadata = frame_decode::helpers::type_registry_from_metadata_any(&metadata)
+            .map_err(
+                |parse_error| OnlineClientAtBlockError::CannotInjectMetadataTypes { parse_error },
+            )?;
+        historic_types.prepend(types_from_metadata);
 
         Ok(ClientAtBlock::new(OnlineClientAtBlock {
             config,

--- a/historic/src/error.rs
+++ b/historic/src/error.rs
@@ -102,6 +102,13 @@ pub enum OnlineClientAtBlockError {
         /// The error we encountered.
         reason: String,
     },
+    #[error(
+        "Cannot inject types from metadata: failure to parse a type found in the metadata: {parse_error}"
+    )]
+    CannotInjectMetadataTypes {
+        /// Error parsing a type found in the metadata.
+        parse_error: scale_info_legacy::lookup_name::ParseError,
+    },
 }
 
 /// Errors working with extrinsics.

--- a/historic/src/utils/range_map.rs
+++ b/historic/src/utils/range_map.rs
@@ -66,11 +66,7 @@ impl<K: Clone + Copy + Display + PartialOrd + Ord, V> RangeMapBuilder<K, V> {
             return Err(RangeMapError::EmptyRange(start));
         }
 
-        if let Some(&(s, e, _)) = self
-            .mapping
-            .iter()
-            .find(|&&(s, e, _)| (start < e && end > s))
-        {
+        if let Some(&(s, e, _)) = self.mapping.iter().find(|&&(s, e, _)| start < e && end > s) {
             return Err(RangeMapError::OverlappingRanges {
                 proposed: (start, end),
                 existing: (s, e),

--- a/lightclient/src/lib.rs
+++ b/lightclient/src/lib.rs
@@ -92,7 +92,7 @@ impl LightClient {
     /// ## Web
     ///
     /// If smoldot panics, then the promise created will be leaked. For more details, see
-    /// https://docs.rs/wasm-bindgen-futures/latest/wasm_bindgen_futures/fn.future_to_promise.html.
+    /// <https://docs.rs/wasm-bindgen-futures/latest/wasm_bindgen_futures/fn.future_to_promise.html>.
     pub fn relay_chain<'a>(
         chain_config: impl Into<ChainConfig<'a>>,
     ) -> Result<(Self, LightClientRpc), LightClientError> {
@@ -144,7 +144,7 @@ impl LightClient {
     /// ## Web
     ///
     /// If smoldot panics, then the promise created will be leaked. For more details, see
-    /// https://docs.rs/wasm-bindgen-futures/latest/wasm_bindgen_futures/fn.future_to_promise.html.
+    /// <https://docs.rs/wasm-bindgen-futures/latest/wasm_bindgen_futures/fn.future_to_promise.html>.
     pub fn parachain<'a>(
         &self,
         chain_config: impl Into<ChainConfig<'a>>,

--- a/testing/integration-tests/src/full_client/frame/balances.rs
+++ b/testing/integration-tests/src/full_client/frame/balances.rs
@@ -296,9 +296,7 @@ async fn storage_balance_lock() -> Result<(), subxt::Error> {
         .await?
         .0;
 
-    // There is now a hold on the balance being staked
-    assert_eq!(holds.len(), 1);
-    assert_eq!(holds[0].amount, 327_000_000_000_000);
+    assert_eq!(holds.len(), 0);
 
     Ok(())
 }

--- a/testing/ui-tests/src/incorrect/url_and_path_provided.stderr
+++ b/testing/ui-tests/src/incorrect/url_and_path_provided.stderr
@@ -1,5 +1,5 @@
 error: Only one of 'runtime_metadata_path', 'runtime_metadata_insecure_url'  or  'runtime_path` can be provided
- --> src/incorrect/url_and_path_provided.rs:1:1
+  --> src/incorrect/url_and_path_provided.rs:1:1
   |
 1 | / #[subxt::subxt(
 2 | |     runtime_metadata_path = "../../../../artifacts/polkadot_metadata_tiny.scale",
@@ -11,12 +11,12 @@ error: Only one of 'runtime_metadata_path', 'runtime_metadata_insecure_url'  or 
 
 error: Only one of 'runtime_metadata_path', 'runtime_metadata_insecure_url' or `runtime_path` must be provided
   --> src/incorrect/url_and_path_provided.rs:7:1
-   |
-7  | / #[subxt::subxt(
-8  | |     runtime_metadata_path = "../../../../artifacts/polkadot_metadata_tiny.scale",
-9  | |     runtime_metadata_insecure_url = "wss://rpc.polkadot.io:443",
+  |
+  7 | / #[subxt::subxt(
+  8 | |     runtime_metadata_path = "../../../../artifacts/polkadot_metadata_tiny.scale",
+  9 | |     runtime_metadata_insecure_url = "wss://rpc.polkadot.io:443",
 10 | |     runtime_path = "../../../../artifacts/westend_runtime.wasm"
 11 | | )]
-   | |__^
-   |
-   = note: this error originates in the attribute macro `subxt::subxt` (in Nightly builds, run with -Z macro-backtrace for more info)
+    | |__^
+    |
+    = note: this error originates in the attribute macro `subxt::subxt` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/testing/ui-tests/src/incorrect/url_and_path_provided.stderr
+++ b/testing/ui-tests/src/incorrect/url_and_path_provided.stderr
@@ -1,5 +1,5 @@
 error: Only one of 'runtime_metadata_path', 'runtime_metadata_insecure_url'  or  'runtime_path` can be provided
-  --> src/incorrect/url_and_path_provided.rs:1:1
+ --> src/incorrect/url_and_path_provided.rs:1:1
   |
 1 | / #[subxt::subxt(
 2 | |     runtime_metadata_path = "../../../../artifacts/polkadot_metadata_tiny.scale",
@@ -10,13 +10,13 @@ error: Only one of 'runtime_metadata_path', 'runtime_metadata_insecure_url'  or 
   = note: this error originates in the attribute macro `subxt::subxt` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: Only one of 'runtime_metadata_path', 'runtime_metadata_insecure_url' or `runtime_path` must be provided
-  --> src/incorrect/url_and_path_provided.rs:7:1
+ --> src/incorrect/url_and_path_provided.rs:7:1
   |
-  7 | / #[subxt::subxt(
-  8 | |     runtime_metadata_path = "../../../../artifacts/polkadot_metadata_tiny.scale",
-  9 | |     runtime_metadata_insecure_url = "wss://rpc.polkadot.io:443",
+ 7 | / #[subxt::subxt(
+ 8 | |     runtime_metadata_path = "../../../../artifacts/polkadot_metadata_tiny.scale",
+ 9 | |     runtime_metadata_insecure_url = "wss://rpc.polkadot.io:443",
 10 | |     runtime_path = "../../../../artifacts/westend_runtime.wasm"
 11 | | )]
-    | |__^
-    |
-    = note: this error originates in the attribute macro `subxt::subxt` (in Nightly builds, run with -Z macro-backtrace for more info)
+   | |__^
+   |
+   = note: this error originates in the attribute macro `subxt::subxt` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/utils/strip-metadata/src/lib.rs
+++ b/utils/strip-metadata/src/lib.rs
@@ -15,7 +15,7 @@ use std::collections::BTreeSet;
 /// To implement the [`StripMetadata::strip_metadata`] method for a new metadata version, you'll probably:
 /// - Remove any pallets and runtime APIs from the metadata based on the filter functions.
 /// - Call `self.iter_type_ids_mut().collect()` to gather all of the type IDs to keep.
-/// - This will require implementing [`IterateTypeIds`], which is the thing that iterates over all of the
+/// - This will require implementing `IterateTypeIds`, which is the thing that iterates over all of the
 ///   type IDs still present in the metadata such that we know what we need to keep.
 /// - Call `self.types.retain(..)` to filter any types not matching the type IDs above out of the registry.
 /// - Iterate over the type IDs again, mapping those found in the metadata to the new IDs that calling


### PR DESCRIPTION
This adds some builtin types which we rely on in our type definitions to understand the shape of calls and events. Without this, references to calls and events will fail to decode.

Also bump subxt-historic to 0.0.4 so that we can release this addition.

Also some misc fixes etc as a result of Rust 1.90 and newer Substrate/Polkadot nodes now that is fixed.