### PR TITLE
 Add missing standard derives to core types

### DIFF
--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -23,7 +23,7 @@ pub struct ClientState<C: Config> {
 }
 
 /// Runtime version information needed to submit transactions.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Hash)]
 pub struct RuntimeVersion {
     /// Version of the runtime specification. A full-node will not attempt to use its native
     /// runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,

--- a/core/src/config/substrate.rs
+++ b/core/src/config/substrate.rs
@@ -40,7 +40,7 @@ pub type SubstrateExtrinsicParams<T> = DefaultExtrinsicParams<T>;
 pub type SubstrateExtrinsicParamsBuilder<T> = DefaultExtrinsicParamsBuilder<T>;
 
 /// A hasher (ie implements [`Hasher`]) which hashes values using the blaks2_256 algorithm.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Hash)]
 pub struct BlakeTwo256;
 
 impl Hasher for BlakeTwo256 {
@@ -59,10 +59,10 @@ impl Hasher for BlakeTwo256 {
 /// hash types, falling back to blake2_256 if the hasher information is not available.
 ///
 /// Currently this hasher supports only `BlakeTwo256` and `Keccak256` hashing methods.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct DynamicHasher256(HashType);
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 enum HashType {
     // Most chains use this:
     BlakeTwo256,
@@ -108,7 +108,7 @@ impl Hasher for DynamicHasher256 {
 
 /// A generic Substrate header type, adapted from `sp_runtime::generic::Header`.
 /// The block number and hasher can be configured to adapt this for other nodes.
-#[derive(Encode, Decode, Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+#[derive(Encode, Decode, Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SubstrateHeader<N: Copy + Into<U256> + TryFrom<U256>, H: Hasher> {
     /// The parent hash.
@@ -143,7 +143,7 @@ where
 }
 
 /// Generic header digest. From `sp_runtime::generic::digest`.
-#[derive(Encode, Decode, Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Default)]
+#[derive(Encode, Decode, Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Default)]
 pub struct Digest {
     /// A list of digest items.
     pub logs: Vec<DigestItem>,
@@ -151,7 +151,7 @@ pub struct Digest {
 
 /// Digest item that is able to encode/decode 'system' digest items and
 /// provide opaque access to other items. From `sp_runtime::generic::digest`.
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
 pub enum DigestItem {
     /// A pre-runtime digest.
     ///

--- a/core/src/config/transaction_extensions.rs
+++ b/core/src/config/transaction_extensions.rs
@@ -112,6 +112,7 @@ pub enum VerifySignatureDetails<T: Config> {
 }
 
 /// The [`CheckMetadataHash`] transaction extension.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct CheckMetadataHash {
     // Eventually we might provide or calculate the metadata hash here,
     // but for now we never provide a hash and so this is empty.
@@ -167,6 +168,7 @@ impl CheckMetadataHashMode {
 }
 
 /// The [`CheckSpecVersion`] transaction extension.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct CheckSpecVersion(u32);
 
 impl<T: Config> ExtrinsicParams<T> for CheckSpecVersion {
@@ -191,6 +193,7 @@ impl<T: Config> TransactionExtension<T> for CheckSpecVersion {
 }
 
 /// The [`CheckNonce`] transaction extension.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct CheckNonce(u64);
 
 impl<T: Config> ExtrinsicParams<T> for CheckNonce {
@@ -215,7 +218,7 @@ impl<T: Config> TransactionExtension<T> for CheckNonce {
 }
 
 /// Configure the nonce used.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Eq, PartialEq)]
 pub struct CheckNonceParams(Option<u64>);
 
 impl CheckNonceParams {
@@ -238,6 +241,7 @@ impl<T: Config> Params<T> for CheckNonceParams {
 }
 
 /// The [`CheckTxVersion`] transaction extension.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct CheckTxVersion(u32);
 
 impl<T: Config> ExtrinsicParams<T> for CheckTxVersion {
@@ -262,6 +266,7 @@ impl<T: Config> TransactionExtension<T> for CheckTxVersion {
 }
 
 /// The [`CheckGenesis`] transaction extension.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct CheckGenesis<T: Config>(HashFor<T>);
 
 impl<T: Config> ExtrinsicParams<T> for CheckGenesis<T> {
@@ -286,6 +291,7 @@ impl<T: Config> TransactionExtension<T> for CheckGenesis<T> {
 }
 
 /// The [`CheckMortality`] transaction extension.
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CheckMortality<T: Config> {
     params: CheckMortalityParamsInner<T>,
     genesis_hash: HashFor<T>,
@@ -353,8 +359,10 @@ impl<T: Config> TransactionExtension<T> for CheckMortality<T> {
 }
 
 /// Parameters to configure the [`CheckMortality`] transaction extension.
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CheckMortalityParams<T: Config>(CheckMortalityParamsInner<T>);
 
+#[derive(Clone, Debug, Eq, PartialEq)]
 enum CheckMortalityParamsInner<T: Config> {
     /// The transaction will be immortal.
     Immortal,
@@ -469,6 +477,7 @@ impl<T: Config> TransactionExtension<T> for ChargeAssetTxPayment<T> {
 }
 
 /// Parameters to configure the [`ChargeAssetTxPayment`] transaction extension.
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ChargeAssetTxPaymentParams<T: Config> {
     tip: u128,
     asset_id: Option<T::AssetId>,
@@ -546,7 +555,7 @@ impl<T: Config> TransactionExtension<T> for ChargeTransactionPayment {
 }
 
 /// Parameters to configure the [`ChargeTransactionPayment`] transaction extension.
-#[derive(Default)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Default)]
 pub struct ChargeTransactionPaymentParams {
     tip: u128,
 }

--- a/core/src/utils/account_id.rs
+++ b/core/src/utils/account_id.rs
@@ -19,6 +19,7 @@ use thiserror::Error as DeriveError;
 /// that type.
 #[derive(
     Clone,
+    Copy,
     Eq,
     PartialEq,
     Ord,
@@ -26,6 +27,7 @@ use thiserror::Error as DeriveError;
     Encode,
     Decode,
     Debug,
+    Hash,
     scale_encode::EncodeAsType,
     scale_decode::DecodeAsType,
     scale_info::TypeInfo,

--- a/core/src/utils/account_id20.rs
+++ b/core/src/utils/account_id20.rs
@@ -21,6 +21,7 @@ use thiserror::Error as DeriveError;
     Encode,
     Decode,
     Debug,
+    Hash,
     scale_encode::EncodeAsType,
     scale_decode::DecodeAsType,
     scale_info::TypeInfo,


### PR DESCRIPTION
This PR adds missing standard derives (`Hash`, `Eq`, `Copy`, `Default`) to core data structures, including `AccountId32`,`RuntimeVersion`, and various transaction extensions.

 **Key Benefits:**
-  **Collection Support:** Types like `AccountId` and`RuntimeVersion` can now be used as keys in `HashMap` and `HashSet.
-  **Ergonomics:** Adds `Copy` to small POD types (e.g., `AccountId32`), reducing the need for explicit `.clone()` calls.