### PR TITLE
Attempt to Fix CI take 2

### DIFF
--- a/.github/workflows/build-nodes.yml
+++ b/.github/workflows/build-nodes.yml
@@ -18,7 +18,7 @@ jobs:
           repository: paritytech/polkadot-sdk
 
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler curl gcc make clang cmake llvm-dev
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler curl gcc make clang cmake llvm-dev libclang-dev
 
       - name: Install Rust stable toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/build-nodes.yml
+++ b/.github/workflows/build-nodes.yml
@@ -18,7 +18,7 @@ jobs:
           repository: paritytech/polkadot-sdk
 
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler curl gcc make clang cmake
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler curl gcc make clang cmake llvm-dev
 
       - name: Install Rust stable toolchain
         uses: actions-rs/toolchain@v1


### PR DESCRIPTION
The build node binary script is broken. Reason is probably [this PR in polkadot-sdk](https://github.com/paritytech/polkadot-sdk/commit/fa417f9fde23634d6157b928ddfe9d0b19299d57)

It looks like running the CI job on this branch with both `llvm-dev` and `libclang-dev` seems to work now (my last PR just added the former).

 