### PR TITLE
Fix CI node build by updating rust toolchain

### DIFF
--- a/.github/workflows/build-nodes.yml
+++ b/.github/workflows/build-nodes.yml
@@ -20,11 +20,11 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler curl gcc make clang cmake llvm-dev libclang-dev
 
-      - name: Install Rust v1.88 toolchain
+      - name: Install Rust stable toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.88
+          toolchain: stable
           components: rust-src
           target: wasm32-unknown-unknown
 


### PR DESCRIPTION
Build node job fails all the time because it has outdated rust version:
https://github.com/paritytech/subxt/actions/runs/24757844020

This blocks CI on other PRs, e.g. https://github.com/paritytech/subxt/pull/2217