### PR TITLE
Add sudo examples for inspecting inner call results

### DIFF
--- a/testing/integration-tests/src/full_client/frame/sudo.rs
+++ b/testing/integration-tests/src/full_client/frame/sudo.rs
@@ -16,7 +16,7 @@ type Call = runtime_types::kitchensink_runtime::RuntimeCall;
 type BalancesCall = runtime_types::pallet_balances::pallet::Call;
 
 #[subxt_test]
-async fn test_sudo() -> Result<(), subxt::Error> {
+async fn test_sudo_reports_wrapped_call_failure() -> Result<(), subxt::Error> {
     let ctx = test_context().await;
     let api = ctx.client();
 
@@ -35,14 +35,53 @@ async fn test_sudo() -> Result<(), subxt::Error> {
         .create_signed(&tx, &alice, Default::default())
         .await?;
 
-    let found_event = signed_extrinsic
+    // The sudo extrinsic itself succeeds, but the wrapped call still needs to
+    // be inspected via the `Sudid` event. `transfer_allow_death` expects a
+    // signed origin, so under `Root` we should see the inner call fail.
+    let sudo_event = signed_extrinsic
         .submit_and_watch()
         .await?
         .wait_for_finalized_success()
         .await?
-        .has::<sudo::events::Sudid>();
+        .find_first::<sudo::events::Sudid>()?
+        .expect("Expected sudo::events::Sudid");
 
-    assert!(found_event);
+    assert!(matches!(
+        sudo_event.sudo_result,
+        Err(runtime_types::sp_runtime::DispatchError::BadOrigin)
+    ));
+    Ok(())
+}
+
+#[subxt_test]
+async fn test_sudo_reports_wrapped_call_success() -> Result<(), subxt::Error> {
+    let ctx = test_context().await;
+    let api = ctx.client();
+
+    let alice = dev::alice();
+    let bob = dev::bob().public_key().into();
+
+    let call = Call::Balances(BalancesCall::force_set_balance {
+        who: bob,
+        new_free: 10_000,
+    });
+    let tx = node_runtime::tx().sudo().sudo(call);
+
+    let signed_extrinsic = api
+        .tx()
+        .await?
+        .create_signed(&tx, &alice, Default::default())
+        .await?;
+
+    let sudo_event = signed_extrinsic
+        .submit_and_watch()
+        .await?
+        .wait_for_finalized_success()
+        .await?
+        .find_first::<sudo::events::Sudid>()?
+        .expect("Expected sudo::events::Sudid");
+
+    assert!(sudo_event.sudo_result.is_ok());
     Ok(())
 }
 
@@ -54,9 +93,9 @@ async fn test_sudo_unchecked_weight() -> Result<(), subxt::Error> {
     let alice = dev::alice();
     let bob = dev::bob().public_key().into();
 
-    let call = Call::Balances(BalancesCall::transfer_allow_death {
-        dest: bob,
-        value: 10_000,
+    let call = Call::Balances(BalancesCall::force_set_balance {
+        who: bob,
+        new_free: 10_000,
     });
     let tx = node_runtime::tx().sudo().sudo_unchecked_weight(
         call,
@@ -72,13 +111,14 @@ async fn test_sudo_unchecked_weight() -> Result<(), subxt::Error> {
         .create_signed(&tx, &alice, Default::default())
         .await?;
 
-    let found_event = signed_extrinsic
+    let sudo_event = signed_extrinsic
         .submit_and_watch()
         .await?
         .wait_for_finalized_success()
         .await?
-        .has::<sudo::events::Sudid>();
+        .find_first::<sudo::events::Sudid>()?
+        .expect("Expected sudo::events::Sudid");
 
-    assert!(found_event);
+    assert!(sudo_event.sudo_result.is_ok());
     Ok(())
 }


### PR DESCRIPTION
## Summary

- make the sudo integration tests inspect the inner `Sudid` result instead of only checking outer extrinsic success
- add a failing wrapped-call example that shows why `Sudid` must be decoded
- add successful `sudo` and `sudo_unchecked_weight` examples using a root-only balances call

## Why

Issue #1854 asks for an example of how to get the result of a wrapped sudo call. The existing tests only proved that the outer sudo extrinsic finalized, which can hide inner-call failure. This patch turns the sudo tests into concrete examples of reading `sudo_result` from the `Sudid` event.

## Notes

- I could not run the full integration test suite locally because `testing/test-runtime` requires a local `substrate` or `substrate-node` binary on PATH.
- `cargo fmt --all` was run.

Closes #1854
