### PR TITLE
subxt-historic: expose metadata at a given block

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5739,7 +5739,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-historic"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "frame-decode",
  "frame-metadata 23.0.0",

--- a/historic/CHANGELOG.md
+++ b/historic/CHANGELOG.md
@@ -4,6 +4,10 @@ This is separate from the Subxt changelog as subxt-historic is currently releasa
 
 Eventually this project will merge with Subxt and no longer exist, but until then it's being maintained and updated where needed.
 
+## 0.0.6 (2025-12-01)
+
+- Add `.metadata()` on `ClientAtBlock` to expose the current metadata at some block.
+
 ## 0.0.5 (2025-11-21)
 
 - Rename some fields for consistency.

--- a/historic/Cargo.toml
+++ b/historic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subxt-historic"
-version = "0.0.5"
+version = "0.0.6"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/historic/src/client.rs
+++ b/historic/src/client.rs
@@ -4,6 +4,7 @@ mod online_client;
 use crate::config::Config;
 use crate::extrinsics::ExtrinsicsClient;
 use crate::storage::StorageClient;
+use frame_metadata::RuntimeMetadata;
 use std::marker::PhantomData;
 
 // We keep these traits internal, so that we can mess with them later if needed,
@@ -43,5 +44,10 @@ where
     /// Work with storage.
     pub fn storage(&'_ self) -> StorageClient<'_, Client, T> {
         StorageClient::new(&self.client)
+    }
+
+    /// Return the metadata in use at this block.
+    pub fn metadata(&self) -> &RuntimeMetadata {
+        self.client.metadata()
     }
 }


### PR DESCRIPTION
Also prep to release 0.0.6 with this change.