### PR TITLE
Rename the VerifySignature Transaction Extension to VerifyMultiSignature to align with Polkadot

### DIFF
--- a/subxt/src/config/transaction_extensions.rs
+++ b/subxt/src/config/transaction_extensions.rs
@@ -51,7 +51,7 @@ impl<T: Config> TransactionExtension<T> for VerifySignature<T> {
 impl<T: Config> frame_decode::extrinsics::TransactionExtension<PortableRegistry>
     for VerifySignature<T>
 {
-    const NAME: &str = "VerifySignature";
+    const NAME: &str = "VerifyMultiSignature";
 
     fn encode_value_to(
         &self,


### PR DESCRIPTION
The extension was never called VerifySignature but the struct name is VerifySignature, so this was probably just a mistake in the first place. Fix the naming so that it is used as needed for V5 extrinsics.