### PR TITLE
Prep to release subxt-historic v0.0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5739,7 +5739,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-historic"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "frame-decode",
  "frame-metadata 23.0.0",

--- a/historic/CHANGELOG.md
+++ b/historic/CHANGELOG.md
@@ -1,0 +1,11 @@
+# subxt-historic changelog
+
+This is separate from the Subxt changelog as subxt-historic is currently releasaed separately.
+
+Eventually this project will merge with Subxt and no longer exist, but until then it's being maintained and updated where needed.
+
+## 0.0.5 (2025-11-21)
+
+- Rename some fields for consistency.
+- Update versions of underlying libraries being used.
+- Add `.visit()` methods to extrinsic fields and storage values, and examples of using this to our examples.

--- a/historic/Cargo.toml
+++ b/historic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subxt-historic"
-version = "0.0.4"
+version = "0.0.5"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
subxt-historic is released independently from other libraries in this repository. It will eventually merge with Subxt and disappear.

- Rename some fields for consistency.
- Update versions of underlying libraries being used.
- Add `.visit()` methods to extrinsic fields and storage values, and examples of using this to our examples.