### PR TITLE
feat: Add `system_chainType` to legacy rpcs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Add `system_chain_type()` RPC method to `LegacyRpcMethods`
+
 ## [0.44.0] - 2025-08-28
 
 This small release primarily fixes a few issues, but also adds the code for a prelease of `subxt-historic`, a new crate (at the moment) for working with historic blocks and state. Future releases will aim to stabilize this crate to the level of other `subxt` crates or otherwise merge the logic into `subxt` itself.

--- a/rpcs/src/methods/legacy.rs
+++ b/rpcs/src/methods/legacy.rs
@@ -126,6 +126,11 @@ impl<T: RpcConfig> LegacyRpcMethods<T> {
         self.client.request("system_version", rpc_params![]).await
     }
 
+    /// Fetch system chain type
+    pub async fn system_chain_type(&self) -> Result<String, Error> {
+        self.client.request("system_chainType", rpc_params![]).await
+    }
+
     /// Fetch system properties
     pub async fn system_properties(&self) -> Result<SystemProperties, Error> {
         self.client

--- a/testing/integration-tests/src/full_client/client/legacy_rpcs.rs
+++ b/testing/integration-tests/src/full_client/client/legacy_rpcs.rs
@@ -119,6 +119,14 @@ async fn system_version() {
 }
 
 #[subxt_test]
+async fn system_chain_type() {
+    let ctx = test_context().await;
+    let rpc = ctx.legacy_rpc_methods().await;
+
+    let _ = rpc.system_chain_type().await.unwrap();
+}
+
+#[subxt_test]
 async fn system_properties() {
     let ctx = test_context().await;
     let rpc = ctx.legacy_rpc_methods().await;

--- a/testing/integration-tests/src/full_client/client/legacy_rpcs.rs
+++ b/testing/integration-tests/src/full_client/client/legacy_rpcs.rs
@@ -123,7 +123,8 @@ async fn system_chain_type() {
     let ctx = test_context().await;
     let rpc = ctx.legacy_rpc_methods().await;
 
-    let _ = rpc.system_chain_type().await.unwrap();
+    let chain_type = rpc.system_chain_type().await.unwrap();
+    assert_eq!(chain_type, "Development");
 }
 
 #[subxt_test]


### PR DESCRIPTION
Adds a missing legacy rpc method. 

Please let me know if there is anything else i need to add.