### PR TITLE
Align parachain example with Asset Hub terminology

### DIFF
--- a/examples/parachain-example/README.md
+++ b/examples/parachain-example/README.md
@@ -1,7 +1,7 @@
 # parachain-example
 
-This example showcases working with Subxt and Zombienet to try out connecting to a locally deployed parachain, here
-["Statemint"](https://parachains.info/details/statemint), also known as "Asset Hub".
+This example showcases working with Subxt and Zombienet to try out connecting to a locally
+deployed Asset Hub parachain.
 
 ## Running the example
 
@@ -66,7 +66,8 @@ To run our example code.
 
 ## Dev notes
 
-We can obtain the metadata for Statemint via the [subxt cli](https://crates.io/crates/subxt-cli) tool, like so:
+We can obtain the metadata for Asset Hub via the [subxt cli](https://crates.io/crates/subxt-cli)
+tool, like so:
 
 ```txt
 subxt metadata  --url wss://polkadot-asset-hub-rpc.polkadot.io:443 > statemint_metadata.scale

--- a/examples/parachain-example/src/main.rs
+++ b/examples/parachain-example/src/main.rs
@@ -5,11 +5,11 @@ use subxt::{
 use subxt_signer::sr25519::dev::{self};
 
 #[subxt::subxt(runtime_metadata_path = "statemint_metadata.scale")]
-pub mod statemint {}
+pub mod asset_hub {}
 
 // PolkadotConfig or SubstrateConfig will suffice for this example at the moment,
 // but PolkadotConfig is a little more correct, having the right `Address` type.
-type StatemintConfig = PolkadotConfig;
+type AssetHubConfig = PolkadotConfig;
 
 #[tokio::main]
 pub async fn main() {
@@ -20,7 +20,7 @@ pub async fn main() {
 
 async fn run() -> Result<(), Box<dyn std::error::Error>> {
     // (the port 42069 is specified in the asset-hub-zombienet.toml)
-    let api = OnlineClient::<StatemintConfig>::from_url("ws://127.0.0.1:42069").await?;
+    let api = OnlineClient::<AssetHubConfig>::from_url("ws://127.0.0.1:42069").await?;
     println!("Connection with parachain established.");
 
     let alice: MultiAddress<AccountId32, ()> = dev::alice().public_key().into();
@@ -30,7 +30,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     const NTF_ID: u32 = 234;
 
     // create a collection with id `12`
-    let collection_creation_tx = statemint::tx()
+    let collection_creation_tx = asset_hub::tx()
         .uniques()
         .create(COLLECTION_ID, alice.clone());
     let _collection_creation_events = api
@@ -47,7 +47,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     println!("Collection created.");
 
     // create an nft in that collection with id `234`
-    let nft_creation_tx = statemint::tx()
+    let nft_creation_tx = asset_hub::tx()
         .uniques()
         .mint(COLLECTION_ID, NTF_ID, alice.clone());
     let _nft_creation_events = api
@@ -64,7 +64,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     println!("NFT created.");
 
     // check in storage, that alice is the official owner of the NFT:
-    let nft_owner_storage_query = statemint::storage().uniques().asset();
+    let nft_owner_storage_query = asset_hub::storage().uniques().asset();
     let nft_storage_details = api
         .at_current_block()
         .await?


### PR DESCRIPTION
## Summary

Align the larger `parachain-example` with the Asset Hub terminology already used elsewhere in the repo.

This keeps the example behavior unchanged and only updates the stale `Statemint` naming in:

- `examples/parachain-example/README.md`
- `examples/parachain-example/src/main.rs`

## What changed

- update the README narrative to refer directly to Asset Hub
- rename the generated module usage from `statemint` to `asset_hub`
- rename `StatemintConfig` to `AssetHubConfig`

## What did not change

- no example logic changes
- no API changes
- no config changes
- no metadata file rename in this PR

I left `statemint_metadata.scale` as-is to keep the first pass narrow and avoid file-move churn.

## Verification

- `cargo check --manifest-path examples/parachain-example/Cargo.toml`
