### PR TITLE
Fix: `SubstrateConfigBuilder::set_genesis_hash` is a no-op

### DIFF
--- a/subxt/src/config/substrate.rs
+++ b/subxt/src/config/substrate.rs
@@ -4,7 +4,9 @@
 
 //! Substrate specific configuration
 
-use super::{Config, DefaultExtrinsicParamsBuilder, DefaultTransactionExtensions, Hasher, Header};
+use super::{
+    Config, DefaultExtrinsicParamsBuilder, DefaultTransactionExtensions, HashFor, Hasher, Header,
+};
 use crate::config::Hash;
 use crate::metadata::{ArcMetadata, Metadata};
 use crate::utils::RangeMap;
@@ -193,7 +195,7 @@ impl Config for SubstrateConfig {
             .cloned()
     }
 
-    fn genesis_hash(&self) -> Option<H256> {
+    fn genesis_hash(&self) -> Option<HashFor<Self>> {
         self.inner.genesis_hash
     }
 
@@ -569,7 +571,10 @@ mod test {
     fn builder_propagates_genesis_hash() {
         let hash = H256::from([42u8; 32]);
         let config = SubstrateConfig::builder().set_genesis_hash(hash).build();
-        assert_eq!(<SubstrateConfig as Config>::genesis_hash(&config), Some(hash));
+        assert_eq!(
+            <SubstrateConfig as Config>::genesis_hash(&config),
+            Some(hash)
+        );
     }
 
     #[test]

--- a/subxt/src/config/substrate.rs
+++ b/subxt/src/config/substrate.rs
@@ -102,6 +102,7 @@ impl SubstrateConfigBuilder {
                 legacy_types: self.legacy_types,
                 spec_and_transaction_version_for_block_number: self
                     .spec_and_transaction_version_for_block_number,
+                genesis_hash: self.genesis_hash,
                 metadata_for_spec_version: self.metadata_for_spec_version,
             }),
         }
@@ -132,6 +133,7 @@ pub struct SubstrateConfig {
 struct SubstrateConfigInner {
     legacy_types: Option<ChainTypeRegistry>,
     spec_and_transaction_version_for_block_number: RangeMap<u64, (u32, u32)>,
+    genesis_hash: Option<H256>,
     metadata_for_spec_version: RwLock<HashMap<u32, ArcMetadata>>,
 }
 
@@ -189,6 +191,10 @@ impl Config for SubstrateConfig {
             .unwrap()
             .get(&spec_version)
             .cloned()
+    }
+
+    fn genesis_hash(&self) -> Option<H256> {
+        self.inner.genesis_hash
     }
 
     fn set_metadata_for_spec_version(&self, spec_version: u32, metadata: ArcMetadata) {
@@ -557,5 +563,18 @@ mod test {
         let header: SubstrateHeader<H256> =
             serde_json::from_str(numeric_block_number_json).expect("valid block header");
         assert_eq!(header.number(), 4);
+    }
+
+    #[test]
+    fn builder_propagates_genesis_hash() {
+        let hash = H256::from([42u8; 32]);
+        let config = SubstrateConfig::builder().set_genesis_hash(hash).build();
+        assert_eq!(<SubstrateConfig as Config>::genesis_hash(&config), Some(hash));
+    }
+
+    #[test]
+    fn builder_without_genesis_hash_returns_none() {
+        let config = SubstrateConfig::builder().build();
+        assert_eq!(<SubstrateConfig as Config>::genesis_hash(&config), None);
     }
 }


### PR DESCRIPTION
`SubstrateConfigBuilder::set_genesis_hash` is a no-op: the value is stored on the builder but `build()` never copies it into `SubstrateConfigInner`, and `impl Config for SubstrateConfig` never overrides `genesis_hash()`, so it falls back to the trait default of `None`.

Offline workflows that rely on the configured genesis hash fail with `ExtrinsicError::GenesisHashNotProvided`:

```rust
let config = SubstrateConfig::builder()
    .set_genesis_hash(genesis_hash)
    .set_metadata_for_spec_versions(...)
    .set_spec_version_for_block_ranges(...)
    .build();
let client = OfflineClient::<SubstrateConfig>::new_with_config(config);
let at_block = client.at_block(0u64)?;
at_block.tx().create_signable_offline(&call, params)?; // GenesisHashNotProvided
```

The `OnlineClient` path is unaffected, since the hash is fetched from the network when `genesis_hash` is None.

This adds the missing `genesis_hash` field on `SubstrateConfigInner`, propagates it through `build()`, and overrides `Config::genesis_hash` for `SubstrateConfig`.