### PR TITLE
Fix typos in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Subxt is a library for interacting with [Substrate](https://github.com/paritytec
 - Read and iterate over storage values.
 - Read constants and custom values from the metadata.
 - Call runtime APIs, returning the results.
-- Do all of the above via a safe, statically types interface or via a dynamic one when you need the flexibility.
+- Do all of the above via a safe, statically typed interface or via a dynamic one when you need the flexibility.
 - Compile to WASM and run entirely in the browser.
 - Do a bunch of things in a `#[no_std]` environment via the `subxt-core` crate.
 - Use a built-in light client (`smoldot`) to interact with chains.

--- a/examples/ffi-example/README.md
+++ b/examples/ffi-example/README.md
@@ -45,7 +45,7 @@ which does a single balance transfer and returns 0 on success, –1 on error.
 ## Prerequisites
 - Rust toolchain (with cargo)
 - Python 3
-- Node.js (for the JS example. Version 19 worked on my M2 Mac, but version 22 did not, so YMMY).
+- Node.js (for the JS example. Version 19 worked on my M2 Mac, but version 22 did not, so YMMV).
 - A running Substrate node (Polkadot) on ws://127.0.0.1:8000. One can use Chopsticks for a quick local Polkadot node:
 
   ```shell

--- a/historic/README.md
+++ b/historic/README.md
@@ -1,6 +1,6 @@
 # subxt-historic
 
-**This create is a work in progress and currently is released only as a preview.**
+**This crate is a work in progress and currently is released only as a preview.**
 
 While `subxt` is a library for working at the head of a chain (submitting transactions and obtaining the current state), `subxt-historic` is a library for decoding blocks and state that are anywhere in a chain. To broadly summarize the differences:
 


### PR DESCRIPTION
Fixes three documentation typos:
  - "statically types" → "statically typed" (grammar)
  - "create" → "crate" (Rust terminology)
  - "YMMY" → "YMMV" (abbreviation)