### PR TITLE
Prep subxt-historic 0.0.7 release: expose ClientAtBlock bits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5739,7 +5739,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-historic"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "frame-decode",
  "frame-metadata 23.0.0",

--- a/historic/CHANGELOG.md
+++ b/historic/CHANGELOG.md
@@ -4,6 +4,24 @@ This is separate from the Subxt changelog as subxt-historic is currently releasa
 
 Eventually this project will merge with Subxt and no longer exist, but until then it's being maintained and updated where needed.
 
+## 0.0.7 (2025-12-03)
+
+Expose `OfflineClientAtBlock`, `OfflineClientAtBlockT`, `OnlinelientAtBlock`, `OnlineClientAtBlockT`.
+
+This is so that you can pass the `ClientAtBlock` into functions like so:
+
+```rust
+use subxt_historic::config::Config;
+use subxt_historic::client::{ ClientAtBlock, OnlineClientAtBlock, OnlineClientAtBlockT };
+
+fn accepts_client_at_block_concrete<T: Config>(client: &ClientAtBlock<OnlineClientAtBlock<'_, T>, T>) {
+    // ...
+}
+fn accepts_client_at_block_generic<'conf, T: Config + 'conf, C: OnlineClientAtBlockT<'conf, T>>(client: &ClientAtBlock<C, T>) {
+    // ...
+}
+```
+
 ## 0.0.6 (2025-12-01)
 
 - Add `.metadata()` on `ClientAtBlock` to expose the current metadata at some block.

--- a/historic/Cargo.toml
+++ b/historic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subxt-historic"
-version = "0.0.6"
+version = "0.0.7"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/historic/src/client.rs
+++ b/historic/src/client.rs
@@ -7,13 +7,8 @@ use crate::storage::StorageClient;
 use frame_metadata::RuntimeMetadata;
 use std::marker::PhantomData;
 
-// We keep these traits internal, so that we can mess with them later if needed,
-// and instead only the concrete types are public which wrap these trait impls.
-pub(crate) use offline_client::OfflineClientAtBlockT;
-pub(crate) use online_client::OnlineClientAtBlockT;
-
-pub use offline_client::OfflineClient;
-pub use online_client::OnlineClient;
+pub use offline_client::{OfflineClient, OfflineClientAtBlock, OfflineClientAtBlockT};
+pub use online_client::{OnlineClient, OnlineClientAtBlock, OnlineClientAtBlockT};
 
 /// This represents a client at a specific block number.
 pub struct ClientAtBlock<Client, T> {

--- a/historic/src/client/offline_client.rs
+++ b/historic/src/client/offline_client.rs
@@ -47,7 +47,6 @@ impl<T: Config> OfflineClient<T> {
 }
 
 /// This represents an offline-only client at a specific block.
-#[doc(hidden)]
 pub trait OfflineClientAtBlockT<'client, T: Config + 'client> {
     /// Get the configuration for this client.
     fn config(&self) -> &'client T;
@@ -60,7 +59,6 @@ pub trait OfflineClientAtBlockT<'client, T: Config + 'client> {
 // Dev note: this shouldn't need to be exposed unless there is some
 // need to explicitly name the ClientAAtBlock type. Rather keep it
 // private to allow changes if possible.
-#[doc(hidden)]
 pub struct OfflineClientAtBlock<'client, T: Config + 'client> {
     /// The configuration for this chain.
     config: &'client T,

--- a/historic/src/client/online_client.rs
+++ b/historic/src/client/online_client.rs
@@ -151,7 +151,6 @@ impl<T: Config> OnlineClient<T> {
 }
 
 /// This represents an online client at a specific block.
-#[doc(hidden)]
 pub trait OnlineClientAtBlockT<'client, T: Config + 'client>:
     OfflineClientAtBlockT<'client, T>
 {
@@ -164,7 +163,6 @@ pub trait OnlineClientAtBlockT<'client, T: Config + 'client>:
 // Dev note: this shouldn't need to be exposed unless there is some
 // need to explicitly name the ClientAAtBlock type. Rather keep it
 // private to allow changes if possible.
-#[doc(hidden)]
 pub struct OnlineClientAtBlock<'client, T: Config + 'client> {
     /// The configuration for this chain.
     config: &'client T,


### PR DESCRIPTION
Expose `OfflineClientAtBlock`, `OfflineClientAtBlockT`, `OnlinelientAtBlock`, `OnlineClientAtBlockT`.

This is so that you can pass the `ClientAtBlock` into functions like so:

```rust
use subxt_historic::config::Config;
use subxt_historic::client::{ ClientAtBlock, OnlineClientAtBlock, OnlineClientAtBlockT };

fn accepts_client_at_block_concrete<T: Config>(client: &ClientAtBlock<OnlineClientAtBlock<'_, T>, T>) {
    // ...
}
fn accepts_client_at_block_generic<'conf, T: Config + 'conf, C: OnlineClientAtBlockT<'conf, T>>(client: &ClientAtBlock<C, T>) {
    // ...
}
```

closes #2137 