### PR TITLE
Fix typos

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,7 +13,7 @@
 # - Multiple owners are supported.
 # - Either handle (e.g, @github_user or @github_org/team) or email can be used. Keep in mind,
 #   that handles might work better because they are more recognizable on GitHub,
-#   eyou can use them for mentioning unlike an email.
+#   you can use them for mentioning unlike an email.
 # - The latest matching rule, if multiple, takes precedence.
 
 # main codeowner

--- a/historic/src/client/offline_client.rs
+++ b/historic/src/client/offline_client.rs
@@ -62,7 +62,7 @@ pub trait OfflineClientAtBlockT<'client, T: Config + 'client> {
 // private to allow changes if possible.
 #[doc(hidden)]
 pub struct OfflineClientAtBlock<'client, T: Config + 'client> {
-    /// The configuration for thie chain.
+    /// The configuration for this chain.
     config: &'client T,
     /// Historic types to use at this block number.
     legacy_types: TypeRegistrySet<'client>,

--- a/historic/src/client/online_client.rs
+++ b/historic/src/client/online_client.rs
@@ -133,7 +133,7 @@ impl<T: Config> OnlineClient<T> {
         };
 
         let mut historic_types = config.legacy_types_for_spec_version(spec_version);
-        // The metadata can be used to construct call and event types instead of us havign to hardcode them all for every spec version:
+        // The metadata can be used to construct call and event types instead of us having to hardcode them all for every spec version:
         let types_from_metadata = frame_decode::helpers::type_registry_from_metadata_any(&metadata)
             .map_err(
                 |parse_error| OnlineClientAtBlockError::CannotInjectMetadataTypes { parse_error },

--- a/metadata/src/utils/validation.rs
+++ b/metadata/src/utils/validation.rs
@@ -394,7 +394,7 @@ pub fn get_runtime_api_hash(runtime_api: &RuntimeApiMethodMetadata) -> Hash {
 /// Obtain the hash of all of a runtime API trait, including all of its methods.
 pub fn get_runtime_apis_hash(trait_metadata: RuntimeApiMetadata) -> Hash {
     // Each API is already hashed considering the trait name, so we don't need
-    // to consider thr trait name again here.
+    // to consider the trait name again here.
     trait_metadata
         .methods()
         .fold([0u8; HASH_LEN], |bytes, method_metadata| {
@@ -431,7 +431,7 @@ pub fn get_view_function_hash(view_function: &ViewFunctionMetadata) -> Hash {
 /// Obtain the hash of all of the view functions in a pallet, including all of its methods.
 fn get_pallet_view_functions_hash(pallet_metadata: &PalletMetadata) -> Hash {
     // Each API is already hashed considering the trait name, so we don't need
-    // to consider thr trait name again here.
+    // to consider the trait name again here.
     pallet_metadata
         .view_functions()
         .fold([0u8; HASH_LEN], |bytes, method_metadata| {

--- a/subxt/src/error/dispatch_error.rs
+++ b/subxt/src/error/dispatch_error.rs
@@ -118,7 +118,7 @@ pub enum ArithmeticError {
     DivisionByZero,
 }
 
-/// An error relating to thr transactional layers when dispatching a transaction.
+/// An error relating to the transactional layers when dispatching a transaction.
 #[derive(scale_decode::DecodeAsType, Debug, thiserror::Error, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum TransactionalError {


### PR DESCRIPTION
Quick PR to fix some typos I spotted:

"eyou" → "you",
"thie" → "this",
"havign" → "having",
"thr" → "the".