### PR TITLE
[v0.44.x] Prep to release 0.44.3: Rename the VerifySignature Transaction Extension to VerifyMultiSignature to align with Polkadot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.44.3] - 2026-03-12
+
+Fix support for the `VerifyMultiSignature` transaction extension. 
+
 ## [0.44.2] - 2026-01-09
 
 This manually cherry-picks https://github.com/paritytech/subxt/pull/2142 onto the 0.44 branch to allow using $OUT_DIR in a couple of Subxt macro attributes.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,7 +464,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "artifacts"
-version = "0.44.2"
+version = "0.44.3"
 dependencies = [
  "substrate-runner",
 ]
@@ -2110,7 +2110,7 @@ dependencies = [
 
 [[package]]
 name = "generate-custom-metadata"
-version = "0.44.2"
+version = "0.44.3"
 dependencies = [
  "frame-metadata 23.0.0",
  "parity-scale-codec",
@@ -2731,7 +2731,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.44.2"
+version = "0.44.3"
 dependencies = [
  "assert_matches",
  "cfg_aliases",
@@ -5575,7 +5575,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-runner"
-version = "0.44.2"
+version = "0.44.3"
 
 [[package]]
 name = "subtle"
@@ -5585,7 +5585,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "subxt"
-version = "0.44.2"
+version = "0.44.3"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -5630,7 +5630,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-cli"
-version = "0.44.2"
+version = "0.44.3"
 dependencies = [
  "clap",
  "color-eyre",
@@ -5662,7 +5662,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-codegen"
-version = "0.44.2"
+version = "0.44.3"
 dependencies = [
  "frame-metadata 23.0.0",
  "getrandom 0.2.16",
@@ -5679,7 +5679,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-core"
-version = "0.44.2"
+version = "0.44.3"
 dependencies = [
  "assert_matches",
  "base58",
@@ -5735,7 +5735,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-lightclient"
-version = "0.44.2"
+version = "0.44.3"
 dependencies = [
  "futures",
  "futures-timer",
@@ -5760,7 +5760,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.44.2"
+version = "0.44.3"
 dependencies = [
  "darling",
  "parity-scale-codec",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-metadata"
-version = "0.44.2"
+version = "0.44.3"
 dependencies = [
  "bitvec",
  "criterion",
@@ -5796,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-rpcs"
-version = "0.44.2"
+version = "0.44.3"
 dependencies = [
  "derive-where",
  "finito",
@@ -5825,7 +5825,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-signer"
-version = "0.44.2"
+version = "0.44.3"
 dependencies = [
  "base64 0.22.1",
  "bip32",
@@ -5858,7 +5858,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-test-macro"
-version = "0.44.2"
+version = "0.44.3"
 dependencies = [
  "quote",
  "syn 2.0.101",
@@ -5866,7 +5866,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-utils-fetchmetadata"
-version = "0.44.2"
+version = "0.44.3"
 dependencies = [
  "frame-metadata 23.0.0",
  "hex",
@@ -5879,7 +5879,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-utils-stripmetadata"
-version = "0.44.2"
+version = "0.44.3"
 dependencies = [
  "either",
  "frame-metadata 23.0.0",
@@ -5962,7 +5962,7 @@ dependencies = [
 
 [[package]]
 name = "test-runtime"
-version = "0.44.2"
+version = "0.44.3"
 dependencies = [
  "hex",
  "impl-serde",
@@ -6390,7 +6390,7 @@ checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "ui-tests"
-version = "0.44.2"
+version = "0.44.3"
 dependencies = [
  "frame-metadata 23.0.0",
  "generate-custom-metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ resolver = "2"
 [workspace.package]
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2024"
-version = "0.44.2"
+version = "0.44.3"
 rust-version = "1.85.0"
 license = "Apache-2.0 OR GPL-3.0"
 repository = "https://github.com/paritytech/subxt"
@@ -156,16 +156,16 @@ sp-state-machine = { version = "0.45.0", default-features = false }
 sp-runtime = { version = "41.1.0", default-features = false }
 
 # Subxt workspace crates:
-subxt = { version = "0.44.2", path = "subxt", default-features = false }
-subxt-core = { version = "0.44.2", path = "core", default-features = false }
-subxt-macro = { version = "0.44.2", path = "macro" }
-subxt-metadata = { version = "0.44.2", path = "metadata", default-features = false }
-subxt-codegen = { version = "0.44.2", path = "codegen" }
-subxt-signer = { version = "0.44.2", path = "signer", default-features = false }
-subxt-rpcs = { version = "0.44.2", path = "rpcs", default-features = false }
-subxt-lightclient = { version = "0.44.2", path = "lightclient", default-features = false }
-subxt-utils-fetchmetadata = { version = "0.44.2", path = "utils/fetch-metadata", default-features = false }
-subxt-utils-stripmetadata = { version = "0.44.2", path = "utils/strip-metadata", default-features = false }
+subxt = { version = "0.44.3", path = "subxt", default-features = false }
+subxt-core = { version = "0.44.3", path = "core", default-features = false }
+subxt-macro = { version = "0.44.3", path = "macro" }
+subxt-metadata = { version = "0.44.3", path = "metadata", default-features = false }
+subxt-codegen = { version = "0.44.3", path = "codegen" }
+subxt-signer = { version = "0.44.3", path = "signer", default-features = false }
+subxt-rpcs = { version = "0.44.3", path = "rpcs", default-features = false }
+subxt-lightclient = { version = "0.44.3", path = "lightclient", default-features = false }
+subxt-utils-fetchmetadata = { version = "0.44.3", path = "utils/fetch-metadata", default-features = false }
+subxt-utils-stripmetadata = { version = "0.44.3", path = "utils/strip-metadata", default-features = false }
 test-runtime = { path = "testing/test-runtime" }
 substrate-runner = { path = "testing/substrate-runner" }
 

--- a/core/src/config/transaction_extensions.rs
+++ b/core/src/config/transaction_extensions.rs
@@ -92,7 +92,7 @@ impl<T: Config> ExtrinsicParamsEncoder for VerifySignature<T> {
 impl<T: Config> TransactionExtension<T> for VerifySignature<T> {
     type Decoded = Static<VerifySignatureDetails<T>>;
     fn matches(identifier: &str, _type_id: u32, _types: &PortableRegistry) -> bool {
-        identifier == "VerifySignature"
+        identifier == "VerifyMultiSignature"
     }
 }
 

--- a/core/src/config/transaction_extensions.rs
+++ b/core/src/config/transaction_extensions.rs
@@ -92,7 +92,9 @@ impl<T: Config> ExtrinsicParamsEncoder for VerifySignature<T> {
 impl<T: Config> TransactionExtension<T> for VerifySignature<T> {
     type Decoded = Static<VerifySignatureDetails<T>>;
     fn matches(identifier: &str, _type_id: u32, _types: &PortableRegistry) -> bool {
-        identifier == "VerifyMultiSignature"
+        // The name is expected to be VerifyMultiSignature, but to ensure 100% backward
+        // compatibility, also accept VerifySignature.
+        identifier == "VerifyMultiSignature" || identifier == "verifySignature"
     }
 }
 

--- a/examples/ffi-example/Cargo.lock
+++ b/examples/ffi-example/Cargo.lock
@@ -2686,7 +2686,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "subxt"
-version = "0.44.2"
+version = "0.44.3"
 dependencies = [
  "async-trait",
  "derive-where",
@@ -2721,7 +2721,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-codegen"
-version = "0.44.2"
+version = "0.44.3"
 dependencies = [
  "heck",
  "parity-scale-codec",
@@ -2736,7 +2736,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-core"
-version = "0.44.2"
+version = "0.44.3"
 dependencies = [
  "base58",
  "blake2",
@@ -2774,7 +2774,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-lightclient"
-version = "0.44.2"
+version = "0.44.3"
 dependencies = [
  "futures",
  "futures-util",
@@ -2789,7 +2789,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.44.2"
+version = "0.44.3"
 dependencies = [
  "darling",
  "parity-scale-codec",
@@ -2804,7 +2804,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-metadata"
-version = "0.44.2"
+version = "0.44.3"
 dependencies = [
  "frame-decode",
  "frame-metadata",
@@ -2817,7 +2817,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-rpcs"
-version = "0.44.2"
+version = "0.44.3"
 dependencies = [
  "derive-where",
  "frame-metadata",
@@ -2839,7 +2839,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-signer"
-version = "0.44.2"
+version = "0.44.3"
 dependencies = [
  "base64",
  "bip39",
@@ -2865,7 +2865,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-utils-fetchmetadata"
-version = "0.44.2"
+version = "0.44.3"
 dependencies = [
  "hex",
  "parity-scale-codec",

--- a/examples/parachain-example/Cargo.lock
+++ b/examples/parachain-example/Cargo.lock
@@ -2757,7 +2757,7 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "subxt"
-version = "0.44.2"
+version = "0.44.3"
 dependencies = [
  "async-trait",
  "derive-where",
@@ -2792,7 +2792,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-codegen"
-version = "0.44.2"
+version = "0.44.3"
 dependencies = [
  "heck",
  "parity-scale-codec",
@@ -2807,7 +2807,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-core"
-version = "0.44.2"
+version = "0.44.3"
 dependencies = [
  "base58",
  "blake2",
@@ -2835,7 +2835,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-lightclient"
-version = "0.44.2"
+version = "0.44.3"
 dependencies = [
  "futures",
  "futures-util",
@@ -2850,7 +2850,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.44.2"
+version = "0.44.3"
 dependencies = [
  "darling",
  "parity-scale-codec",
@@ -2865,7 +2865,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-metadata"
-version = "0.44.2"
+version = "0.44.3"
 dependencies = [
  "frame-decode",
  "frame-metadata",
@@ -2878,7 +2878,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-rpcs"
-version = "0.44.2"
+version = "0.44.3"
 dependencies = [
  "derive-where",
  "frame-metadata",
@@ -2900,7 +2900,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-signer"
-version = "0.44.2"
+version = "0.44.3"
 dependencies = [
  "base64 0.22.1",
  "bip39",
@@ -2926,7 +2926,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-utils-fetchmetadata"
-version = "0.44.2"
+version = "0.44.3"
 dependencies = [
  "hex",
  "parity-scale-codec",

--- a/examples/wasm-example/Cargo.lock
+++ b/examples/wasm-example/Cargo.lock
@@ -2452,7 +2452,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "subxt"
-version = "0.44.2"
+version = "0.44.3"
 dependencies = [
  "async-trait",
  "derive-where",
@@ -2486,7 +2486,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-codegen"
-version = "0.44.2"
+version = "0.44.3"
 dependencies = [
  "getrandom",
  "heck",
@@ -2502,7 +2502,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-core"
-version = "0.44.2"
+version = "0.44.3"
 dependencies = [
  "base58",
  "blake2",
@@ -2530,7 +2530,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-lightclient"
-version = "0.44.2"
+version = "0.44.3"
 dependencies = [
  "futures",
  "futures-timer",
@@ -2555,7 +2555,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.44.2"
+version = "0.44.3"
 dependencies = [
  "darling",
  "parity-scale-codec",
@@ -2570,7 +2570,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-metadata"
-version = "0.44.2"
+version = "0.44.3"
 dependencies = [
  "frame-decode",
  "frame-metadata",
@@ -2583,7 +2583,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-rpcs"
-version = "0.44.2"
+version = "0.44.3"
 dependencies = [
  "derive-where",
  "finito",
@@ -2608,7 +2608,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-utils-fetchmetadata"
-version = "0.44.2"
+version = "0.44.3"
 dependencies = [
  "hex",
  "parity-scale-codec",


### PR DESCRIPTION
Looking at the code now, it looiks like this extension was never called `VerifySignature` in the first place, so this is a bug fix rather than a breaking change.