### PR TITLE
Fix typos

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,7 +13,7 @@
 # - Multiple owners are supported.
 # - Either handle (e.g, @github_user or @github_org/team) or email can be used. Keep in mind,
 #   that handles might work better because they are more recognizable on GitHub,
-#   eyou can use them for mentioning unlike an email.
+#   you can use them for mentioning unlike an email.
 # - The latest matching rule, if multiple, takes precedence.
 
 # main codeowner

--- a/historic/src/client/offline_client.rs
+++ b/historic/src/client/offline_client.rs
@@ -62,7 +62,7 @@ pub trait OfflineClientAtBlockT<'client, T: Config + 'client> {
 // private to allow changes if possible.
 #[doc(hidden)]
 pub struct OfflineClientAtBlock<'client, T: Config + 'client> {
-    /// The configuration for thie chain.
+    /// The configuration for this chain.
     config: &'client T,
     /// Historic types to use at this block number.
     legacy_types: TypeRegistrySet<'client>,

--- a/historic/src/client/online_client.rs
+++ b/historic/src/client/online_client.rs
@@ -133,7 +133,7 @@ impl<T: Config> OnlineClient<T> {
         };
 
         let mut historic_types = config.legacy_types_for_spec_version(spec_version);
-        // The metadata can be used to construct call and event types instead of us havign to hardcode them all for every spec version:
+        // The metadata can be used to construct call and event types instead of us having to hardcode them all for every spec version:
         let types_from_metadata = frame_decode::helpers::type_registry_from_metadata_any(&metadata)
             .map_err(
                 |parse_error| OnlineClientAtBlockError::CannotInjectMetadataTypes { parse_error },


### PR DESCRIPTION
Quick PR to fix some typos I spotted: 
 "eyou" → "you", 
"thie" → "this", 
 "havign" → "having".