### PR TITLE
subxt-historic: prep 0.0.8 release: expose type resolver that can be used with visitors

### DIFF
--- a/historic/CHANGELOG.md
+++ b/historic/CHANGELOG.md
@@ -4,6 +4,10 @@ This is separate from the Subxt changelog as subxt-historic is currently releasa
 
 Eventually this project will merge with Subxt and no longer exist, but until then it's being maintained and updated where needed.
 
+## 0.0.8 (2025-12-04)
+
+Expose `ClientAtBlock::resolver()`. This hands back a type resolver which is capable of resolving type IDs given by the `.visit()` methods on extrinsic fields and storage values. The extrinsics example has been modified to show how this can be used.
+
 ## 0.0.7 (2025-12-03)
 
 Expose `OfflineClientAtBlock`, `OfflineClientAtBlockT`, `OnlinelientAtBlock`, `OnlineClientAtBlockT`.

--- a/historic/examples/extrinsics.rs
+++ b/historic/examples/extrinsics.rs
@@ -431,7 +431,7 @@ mod value {
             // on them. here we see whether the enum type has any data attached:
             let has_data_visitor = scale_type_resolver::visitor::new((), |_, _| false)
                 .visit_variant(|_, _, variants| {
-                    for variant in variants {
+                    for mut variant in variants {
                         if variant.fields.next().is_some() {
                             return true;
                         }

--- a/historic/examples/extrinsics.rs
+++ b/historic/examples/extrinsics.rs
@@ -432,7 +432,7 @@ mod value {
             let has_data_visitor = scale_type_resolver::visitor::new((), |_, _| false)
                 .visit_variant(|_, _, variants| {
                     for variant in variants {
-                        for _ in variant.fields {
+                        if variant.fields.next().is_some() {
                             return true;
                         }
                     }

--- a/historic/src/client.rs
+++ b/historic/src/client.rs
@@ -4,6 +4,7 @@ mod online_client;
 use crate::config::Config;
 use crate::extrinsics::ExtrinsicsClient;
 use crate::storage::StorageClient;
+use crate::utils::AnyResolver;
 use frame_metadata::RuntimeMetadata;
 use std::marker::PhantomData;
 
@@ -44,5 +45,29 @@ where
     /// Return the metadata in use at this block.
     pub fn metadata(&self) -> &RuntimeMetadata {
         self.client.metadata()
+    }
+
+    /// Return something which implements [`scale_type_resolver::TypeResolver`] and
+    /// can be used in conjnction with type IDs in `.visit` methods.
+    pub fn resolver(&self) -> AnyResolver<'_, 'client> {
+        match self.client.metadata() {
+            RuntimeMetadata::V0(_)
+            | RuntimeMetadata::V1(_)
+            | RuntimeMetadata::V2(_)
+            | RuntimeMetadata::V3(_)
+            | RuntimeMetadata::V4(_)
+            | RuntimeMetadata::V5(_)
+            | RuntimeMetadata::V6(_)
+            | RuntimeMetadata::V7(_)
+            | RuntimeMetadata::V8(_)
+            | RuntimeMetadata::V9(_)
+            | RuntimeMetadata::V10(_)
+            | RuntimeMetadata::V11(_)
+            | RuntimeMetadata::V12(_)
+            | RuntimeMetadata::V13(_) => AnyResolver::B(self.client.legacy_types()),
+            RuntimeMetadata::V14(m) => AnyResolver::A(&m.types),
+            RuntimeMetadata::V15(m) => AnyResolver::A(&m.types),
+            RuntimeMetadata::V16(m) => AnyResolver::A(&m.types),
+        }
     }
 }

--- a/historic/src/extrinsics/extrinsic_call.rs
+++ b/historic/src/extrinsics/extrinsic_call.rs
@@ -54,7 +54,7 @@ impl<'extrinsics, 'atblock> ExtrinsicCall<'extrinsics, 'atblock> {
 pub struct ExtrinsicCallFields<'extrinsics, 'atblock> {
     all_bytes: &'extrinsics [u8],
     info: &'extrinsics AnyExtrinsicInfo<'atblock>,
-    resolver: AnyResolver<'atblock>,
+    resolver: AnyResolver<'atblock, 'atblock>,
 }
 
 impl<'extrinsics, 'atblock> ExtrinsicCallFields<'extrinsics, 'atblock> {
@@ -135,7 +135,7 @@ impl<'extrinsics, 'atblock> ExtrinsicCallFields<'extrinsics, 'atblock> {
 pub struct ExtrinsicCallField<'fields, 'extrinsics, 'atblock> {
     field_bytes: &'extrinsics [u8],
     info: AnyExtrinsicCallFieldInfo<'extrinsics, 'atblock>,
-    resolver: &'fields AnyResolver<'atblock>,
+    resolver: &'fields AnyResolver<'atblock, 'atblock>,
 }
 
 enum AnyExtrinsicCallFieldInfo<'extrinsics, 'atblock> {
@@ -172,7 +172,9 @@ impl<'fields, 'extrinsics, 'atblock> ExtrinsicCallField<'fields, 'extrinsics, 'a
     /// Visit the given field with a [`scale_decode::visitor::Visitor`]. This is like a lower level
     /// version of [`ExtrinsicCallField::decode_as`], as the visitor is able to preserve lifetimes
     /// and has access to more type information than is available via [`ExtrinsicCallField::decode_as`].
-    pub fn visit<V: scale_decode::visitor::Visitor<TypeResolver = AnyResolver<'atblock>>>(
+    pub fn visit<
+        V: scale_decode::visitor::Visitor<TypeResolver = AnyResolver<'atblock, 'atblock>>,
+    >(
         &self,
         visitor: V,
     ) -> Result<V::Value<'extrinsics, 'fields>, V::Error> {

--- a/historic/src/storage/storage_value.rs
+++ b/historic/src/storage/storage_value.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 pub struct StorageValue<'atblock> {
     pub(crate) info: Arc<AnyStorageInfo<'atblock>>,
     bytes: Cow<'atblock, [u8]>,
-    resolver: AnyResolver<'atblock>,
+    resolver: AnyResolver<'atblock, 'atblock>,
 }
 
 impl<'atblock> StorageValue<'atblock> {
@@ -41,7 +41,9 @@ impl<'atblock> StorageValue<'atblock> {
     /// Visit the given field with a [`scale_decode::visitor::Visitor`]. This is like a lower level
     /// version of [`StorageValue::decode_as`], as the visitor is able to preserve lifetimes
     /// and has access to more type information than is available via [`StorageValue::decode_as`].
-    pub fn visit<V: scale_decode::visitor::Visitor<TypeResolver = AnyResolver<'atblock>>>(
+    pub fn visit<
+        V: scale_decode::visitor::Visitor<TypeResolver = AnyResolver<'atblock, 'atblock>>,
+    >(
         &self,
         visitor: V,
     ) -> Result<V::Value<'_, '_>, V::Error> {

--- a/historic/src/utils/any_resolver.rs
+++ b/historic/src/utils/any_resolver.rs
@@ -3,10 +3,8 @@ use scale_info_legacy::LookupName;
 use scale_type_resolver::ResolvedTypeVisitor;
 
 /// A type resolver which could either be for modern or historic resolving.
-pub type AnyResolver<'resolver> = Either<
-    &'resolver scale_info::PortableRegistry,
-    &'resolver scale_info_legacy::TypeRegistrySet<'resolver>,
->;
+pub type AnyResolver<'a, 'b> =
+    Either<&'a scale_info::PortableRegistry, &'a scale_info_legacy::TypeRegistrySet<'b>>;
 
 /// A type ID which is either a modern or historic ID.
 pub type AnyTypeId = Either<u32, scale_info_legacy::LookupName>;
@@ -60,7 +58,7 @@ pub enum AnyResolverError {
     ScaleInfoLegacy(scale_info_legacy::type_registry::TypeRegistryResolveError),
 }
 
-impl<'resolver> scale_type_resolver::TypeResolver for AnyResolver<'resolver> {
+impl<'a, 'b> scale_type_resolver::TypeResolver for AnyResolver<'a, 'b> {
     type TypeId = AnyTypeId;
     type Error = AnyResolverError;
 

--- a/testing/integration-tests/src/full_client/codegen/documentation.rs
+++ b/testing/integration-tests/src/full_client/codegen/documentation.rs
@@ -99,12 +99,18 @@ fn interface_docs(should_gen_docs: bool) -> Vec<String> {
 
 #[test]
 fn check_documentation() {
-    // Inspect metadata recursively and obtain all associated documentation.
+    // Inspect metadata and obtain all associated documentation.
     let raw_docs = metadata_docs();
     // Obtain documentation from the generated API.
     let runtime_docs = interface_docs(true);
 
     for raw in raw_docs.iter() {
+        if raw.contains(|c: char| !c.is_ascii()) {
+            // Ignore lines containing on-ascii chars; they are encoded currently
+            // as "\u{nn}" which doesn't match their input which is the raw non-ascii
+            // char.
+            continue;
+        }
         assert!(
             runtime_docs.contains(raw),
             "Documentation not present in runtime API: {raw}"
@@ -114,7 +120,7 @@ fn check_documentation() {
 
 #[test]
 fn check_no_documentation() {
-    // Inspect metadata recursively and obtain all associated documentation.
+    // Inspect metadata and obtain all associated documentation.
     let raw_docs = metadata_docs();
     // Obtain documentation from the generated API.
     let runtime_docs = interface_docs(false);


### PR DESCRIPTION
Expose `ClientAtBlock::resolver()`. This hands back a type resolver which is capable of resolving type IDs given by the `.visit()` methods on extrinsic fields and storage values. The extrinsics example has been modified to show how this can be used.