### PR TITLE
Allow passing $OUT_DIR in the runtime_metadata_path attribute

### DIFF
--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -232,10 +232,20 @@ fn fetch_metadata(args: &RuntimeMetadataArgs) -> Result<subxt_codegen::Metadata,
                 )
             }
 
-            let root = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".into());
-            let root_path = std::path::Path::new(&root);
-            let path = root_path.join(rest_of_path);
-            subxt_utils_fetchmetadata::from_file_blocking(&path)
+            // Replace $OUT_DIR with the actual OUT_DIR environment variable
+            let expanded_path = if rest_of_path.contains("$OUT_DIR") {
+                let out_dir = std::env::var("OUT_DIR").unwrap_or_else(|_| {
+                    abort_call_site!("$OUT_DIR is used in runtime_metadata_path but OUT_DIR environment variable is not set")
+                });
+                rest_of_path.replace("$OUT_DIR", &out_dir)
+            } else {
+                let root = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".into());
+                let root_path = std::path::Path::new(&root);
+                root_path.join(rest_of_path).to_string_lossy().to_string()
+            };
+
+            let path = std::path::Path::new(&expanded_path);
+            subxt_utils_fetchmetadata::from_file_blocking(path)
                 .and_then(|b| subxt_codegen::Metadata::decode(&mut &*b).map_err(Into::into))
                 .map_err(|e| CodegenError::Other(e.to_string()).into_compile_error())?
         }

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -237,14 +237,13 @@ fn fetch_metadata(args: &RuntimeMetadataArgs) -> Result<subxt_codegen::Metadata,
                 let out_dir = std::env::var("OUT_DIR").unwrap_or_else(|_| {
                     abort_call_site!("$OUT_DIR is used in runtime_metadata_path but OUT_DIR environment variable is not set")
                 });
-                rest_of_path.replace("$OUT_DIR", &out_dir)
+                std::path::Path::new(&rest_of_path.replace("$OUT_DIR", &out_dir))
             } else {
                 let root = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".into());
                 let root_path = std::path::Path::new(&root);
-                root_path.join(rest_of_path).to_string_lossy().to_string()
+                root_path.join(rest_of_path)
             };
 
-            let path = std::path::Path::new(&expanded_path);
             subxt_utils_fetchmetadata::from_file_blocking(path)
                 .and_then(|b| subxt_codegen::Metadata::decode(&mut &*b).map_err(Into::into))
                 .map_err(|e| CodegenError::Other(e.to_string()).into_compile_error())?

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -233,18 +233,18 @@ fn fetch_metadata(args: &RuntimeMetadataArgs) -> Result<subxt_codegen::Metadata,
             }
 
             // Replace $OUT_DIR with the actual OUT_DIR environment variable
-            let expanded_path = if rest_of_path.contains("$OUT_DIR") {
+            let path = if rest_of_path.contains("$OUT_DIR") {
                 let out_dir = std::env::var("OUT_DIR").unwrap_or_else(|_| {
                     abort_call_site!("$OUT_DIR is used in runtime_metadata_path but OUT_DIR environment variable is not set")
                 });
-                std::path::Path::new(&rest_of_path.replace("$OUT_DIR", &out_dir))
+                std::path::Path::new(&rest_of_path.replace("$OUT_DIR", &out_dir)).into()
             } else {
                 let root = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".into());
                 let root_path = std::path::Path::new(&root);
                 root_path.join(rest_of_path)
             };
 
-            subxt_utils_fetchmetadata::from_file_blocking(path)
+            subxt_utils_fetchmetadata::from_file_blocking(&path)
                 .and_then(|b| subxt_codegen::Metadata::decode(&mut &*b).map_err(Into::into))
                 .map_err(|e| CodegenError::Other(e.to_string()).into_compile_error())?
         }

--- a/subxt/src/lib.rs
+++ b/subxt/src/lib.rs
@@ -153,7 +153,7 @@ pub mod ext {
 ///
 /// You can use the `$OUT_DIR` placeholder in the path to reference metadata generated at build time:
 ///
-/// ```rust,no_run
+/// ```rust,ignore
 /// #[subxt::subxt(
 ///     runtime_metadata_path = "$OUT_DIR/metadata.scale",
 /// )]
@@ -175,7 +175,7 @@ pub mod ext {
 ///
 /// You can also use the `$OUT_DIR` placeholder in the path to reference WASM files generated at build time:
 ///
-/// ```rust,no_run
+/// ```rust,ignore
 /// #[subxt::subxt(
 ///     runtime_path = "$OUT_DIR/runtime.wasm",
 /// )]

--- a/subxt/src/lib.rs
+++ b/subxt/src/lib.rs
@@ -151,6 +151,15 @@ pub mod ext {
 /// mod polkadot {}
 /// ```
 ///
+/// You can use the `$OUT_DIR` placeholder in the path to reference metadata generated at build time:
+///
+/// ```rust,no_run
+/// #[subxt::subxt(
+///     runtime_metadata_path = "$OUT_DIR/metadata.scale",
+/// )]
+/// mod polkadot {}
+/// ```
+///
 /// ## Using a WASM runtime via `runtime_path = "..."`
 ///
 /// This requires the `runtime-wasm-path` feature flag.
@@ -160,6 +169,15 @@ pub mod ext {
 /// ```rust,no_run
 /// #[subxt::subxt(
 ///     runtime_path = "../artifacts/westend_runtime.wasm",
+/// )]
+/// mod polkadot {}
+/// ```
+///
+/// You can also use the `$OUT_DIR` placeholder in the path to reference WASM files generated at build time:
+///
+/// ```rust,no_run
+/// #[subxt::subxt(
+///     runtime_path = "$OUT_DIR/runtime.wasm",
 /// )]
 /// mod polkadot {}
 /// ```


### PR DESCRIPTION
the `runtime_metadata_path` attribute requires a string literal. 
This makes it impossible to generate the runtime metadata at build time and place it in `OUT_DIR`

This PR extends the macro to recognize the `$OUT_DIR` placeholder inside `runtime_metadata_path` and replaces it with the actual `OUT_DIR` environment value at macro expansion time. 

This allows users to write:

```rust

runtime_metadata_path = "$OUT_DIR/md.scale"
```
