### PR TITLE
Update to frame-decode 0.17.1 and update CHANGELOG with frame-decode updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,12 @@ The rules for when to use `PolkadotConfig` and `SubstrateConfig` remain the same
 
 See the docs for `PolkadotConfig` and `SubstrateConfig` for more. One example to be aware of is that if you want to work with historic blocks with `SubstrateConfig`,  you'll need to instantiate it yourself and provide historic type information before passing it to `OnlineClient` or `OfflineClient`.
 
+#### Configuration: `ExtrinsicParams`
+
+Aside from the new historic types support, a notable change to the configuration has been the simplification of transaction extensions, **previously called `ExtrinsicParams`** in our `Config`. **Now, the type is called `TransactionExtensions`** and the supporting traits have been simplified and named more appropriately (just `TransactionExtensions` and `TransactionExtension`), moving to rely more on `frame-decode` for the core logic. For any users that implement their own transaction extensions, migrating to the new traits is straightforward and I would encourage you to look at how the built-in transaction extensions are implemented for guidance here.
+
+See (see [#2177](https://github.com/paritytech/subxt/pull/2177)) for more details around this change.
+
 ### Working at specific blocks
 
 **Before**
@@ -218,6 +224,7 @@ let events = api
 ```
 
 Notes:
+- `SignableTransaction::signer_payload`, `SignableTransaction::sign` and `SignableTransaction::sign_with_account_and_signature` now may return an error (which previously would have led to harder to diagnose issues), and the `SignableTransaction` type now has a lifetime (see [#2177](https://github.com/paritytech/subxt/pull/2177)).
 - We now use `transactions` instead of `tx` everywhere to align better with other API names, but continue to provide `tx` as a shorthand.
 - The word `partial` is changed to `signable` in transaction APIs. "partial" was always a confusing name, and "signable" makes it much clearer what is being created; something that can be signed.
   - `tx().create_partial_offline(..)` => `tx().create_signable_offline(..)`
@@ -461,6 +468,7 @@ A list of the main change PRs follows:
 
 ### Changed
 
+- Upgrade to frame-decode 0.17: remove extrinsic encode logic and use from there ([#2177](https://github.com/paritytech/subxt/pull/2177))
 - [v0.50.0] Implement support for historic blocks in Subxt ([#2131](https://github.com/paritytech/subxt/pull/2131))
 - subxt-historic: 0.0.8 release: expose type resolver that can be used with visitors ([#2140](https://github.com/paritytech/subxt/pull/2140))
 - subxt-historic: 0.0.7 release: expose ClientAtBlock bits ([#2138](https://github.com/paritytech/subxt/pull/2138))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1959,9 +1959,9 @@ dependencies = [
 
 [[package]]
 name = "frame-decode"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea4ae9db992bb3d089885a4fc17d06ffbd6918d7434fd192a20aba02d554bff"
+checksum = "42ea4168fb6383e5abb84b5316804cb463ba2d6c9fa89981792e2b88c209192a"
 dependencies = [
  "frame-metadata 23.0.0",
  "parity-scale-codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ darling = "0.20.10"
 derive-where = "1.2.7"
 either = { version = "1.13.0", default-features = false }
 finito = { version = "0.1.0", default-features = false }
-frame-decode = { version = "0.17.0", default-features = false }
+frame-decode = { version = "0.17.1", default-features = false }
 frame-metadata = { version = "23.0.0", default-features = false }
 futures = { version = "0.3.31", default-features = false, features = ["std"] }
 getrandom = { version = "0.2", default-features = false }


### PR DESCRIPTION
Add mention of the new `TransacitonExtension` bits and fallible transaction signing to the 0.50 CHANGELOG entry, and bump to 0.17.1 just to bring in some tweaked historic Kusama types.