### PR TITLE
chore: Release v0.50.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.50.2] - 2026-07-06
+
+This release fixes an issue whereby setting the genesis hash in the `SubstrateConfigBuilder` had no effect, and improves the reliability of tests against public archival RPC endpoints.
+
+### Changed
+
+- Update Artifacts (auto-generated) ([#2245](https://github.com/paritytech/subxt/pull/2245))
+- tests: Exponential backoff for archival RPC public endpoints ([#2244](https://github.com/paritytech/subxt/pull/2244))
+
+### Fixed
+
+- Fix: `SubstrateConfigBuilder::set_genesis_hash` is a no-op ([#2236](https://github.com/paritytech/subxt/pull/2236))
+
 ## [0.50.1] - 2026-04-27
 
 This release bumps the light-client smoldot crate to the latest version and adds several fixes.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,7 +464,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "artifacts"
-version = "0.50.1"
+version = "0.50.2"
 dependencies = [
  "substrate-runner",
 ]
@@ -2156,7 +2156,7 @@ dependencies = [
 
 [[package]]
 name = "generate-custom-metadata"
-version = "0.50.1"
+version = "0.50.2"
 dependencies = [
  "frame-metadata 23.0.0",
  "parity-scale-codec",
@@ -2789,7 +2789,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.50.1"
+version = "0.50.2"
 dependencies = [
  "assert_matches",
  "cfg_aliases",
@@ -5653,7 +5653,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-runner"
-version = "0.50.1"
+version = "0.50.2"
 
 [[package]]
 name = "subtle"
@@ -5663,7 +5663,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "subxt"
-version = "0.50.1"
+version = "0.50.2"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -5712,7 +5712,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-cli"
-version = "0.50.1"
+version = "0.50.2"
 dependencies = [
  "clap",
  "color-eyre",
@@ -5746,7 +5746,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-codegen"
-version = "0.50.1"
+version = "0.50.2"
 dependencies = [
  "frame-metadata 23.0.0",
  "getrandom 0.2.16",
@@ -5763,7 +5763,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-lightclient"
-version = "0.50.1"
+version = "0.50.2"
 dependencies = [
  "futures",
  "futures-timer",
@@ -5788,7 +5788,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.50.1"
+version = "0.50.2"
 dependencies = [
  "darling",
  "parity-scale-codec",
@@ -5808,7 +5808,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-metadata"
-version = "0.50.1"
+version = "0.50.2"
 dependencies = [
  "bitvec",
  "criterion",
@@ -5827,7 +5827,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-rpcs"
-version = "0.50.1"
+version = "0.50.2"
 dependencies = [
  "derive-where",
  "finito",
@@ -5856,7 +5856,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-signer"
-version = "0.50.1"
+version = "0.50.2"
 dependencies = [
  "base64 0.22.1",
  "bip32",
@@ -5890,7 +5890,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-test-macro"
-version = "0.50.1"
+version = "0.50.2"
 dependencies = [
  "quote",
  "syn 2.0.101",
@@ -5898,7 +5898,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-utils-accountid32"
-version = "0.50.1"
+version = "0.50.2"
 dependencies = [
  "base58",
  "blake2",
@@ -5914,7 +5914,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-utils-fetchmetadata"
-version = "0.50.1"
+version = "0.50.2"
 dependencies = [
  "frame-metadata 23.0.0",
  "hex",
@@ -5927,7 +5927,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-utils-stripmetadata"
-version = "0.50.1"
+version = "0.50.2"
 dependencies = [
  "either",
  "frame-metadata 23.0.0",
@@ -6010,7 +6010,7 @@ dependencies = [
 
 [[package]]
 name = "test-runtime"
-version = "0.50.1"
+version = "0.50.2"
 dependencies = [
  "hex",
  "impl-serde",
@@ -6436,7 +6436,7 @@ checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "ui-tests"
-version = "0.50.1"
+version = "0.50.2"
 dependencies = [
  "frame-metadata 23.0.0",
  "generate-custom-metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ resolver = "2"
 [workspace.package]
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2024"
-version = "0.50.1"
+version = "0.50.2"
 rust-version = "1.85.0"
 license = "Apache-2.0 OR GPL-3.0"
 repository = "https://github.com/paritytech/subxt"


### PR DESCRIPTION
## [0.50.2] - 2026-07-06

This release fixes an issue whereby setting the genesis hash in the `SubstrateConfigBuilder` had no effect, and improves the reliability of tests against public archival RPC endpoints.

### Changed

- Update Artifacts (auto-generated) ([#2245](https://github.com/paritytech/subxt/pull/2245))
- tests: Exponential backoff for archival RPC public endpoints ([#2244](https://github.com/paritytech/subxt/pull/2244))

### Fixed

- Fix: `SubstrateConfigBuilder::set_genesis_hash` is a no-op ([#2236](https://github.com/paritytech/subxt/pull/2236))
