### PR TITLE
chore: Upgrade smoldot to 2.1.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - master
       # If we want to backport changes to an old release, push a branch
-      # eg v0.40.x and CI will run on it. PRs merging to such branches 
+      # eg v0.40.x and CI will run on it. PRs merging to such branches
       # will also trigger CI.
       - v0.[0-9]+.x
   pull_request:
@@ -211,7 +211,7 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
 
-      - name: Install 
+      - name: Install
         uses: actions/setup-node@v4
         with:
           # Node version 20 and higher seem to cause an issue with the JS example so stick to 19 for now.
@@ -230,7 +230,7 @@ jobs:
           echo "Running Python FFI example..."
           python3 src/main.py
           echo "Python FFI example completed with exit code $?"
-          
+
           # Run the node version of the FFI code
           echo "Installing Node.js dependencies..."
           npm i
@@ -331,10 +331,10 @@ jobs:
       matrix:
         # Test each of these features in our integration tests:
         feature:
-        - default
-        - reconnecting-rpc
-        - legacy-backend
-        - chainhead-backend
+          - default
+          - reconnecting-rpc
+          - legacy-backend
+          - chainhead-backend
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6
@@ -447,14 +447,14 @@ jobs:
     name: "Flaky lightclient integration tests (${{ matrix.feature }})"
     runs-on: parity-large
     needs: [clippy, wasm_clippy, check, wasm_check, docs]
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       matrix:
         # Test each of the backends with the light client.
         feature:
-        - default
-        - legacy-backend
-        - chainhead-backend
+          - default
+          - legacy-backend
+          - chainhead-backend
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6
@@ -471,8 +471,10 @@ jobs:
 
       - name: Run crate tests
         id: test
+        env:
+          RUST_LOG: "info,subxt=debug,integration_tests=trace"
         run: |
-          if cargo test -p integration-tests --features light-client-rpc,${{ matrix.feature }}; then
+          if cargo test -p integration-tests --features light-client-rpc,${{ matrix.feature }} light_client -- --nocapture; then
             echo "result=success" >> $GITHUB_OUTPUT
           else
             echo "result=failure" >> $GITHUB_OUTPUT

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3966,9 +3966,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -5002,9 +5002,9 @@ dependencies = [
 
 [[package]]
 name = "smoldot"
-version = "1.1.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9879c3b19576797ad597164a07898aab5c6a99d9aed38a7d17120cace4c0f187"
+checksum = "1d0e22281ede6eb40a9b4fc5e74f1476a31c020e1f3e9940b5efaea885c8285b"
 dependencies = [
  "arrayvec 0.7.6",
  "async-lock",
@@ -5058,9 +5058,9 @@ dependencies = [
 
 [[package]]
 name = "smoldot-light"
-version = "1.1.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23c762d8f022452958f7473a5aa6e5427c178837c8a72a6f5da3e45ed2c7d804"
+checksum = "e92a85743eca4e1b4f614e0bfd64a4cadd7bbae333538dcf7a80ff6c818fe684"
 dependencies = [
  "async-channel",
  "async-lock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ resolver = "2"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2024"
 version = "0.50.2"
-rust-version = "1.85.0"
+rust-version = "1.88.0"
 license = "Apache-2.0 OR GPL-3.0"
 repository = "https://github.com/paritytech/subxt"
 documentation = "https://docs.rs/subxt"
@@ -126,8 +126,8 @@ hyper = "1"
 http-body = "1"
 
 # Light client support:
-smoldot = { version = "1.1.0", default-features = false }
-smoldot-light = { version = "1.1.0", default-features = false }
+smoldot = { version = "2.1.0", default-features = false }
+smoldot-light = { version = "1.3.1", default-features = false }
 tokio-stream = "0.1.16"
 futures-util = "0.3.31"
 rand = "0.8.5"

--- a/cli/src/commands/diff.rs
+++ b/cli/src/commands/diff.rs
@@ -67,18 +67,18 @@ pub async fn run(opts: Opts, output: &mut impl std::io::Write) -> color_eyre::Re
                                 Diff::Added(new) => writeln!(
                                     output,
                                     "{}",
-                                    format!("            + {}", &new.name).green()
+                                    format!("            + {}", new.name).green()
                                 )?,
                                 Diff::Removed(old) => writeln!(
                                     output,
                                     "{}",
-                                    format!("            - {}", &old.name).red()
+                                    format!("            - {}", old.name).red()
                                 )?,
                                 Diff::Changed { from, to: _ } => {
                                     writeln!(
                                         output,
                                         "{}",
-                                        format!("            ~ {}", &from.name).yellow()
+                                        format!("            ~ {}", from.name).yellow()
                                     )?;
                                 }
                             }

--- a/examples/ffi-example/Cargo.lock
+++ b/examples/ffi-example/Cargo.lock
@@ -77,9 +77,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-channel"
-version = "2.3.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
 dependencies = [
  "concurrent-queue",
  "event-listener-strategy",
@@ -239,6 +239,12 @@ dependencies = [
  "rustc-demangle",
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "base32"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "022dfe9eb35f19ebbcb51e0b40a5ab759f46ad60cadf7297e0bd085afb50e076"
 
 [[package]]
 name = "base58"
@@ -837,6 +843,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastbloom"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef975e30683b2d965054bb0a836f8973857c4ebf6acf274fe46617cd285060d8"
+dependencies = [
+ "foldhash 0.2.0",
+ "libm",
+ "portable-atomic",
+ "siphasher",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -889,9 +907,9 @@ dependencies = [
 
 [[package]]
 name = "frame-decode"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea4ae9db992bb3d089885a4fc17d06ffbd6918d7434fd192a20aba02d554bff"
+checksum = "88cda60c640572c970c544ba5879375a18ecfb2c47c617be8265830b63df193d"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
@@ -1076,7 +1094,6 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.1.5",
- "serde",
 ]
 
 [[package]]
@@ -1580,11 +1597,11 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
- "hashbrown 0.15.4",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -1886,6 +1903,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1973,9 +1996,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -2633,13 +2656,14 @@ dependencies = [
 
 [[package]]
 name = "smoldot"
-version = "0.20.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "724ab10d6485cccb4bab080ce436c0b361295274aec7847d7ba84ab1a79a5132"
+checksum = "1d0e22281ede6eb40a9b4fc5e74f1476a31c020e1f3e9940b5efaea885c8285b"
 dependencies = [
  "arrayvec 0.7.6",
  "async-lock",
  "atomic-take",
+ "base32",
  "base64",
  "bip39",
  "blake2-rfc",
@@ -2650,10 +2674,11 @@ dependencies = [
  "ed25519-zebra",
  "either",
  "event-listener",
+ "fastbloom",
  "fnv",
  "futures-lite",
  "futures-util",
- "hashbrown 0.15.4",
+ "hashbrown 0.16.1",
  "hex",
  "hmac 0.12.1",
  "itertools",
@@ -2687,9 +2712,9 @@ dependencies = [
 
 [[package]]
 name = "smoldot-light"
-version = "0.18.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8b4d4971f06f2471f4e57a662dbe8047fa0cc020957764a6211f3fad371f7bd"
+checksum = "e92a85743eca4e1b4f614e0bfd64a4cadd7bbae333538dcf7a80ff6c818fe684"
 dependencies = [
  "async-channel",
  "async-lock",
@@ -2703,7 +2728,7 @@ dependencies = [
  "futures-channel",
  "futures-lite",
  "futures-util",
- "hashbrown 0.15.4",
+ "hashbrown 0.16.1",
  "hex",
  "itertools",
  "log",
@@ -2802,7 +2827,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "subxt"
-version = "0.50.0"
+version = "0.50.2"
 dependencies = [
  "async-trait",
  "derive-where",
@@ -2841,7 +2866,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-codegen"
-version = "0.50.0"
+version = "0.50.2"
 dependencies = [
  "heck",
  "parity-scale-codec",
@@ -2866,7 +2891,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-lightclient"
-version = "0.50.0"
+version = "0.50.2"
 dependencies = [
  "futures",
  "futures-util",
@@ -2881,7 +2906,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.50.0"
+version = "0.50.2"
 dependencies = [
  "darling",
  "parity-scale-codec",
@@ -2896,7 +2921,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-metadata"
-version = "0.50.0"
+version = "0.50.2"
 dependencies = [
  "frame-decode",
  "frame-metadata",
@@ -2911,7 +2936,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-rpcs"
-version = "0.50.0"
+version = "0.50.2"
 dependencies = [
  "derive-where",
  "frame-metadata",
@@ -2932,7 +2957,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-signer"
-version = "0.50.0"
+version = "0.50.2"
 dependencies = [
  "base64",
  "bip39",
@@ -2958,7 +2983,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-utils-accountid32"
-version = "0.50.0"
+version = "0.50.2"
 dependencies = [
  "base58",
  "blake2",
@@ -2972,7 +2997,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-utils-fetchmetadata"
-version = "0.50.0"
+version = "0.50.2"
 dependencies = [
  "hex",
  "parity-scale-codec",

--- a/examples/parachain-example/Cargo.lock
+++ b/examples/parachain-example/Cargo.lock
@@ -77,12 +77,12 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-channel"
-version = "2.3.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
 dependencies = [
  "concurrent-queue",
- "event-listener-strategy 0.5.3",
+ "event-listener-strategy 0.5.4",
  "futures-core",
  "pin-project-lite",
 ]
@@ -247,6 +247,12 @@ dependencies = [
  "object",
  "rustc-demangle",
 ]
+
+[[package]]
+name = "base32"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "022dfe9eb35f19ebbcb51e0b40a5ab759f46ad60cadf7297e0bd085afb50e076"
 
 [[package]]
 name = "base58"
@@ -884,12 +890,24 @@ dependencies = [
 
 [[package]]
 name = "event-listener-strategy"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener 5.4.0",
  "pin-project-lite",
+]
+
+[[package]]
+name = "fastbloom"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef975e30683b2d965054bb0a836f8973857c4ebf6acf274fe46617cd285060d8"
+dependencies = [
+ "foldhash 0.2.0",
+ "libm",
+ "portable-atomic",
+ "siphasher",
 ]
 
 [[package]]
@@ -945,9 +963,9 @@ dependencies = [
 
 [[package]]
 name = "frame-decode"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea4ae9db992bb3d089885a4fc17d06ffbd6918d7434fd192a20aba02d554bff"
+checksum = "88cda60c640572c970c544ba5879375a18ecfb2c47c617be8265830b63df193d"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
@@ -1132,7 +1150,6 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.1.5",
- "serde",
 ]
 
 [[package]]
@@ -1649,11 +1666,11 @@ checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "lru"
-version = "0.12.1"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2994eeba8ed550fd9b47a0b38f0242bc3344e496483c6180b69139cc2fa5d1d7"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -1966,6 +1983,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2041,9 +2064,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -2713,13 +2736,14 @@ dependencies = [
 
 [[package]]
 name = "smoldot"
-version = "0.20.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "724ab10d6485cccb4bab080ce436c0b361295274aec7847d7ba84ab1a79a5132"
+checksum = "1d0e22281ede6eb40a9b4fc5e74f1476a31c020e1f3e9940b5efaea885c8285b"
 dependencies = [
  "arrayvec 0.7.6",
  "async-lock 3.3.0",
  "atomic-take",
+ "base32",
  "base64 0.22.1",
  "bip39",
  "blake2-rfc",
@@ -2730,10 +2754,11 @@ dependencies = [
  "ed25519-zebra",
  "either",
  "event-listener 5.4.0",
+ "fastbloom",
  "fnv",
  "futures-lite",
  "futures-util",
- "hashbrown 0.15.2",
+ "hashbrown 0.16.1",
  "hex",
  "hmac 0.12.1",
  "itertools",
@@ -2767,9 +2792,9 @@ dependencies = [
 
 [[package]]
 name = "smoldot-light"
-version = "0.18.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8b4d4971f06f2471f4e57a662dbe8047fa0cc020957764a6211f3fad371f7bd"
+checksum = "e92a85743eca4e1b4f614e0bfd64a4cadd7bbae333538dcf7a80ff6c818fe684"
 dependencies = [
  "async-channel",
  "async-lock 3.3.0",
@@ -2783,7 +2808,7 @@ dependencies = [
  "futures-channel",
  "futures-lite",
  "futures-util",
- "hashbrown 0.15.2",
+ "hashbrown 0.16.1",
  "hex",
  "itertools",
  "log",
@@ -2882,7 +2907,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "subxt"
-version = "0.50.0"
+version = "0.50.2"
 dependencies = [
  "async-trait",
  "derive-where",
@@ -2921,7 +2946,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-codegen"
-version = "0.50.0"
+version = "0.50.2"
 dependencies = [
  "heck",
  "parity-scale-codec",
@@ -2936,7 +2961,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-lightclient"
-version = "0.50.0"
+version = "0.50.2"
 dependencies = [
  "futures",
  "futures-util",
@@ -2951,7 +2976,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.50.0"
+version = "0.50.2"
 dependencies = [
  "darling",
  "parity-scale-codec",
@@ -2966,7 +2991,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-metadata"
-version = "0.50.0"
+version = "0.50.2"
 dependencies = [
  "frame-decode",
  "frame-metadata",
@@ -2981,7 +3006,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-rpcs"
-version = "0.50.0"
+version = "0.50.2"
 dependencies = [
  "derive-where",
  "frame-metadata",
@@ -3002,7 +3027,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-signer"
-version = "0.50.0"
+version = "0.50.2"
 dependencies = [
  "base64 0.22.1",
  "bip39",
@@ -3028,7 +3053,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-utils-accountid32"
-version = "0.50.0"
+version = "0.50.2"
 dependencies = [
  "base58",
  "blake2",
@@ -3042,7 +3067,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-utils-fetchmetadata"
-version = "0.50.0"
+version = "0.50.2"
 dependencies = [
  "hex",
  "parity-scale-codec",

--- a/examples/wasm-example/Cargo.lock
+++ b/examples/wasm-example/Cargo.lock
@@ -80,9 +80,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-channel"
-version = "2.3.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
 dependencies = [
  "concurrent-queue",
  "event-listener-strategy",
@@ -138,6 +138,12 @@ dependencies = [
  "rustc-demangle",
  "windows-targets",
 ]
+
+[[package]]
+name = "base32"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "022dfe9eb35f19ebbcb51e0b40a5ab759f46ad60cadf7297e0bd085afb50e076"
 
 [[package]]
 name = "base58"
@@ -663,6 +669,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastbloom"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef975e30683b2d965054bb0a836f8973857c4ebf6acf274fe46617cd285060d8"
+dependencies = [
+ "foldhash 0.2.0",
+ "libm",
+ "portable-atomic",
+ "siphasher",
+]
+
+[[package]]
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -719,9 +737,9 @@ dependencies = [
 
 [[package]]
 name = "frame-decode"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea4ae9db992bb3d089885a4fc17d06ffbd6918d7434fd192a20aba02d554bff"
+checksum = "88cda60c640572c970c544ba5879375a18ecfb2c47c617be8265830b63df193d"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
@@ -1128,7 +1146,6 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.1.5",
- "serde",
 ]
 
 [[package]]
@@ -1625,11 +1642,11 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
- "hashbrown 0.15.2",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -1867,6 +1884,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1996,9 +2019,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -2432,13 +2455,14 @@ checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "smoldot"
-version = "0.20.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "724ab10d6485cccb4bab080ce436c0b361295274aec7847d7ba84ab1a79a5132"
+checksum = "1d0e22281ede6eb40a9b4fc5e74f1476a31c020e1f3e9940b5efaea885c8285b"
 dependencies = [
  "arrayvec 0.7.6",
  "async-lock",
  "atomic-take",
+ "base32",
  "base64",
  "bip39",
  "blake2-rfc",
@@ -2449,10 +2473,11 @@ dependencies = [
  "ed25519-zebra",
  "either",
  "event-listener",
+ "fastbloom",
  "fnv",
  "futures-lite",
  "futures-util",
- "hashbrown 0.15.2",
+ "hashbrown 0.16.1",
  "hex",
  "hmac 0.12.1",
  "itertools",
@@ -2486,9 +2511,9 @@ dependencies = [
 
 [[package]]
 name = "smoldot-light"
-version = "0.18.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8b4d4971f06f2471f4e57a662dbe8047fa0cc020957764a6211f3fad371f7bd"
+checksum = "e92a85743eca4e1b4f614e0bfd64a4cadd7bbae333538dcf7a80ff6c818fe684"
 dependencies = [
  "async-channel",
  "async-lock",
@@ -2502,7 +2527,7 @@ dependencies = [
  "futures-channel",
  "futures-lite",
  "futures-util",
- "hashbrown 0.15.2",
+ "hashbrown 0.16.1",
  "hex",
  "itertools",
  "lru",
@@ -2588,7 +2613,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "subxt"
-version = "0.50.0"
+version = "0.50.2"
 dependencies = [
  "async-trait",
  "derive-where",
@@ -2626,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-codegen"
-version = "0.50.0"
+version = "0.50.2"
 dependencies = [
  "getrandom",
  "heck",
@@ -2642,7 +2667,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-lightclient"
-version = "0.50.0"
+version = "0.50.2"
 dependencies = [
  "futures",
  "futures-timer",
@@ -2667,7 +2692,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.50.0"
+version = "0.50.2"
 dependencies = [
  "darling",
  "parity-scale-codec",
@@ -2682,7 +2707,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-metadata"
-version = "0.50.0"
+version = "0.50.2"
 dependencies = [
  "frame-decode",
  "frame-metadata",
@@ -2697,7 +2722,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-rpcs"
-version = "0.50.0"
+version = "0.50.2"
 dependencies = [
  "derive-where",
  "finito",
@@ -2721,7 +2746,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-utils-accountid32"
-version = "0.50.0"
+version = "0.50.2"
 dependencies = [
  "base58",
  "blake2",
@@ -2735,7 +2760,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-utils-fetchmetadata"
-version = "0.50.0"
+version = "0.50.2"
 dependencies = [
  "hex",
  "parity-scale-codec",

--- a/lightclient/src/background.rs
+++ b/lightclient/src/background.rs
@@ -444,17 +444,16 @@ impl<TPlatform: PlatformRef, TChain> BackgroundTaskData<TPlatform, TChain> {
                             "Cannot send method response to id={id} chain={chain_id:?}",
                         );
                     }
-                } else if let Some(subscription_id_state) = self.pending_subscriptions.remove(&id) {
-                    if subscription_id_state
+                } else if let Some(subscription_id_state) = self.pending_subscriptions.remove(&id)
+                    && subscription_id_state
                         .response_sender
                         .send(Err(LightClientRpcError::JsonRpcError(JsonRpcError(error))))
                         .is_err()
-                    {
-                        tracing::warn!(
-                            target: LOG_TARGET,
-                            "Cannot send method response to id {id} chain={chain_id:?}",
-                        );
-                    }
+                {
+                    tracing::warn!(
+                        target: LOG_TARGET,
+                        "Cannot send method response to id {id} chain={chain_id:?}",
+                    );
                 }
             }
             Ok(RpcResponse::Notification {

--- a/metadata/src/lib.rs
+++ b/metadata/src/lib.rs
@@ -1340,10 +1340,10 @@ pub fn decode_runtime_metadata(
     // frame_metadata::OpaqueMetadata is a vec of bytes. If we can decode the length, AND
     // the length definitely corresponds to the number of remaining bytes, then we try to
     // decode the inner bytes.
-    if let Ok(len) = codec::Compact::<u64>::decode(&mut &*input) {
-        if input.len() == len.0 as usize {
-            return decode_runtime_metadata(input);
-        }
+    if let Ok(len) = codec::Compact::<u64>::decode(&mut &*input)
+        && input.len() == len.0 as usize
+    {
+        return decode_runtime_metadata(input);
     }
 
     Err(err)

--- a/rpcs/src/client/mock_rpc_client.rs
+++ b/rpcs/src/client/mock_rpc_client.rs
@@ -194,10 +194,10 @@ impl RpcClientT for MockRpcClient {
     ) -> RawRpcFuture<'a, Box<serde_json::value::RawValue>> {
         // Remove and call a one-time handler if any exist.
         let mut handlers_once = self.method_handlers_once.lock().unwrap();
-        if let Some(handlers) = handlers_once.get_mut(method) {
-            if let Some(handler) = handlers.pop_front() {
-                return handler(method, params)
-            }
+        if let Some(handlers) = handlers_once.get_mut(method)
+            && let Some(handler) = handlers.pop_front()
+        {
+            return handler(method, params)
         }
         drop(handlers_once);
 
@@ -225,10 +225,10 @@ impl RpcClientT for MockRpcClient {
     ) -> RawRpcFuture<'a, RawRpcSubscription> {
         // Remove and call a one-time handler if any exist.
         let mut handlers_once = self.subscription_handlers_once.lock().unwrap();
-        if let Some(handlers) = handlers_once.get_mut(sub) {
-            if let Some(handler) = handlers.pop_front() {
-                return handler(sub, params, unsub)
-            }
+        if let Some(handlers) = handlers_once.get_mut(sub)
+            && let Some(handler) = handlers.pop_front()
+        {
+            return handler(sub, params, unsub)
         }
         drop(handlers_once);
 

--- a/rpcs/src/lib.rs
+++ b/rpcs/src/lib.rs
@@ -133,6 +133,6 @@ impl UserError {
 
 impl core::fmt::Display for UserError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{} ({})", &self.message, &self.code)
+        write!(f, "{} ({})", self.message, self.code)
     }
 }

--- a/rpcs/src/methods/chain_head.rs
+++ b/rpcs/src/methods/chain_head.rs
@@ -817,17 +817,17 @@ impl<H: Hash> Stream for TransactionSubscription<H> {
 
         let res = self.sub.poll_next_unpin(cx);
 
-        if let Poll::Ready(Some(Ok(res))) = &res {
-            if matches!(
+        if let Poll::Ready(Some(Ok(res))) = &res
+            && matches!(
                 res,
                 TransactionStatus::Dropped { .. }
                     | TransactionStatus::Error { .. }
                     | TransactionStatus::Invalid { .. }
                     | TransactionStatus::Finalized { .. }
-            ) {
-                // No more events will occur after these ones.
-                self.done = true
-            }
+            )
+        {
+            // No more events will occur after these ones.
+            self.done = true
         }
 
         res

--- a/signer/src/crypto/seed_from_entropy.rs
+++ b/signer/src/crypto/seed_from_entropy.rs
@@ -13,7 +13,7 @@ use zeroize::Zeroize;
 /// `None` if invalid length.
 #[allow(dead_code)]
 pub fn seed_from_entropy(entropy: &[u8], password: &str) -> Option<[u8; 64]> {
-    if entropy.len() < 16 || entropy.len() > 32 || entropy.len() % 4 != 0 {
+    if entropy.len() < 16 || entropy.len() > 32 || !entropy.len().is_multiple_of(4) {
         return None;
     }
 

--- a/signer/src/eth.rs
+++ b/signer/src/eth.rs
@@ -590,7 +590,7 @@ mod test {
 
         for (case_idx, (keypair, exp_account_id, exp_priv_key)) in cases.into_iter().enumerate() {
             let act_account_id = keypair.public_key().to_account_id().checksum();
-            let act_priv_key = format!("0x{}", &keypair.0.0.display_secret());
+            let act_priv_key = format!("0x{}", keypair.0.0.display_secret());
 
             assert_eq!(
                 exp_account_id, act_account_id,

--- a/signer/tests/wasm/Cargo.lock
+++ b/signer/tests/wasm/Cargo.lock
@@ -113,6 +113,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
+name = "base32"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "022dfe9eb35f19ebbcb51e0b40a5ab759f46ad60cadf7297e0bd085afb50e076"
+
+[[package]]
 name = "base58"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -717,6 +723,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastbloom"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef975e30683b2d965054bb0a836f8973857c4ebf6acf274fe46617cd285060d8"
+dependencies = [
+ "foldhash 0.2.0",
+ "libm",
+ "portable-atomic",
+ "siphasher",
+]
+
+[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -789,9 +807,9 @@ dependencies = [
 
 [[package]]
 name = "frame-decode"
-version = "0.16.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e63257bb5f8d7a707d626aa1b4e464c3b9720edd168b73cee98f48f0dd6386e4"
+checksum = "88cda60c640572c970c544ba5879375a18ecfb2c47c617be8265830b63df193d"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
@@ -1030,7 +1048,6 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.1.5",
- "serde",
 ]
 
 [[package]]
@@ -1474,11 +1491,11 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -1716,6 +1733,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1803,9 +1826,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -2360,13 +2383,14 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smoldot"
-version = "0.20.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "724ab10d6485cccb4bab080ce436c0b361295274aec7847d7ba84ab1a79a5132"
+checksum = "1d0e22281ede6eb40a9b4fc5e74f1476a31c020e1f3e9940b5efaea885c8285b"
 dependencies = [
  "arrayvec 0.7.6",
  "async-lock",
  "atomic-take",
+ "base32",
  "base64",
  "bip39",
  "blake2-rfc",
@@ -2377,10 +2401,11 @@ dependencies = [
  "ed25519-zebra",
  "either",
  "event-listener",
+ "fastbloom",
  "fnv",
  "futures-lite",
  "futures-util",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "hex",
  "hmac 0.12.1",
  "itertools",
@@ -2414,9 +2439,9 @@ dependencies = [
 
 [[package]]
 name = "smoldot-light"
-version = "0.18.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8b4d4971f06f2471f4e57a662dbe8047fa0cc020957764a6211f3fad371f7bd"
+checksum = "e92a85743eca4e1b4f614e0bfd64a4cadd7bbae333538dcf7a80ff6c818fe684"
 dependencies = [
  "async-channel",
  "async-lock",
@@ -2430,7 +2455,7 @@ dependencies = [
  "futures-channel",
  "futures-lite",
  "futures-util",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "hex",
  "itertools",
  "lru",
@@ -2516,7 +2541,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "subxt"
-version = "0.50.0"
+version = "0.50.2"
 dependencies = [
  "async-trait",
  "derive-where",
@@ -2552,7 +2577,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-codegen"
-version = "0.50.0"
+version = "0.50.2"
 dependencies = [
  "getrandom",
  "heck",
@@ -2568,7 +2593,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-lightclient"
-version = "0.50.0"
+version = "0.50.2"
 dependencies = [
  "futures",
  "futures-timer",
@@ -2593,7 +2618,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.50.0"
+version = "0.50.2"
 dependencies = [
  "darling",
  "parity-scale-codec",
@@ -2608,7 +2633,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-metadata"
-version = "0.50.0"
+version = "0.50.2"
 dependencies = [
  "frame-decode",
  "frame-metadata",
@@ -2623,7 +2648,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-rpcs"
-version = "0.50.0"
+version = "0.50.2"
 dependencies = [
  "derive-where",
  "finito",
@@ -2646,7 +2671,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-signer"
-version = "0.50.0"
+version = "0.50.2"
 dependencies = [
  "base64",
  "bip32",
@@ -2675,7 +2700,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-utils-accountid32"
-version = "0.50.0"
+version = "0.50.2"
 dependencies = [
  "base58",
  "blake2",
@@ -2689,7 +2714,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-utils-fetchmetadata"
-version = "0.50.0"
+version = "0.50.2"
 dependencies = [
  "hex",
  "parity-scale-codec",

--- a/subxt/src/backend/chain_head/follow_stream_unpin.rs
+++ b/subxt/src/backend/chain_head/follow_stream_unpin.rs
@@ -458,10 +458,10 @@ impl<H: Hash> Drop for BlockRef<H> {
         // only "external" one left and we should ask to unpin it now. if it's
         // the only ref remaining, it means that it's already been unpinned, so
         // nothing to do here anyway.
-        if Arc::strong_count(&self.inner) == 2 {
-            if let Ok(mut unpin_flags) = self.inner.unpin_flags.lock() {
-                unpin_flags.insert(self.inner.hash);
-            }
+        if Arc::strong_count(&self.inner) == 2
+            && let Ok(mut unpin_flags) = self.inner.unpin_flags.lock()
+        {
+            unpin_flags.insert(self.inner.hash);
         }
     }
 }

--- a/testing/integration-tests/src/full_client/client/archive_rpcs.rs
+++ b/testing/integration-tests/src/full_client/client/archive_rpcs.rs
@@ -104,12 +104,13 @@ async fn archive_v1_finalized_height() {
 
         // On a dev node we expect blocks to be finalized 1 by 1, so panic
         // if the height we fetch has grown by more than 1.
-        if let Some(last) = last_block_height {
-            if archive_block_height != last && archive_block_height != last + 1 {
-                panic!(
-                    "Archive block height should increase 1 at a time, but jumped from {last} to {archive_block_height}"
-                );
-            }
+        if let Some(last) = last_block_height
+            && archive_block_height != last
+            && archive_block_height != last + 1
+        {
+            panic!(
+                "Archive block height should increase 1 at a time, but jumped from {last} to {archive_block_height}"
+            );
         }
 
         last_block_height = Some(archive_block_height);

--- a/testing/integration-tests/src/light_client.rs
+++ b/testing/integration-tests/src/light_client.rs
@@ -27,7 +27,7 @@
 //! For more context see: https://github.com/tokio-rs/tokio/issues/2374.
 //!
 
-use crate::utils::{node_runtime, subxt_test};
+use crate::utils::node_runtime;
 use codec::Compact;
 use std::sync::Arc;
 use std::time::Duration;

--- a/testing/integration-tests/src/light_client.rs
+++ b/testing/integration-tests/src/light_client.rs
@@ -27,9 +27,10 @@
 //! For more context see: https://github.com/tokio-rs/tokio/issues/2374.
 //!
 
-use crate::utils::node_runtime;
+use crate::utils::{node_runtime, subxt_test};
 use codec::Compact;
 use std::sync::Arc;
+use std::time::Duration;
 use subxt::dynamic::Value;
 use subxt::{
     client::OnlineClient, config::PolkadotConfig, lightclient::LightClient, metadata::Metadata,
@@ -37,6 +38,22 @@ use subxt::{
 };
 
 type Client = OnlineClient<PolkadotConfig>;
+
+/// Maximum time to wait for the light client to warp sync and hand us a usable client.
+const CLIENT_INIT_TIMEOUT: Duration = Duration::from_secs(240);
+/// Maximum time to wait for each individual check once the client is up.
+const CHECK_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Run one check against [`CHECK_TIMEOUT`], panicking with the step name if it fails
+/// or times out, so that a stalled light client fails quickly and names the stuck
+/// step instead of hanging until the CI job timeout cancels it without any output.
+async fn run_check(step: &str, fut: impl std::future::Future<Output = Result<(), subxt::Error>>) {
+    match tokio::time::timeout(CHECK_TIMEOUT, fut).await {
+        Ok(Ok(())) => (),
+        Ok(Err(e)) => panic!("light client test step '{step}' failed: {e:?}"),
+        Err(_) => panic!("light client test step '{step}' timed out after {CHECK_TIMEOUT:?}"),
+    }
+}
 
 /// The Polkadot chainspec.
 const POLKADOT_SPEC: &str = include_str!("../../../artifacts/demo_chain_specs/polkadot.json");
@@ -211,31 +228,38 @@ async fn light_client_tests() {
     //     .unwrap();
     // let chain_config = chainspec.get();
 
+    // Surface smoldot and subxt logs when RUST_LOG is set (eg in CI), so that
+    // failures come with diagnostics attached. Smoldot logs via the `log` crate,
+    // which the fmt subscriber picks up through its log compatibility layer.
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .try_init();
+
     tracing::trace!("Init light client");
     let now = std::time::Instant::now();
 
     // We only do this once for all tests because it's quite expensive.
-    let api = create_client().await;
+    let api = tokio::time::timeout(CLIENT_INIT_TIMEOUT, create_client())
+        .await
+        .unwrap_or_else(|_| {
+            panic!("light client initialization timed out after {CLIENT_INIT_TIMEOUT:?}")
+        });
     tracing::trace!("Light client initialization took {:?}", now.elapsed());
 
-    non_finalized_headers_subscription(&api)
-        .await
-        .expect("non_finalized_headers_subscription should pass");
-    finalized_headers_subscription(&api)
-        .await
-        .expect("finalized_headers_subscription should pass");
-    runtime_api_call(&api)
-        .await
-        .expect("runtime_api_call should pass");
-    storage_plain_lookup(&api)
-        .await
-        .expect("storage_plain_lookup should pass");
-    dynamic_constant_query(&api)
-        .await
-        .expect("dynamic_constant_query should pass");
-    dynamic_events(&api)
-        .await
-        .expect("dynamic_events should pass");
+    run_check(
+        "non_finalized_headers_subscription",
+        non_finalized_headers_subscription(&api),
+    )
+    .await;
+    run_check(
+        "finalized_headers_subscription",
+        finalized_headers_subscription(&api),
+    )
+    .await;
+    run_check("runtime_api_call", runtime_api_call(&api)).await;
+    run_check("storage_plain_lookup", storage_plain_lookup(&api)).await;
+    run_check("dynamic_constant_query", dynamic_constant_query(&api)).await;
+    run_check("dynamic_events", dynamic_events(&api)).await;
 
     tracing::trace!("Light complete testing took {:?}", now.elapsed());
 }

--- a/testing/wasm-lightclient-tests/Cargo.lock
+++ b/testing/wasm-lightclient-tests/Cargo.lock
@@ -68,9 +68,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-channel"
-version = "2.3.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
 dependencies = [
  "concurrent-queue",
  "event-listener-strategy",
@@ -126,6 +126,12 @@ dependencies = [
  "object",
  "rustc-demangle",
 ]
+
+[[package]]
+name = "base32"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "022dfe9eb35f19ebbcb51e0b40a5ab759f46ad60cadf7297e0bd085afb50e076"
 
 [[package]]
 name = "base58"
@@ -621,12 +627,24 @@ dependencies = [
 
 [[package]]
 name = "event-listener-strategy"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener",
  "pin-project-lite",
+]
+
+[[package]]
+name = "fastbloom"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef975e30683b2d965054bb0a836f8973857c4ebf6acf274fe46617cd285060d8"
+dependencies = [
+ "foldhash 0.2.0",
+ "libm",
+ "portable-atomic",
+ "siphasher",
 ]
 
 [[package]]
@@ -686,9 +704,9 @@ dependencies = [
 
 [[package]]
 name = "frame-decode"
-version = "0.16.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e63257bb5f8d7a707d626aa1b4e464c3b9720edd168b73cee98f48f0dd6386e4"
+checksum = "88cda60c640572c970c544ba5879375a18ecfb2c47c617be8265830b63df193d"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
@@ -920,7 +938,6 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.1.5",
- "serde",
 ]
 
 [[package]]
@@ -1245,11 +1262,11 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "lru"
-version = "0.12.4"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ee39891760e7d94734f6f63fedc29a2e4a152f836120753a72503f09fcf904"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -1476,6 +1493,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1554,9 +1577,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -1731,9 +1754,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info-legacy"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4afb76e1b2cb589b97278e2f1e2e290c9b7c51d6ac69afab9e1d7d1e136a9276"
+checksum = "d972ce93a4f81efc40fce251e992faf99ecb090c02bcbd3614e213991038c181"
 dependencies = [
  "hashbrown 0.16.1",
  "scale-type-resolver",
@@ -1991,13 +2014,14 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "smoldot"
-version = "0.20.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "724ab10d6485cccb4bab080ce436c0b361295274aec7847d7ba84ab1a79a5132"
+checksum = "1d0e22281ede6eb40a9b4fc5e74f1476a31c020e1f3e9940b5efaea885c8285b"
 dependencies = [
  "arrayvec 0.7.6",
  "async-lock",
  "atomic-take",
+ "base32",
  "base64 0.22.1",
  "bip39",
  "blake2-rfc",
@@ -2008,10 +2032,11 @@ dependencies = [
  "ed25519-zebra",
  "either",
  "event-listener",
+ "fastbloom",
  "fnv",
  "futures-lite",
  "futures-util",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "hex",
  "hmac 0.12.1",
  "itertools",
@@ -2045,9 +2070,9 @@ dependencies = [
 
 [[package]]
 name = "smoldot-light"
-version = "0.18.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8b4d4971f06f2471f4e57a662dbe8047fa0cc020957764a6211f3fad371f7bd"
+checksum = "e92a85743eca4e1b4f614e0bfd64a4cadd7bbae333538dcf7a80ff6c818fe684"
 dependencies = [
  "async-channel",
  "async-lock",
@@ -2061,7 +2086,7 @@ dependencies = [
  "futures-channel",
  "futures-lite",
  "futures-util",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "hex",
  "itertools",
  "lru",
@@ -2141,7 +2166,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "subxt"
-version = "0.50.0"
+version = "0.50.2"
 dependencies = [
  "async-trait",
  "derive-where",
@@ -2179,7 +2204,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-codegen"
-version = "0.50.0"
+version = "0.50.2"
 dependencies = [
  "getrandom",
  "heck",
@@ -2195,7 +2220,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-lightclient"
-version = "0.50.0"
+version = "0.50.2"
 dependencies = [
  "futures",
  "futures-timer",
@@ -2220,7 +2245,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.50.0"
+version = "0.50.2"
 dependencies = [
  "darling",
  "parity-scale-codec",
@@ -2235,7 +2260,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-metadata"
-version = "0.50.0"
+version = "0.50.2"
 dependencies = [
  "frame-decode",
  "frame-metadata",
@@ -2250,7 +2275,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-rpcs"
-version = "0.50.0"
+version = "0.50.2"
 dependencies = [
  "derive-where",
  "finito",
@@ -2274,7 +2299,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-utils-accountid32"
-version = "0.50.0"
+version = "0.50.2"
 dependencies = [
  "base58",
  "blake2",
@@ -2288,7 +2313,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-utils-fetchmetadata"
-version = "0.50.0"
+version = "0.50.2"
 dependencies = [
  "hex",
  "parity-scale-codec",

--- a/testing/wasm-rpc-tests/Cargo.lock
+++ b/testing/wasm-rpc-tests/Cargo.lock
@@ -68,9 +68,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-channel"
-version = "2.3.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
 dependencies = [
  "concurrent-queue",
  "event-listener-strategy",
@@ -126,6 +126,12 @@ dependencies = [
  "object",
  "rustc-demangle",
 ]
+
+[[package]]
+name = "base32"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "022dfe9eb35f19ebbcb51e0b40a5ab759f46ad60cadf7297e0bd085afb50e076"
 
 [[package]]
 name = "base58"
@@ -621,12 +627,24 @@ dependencies = [
 
 [[package]]
 name = "event-listener-strategy"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener",
  "pin-project-lite",
+]
+
+[[package]]
+name = "fastbloom"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef975e30683b2d965054bb0a836f8973857c4ebf6acf274fe46617cd285060d8"
+dependencies = [
+ "foldhash 0.2.0",
+ "libm",
+ "portable-atomic",
+ "siphasher",
 ]
 
 [[package]]
@@ -686,9 +704,9 @@ dependencies = [
 
 [[package]]
 name = "frame-decode"
-version = "0.16.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e63257bb5f8d7a707d626aa1b4e464c3b9720edd168b73cee98f48f0dd6386e4"
+checksum = "88cda60c640572c970c544ba5879375a18ecfb2c47c617be8265830b63df193d"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
@@ -920,7 +938,6 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.1.5",
- "serde",
 ]
 
 [[package]]
@@ -1245,11 +1262,11 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "lru"
-version = "0.12.4"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ee39891760e7d94734f6f63fedc29a2e4a152f836120753a72503f09fcf904"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -1476,6 +1493,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1554,9 +1577,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -1991,13 +2014,14 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "smoldot"
-version = "0.20.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "724ab10d6485cccb4bab080ce436c0b361295274aec7847d7ba84ab1a79a5132"
+checksum = "1d0e22281ede6eb40a9b4fc5e74f1476a31c020e1f3e9940b5efaea885c8285b"
 dependencies = [
  "arrayvec 0.7.6",
  "async-lock",
  "atomic-take",
+ "base32",
  "base64 0.22.1",
  "bip39",
  "blake2-rfc",
@@ -2008,10 +2032,11 @@ dependencies = [
  "ed25519-zebra",
  "either",
  "event-listener",
+ "fastbloom",
  "fnv",
  "futures-lite",
  "futures-util",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "hex",
  "hmac 0.12.1",
  "itertools",
@@ -2045,9 +2070,9 @@ dependencies = [
 
 [[package]]
 name = "smoldot-light"
-version = "0.18.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8b4d4971f06f2471f4e57a662dbe8047fa0cc020957764a6211f3fad371f7bd"
+checksum = "e92a85743eca4e1b4f614e0bfd64a4cadd7bbae333538dcf7a80ff6c818fe684"
 dependencies = [
  "async-channel",
  "async-lock",
@@ -2061,7 +2086,7 @@ dependencies = [
  "futures-channel",
  "futures-lite",
  "futures-util",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "hex",
  "itertools",
  "lru",
@@ -2141,7 +2166,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "subxt"
-version = "0.50.0"
+version = "0.50.2"
 dependencies = [
  "async-trait",
  "derive-where",
@@ -2179,7 +2204,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-codegen"
-version = "0.50.0"
+version = "0.50.2"
 dependencies = [
  "getrandom",
  "heck",
@@ -2195,7 +2220,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-lightclient"
-version = "0.50.0"
+version = "0.50.2"
 dependencies = [
  "futures",
  "futures-timer",
@@ -2220,7 +2245,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.50.0"
+version = "0.50.2"
 dependencies = [
  "darling",
  "parity-scale-codec",
@@ -2235,7 +2260,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-metadata"
-version = "0.50.0"
+version = "0.50.2"
 dependencies = [
  "frame-decode",
  "frame-metadata",
@@ -2250,7 +2275,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-rpcs"
-version = "0.50.0"
+version = "0.50.2"
 dependencies = [
  "derive-where",
  "finito",
@@ -2275,7 +2300,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-utils-accountid32"
-version = "0.50.0"
+version = "0.50.2"
 dependencies = [
  "base58",
  "blake2",
@@ -2289,7 +2314,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-utils-fetchmetadata"
-version = "0.50.0"
+version = "0.50.2"
 dependencies = [
  "hex",
  "parity-scale-codec",

--- a/utils/strip-metadata/src/lib.rs
+++ b/utils/strip-metadata/src/lib.rs
@@ -83,26 +83,26 @@ impl StripMetadata for v16::RuntimeMetadataV16 {
 
         // If the user asked to strip the System pallet, we'll strip most things from it but keep the
         // associated types, because Subxt makes use of them.
-        if !keep_pallet("System") {
-            if let Some(system_pallet) = self.pallets.iter_mut().find(|p| p.name == "System") {
-                let index = system_pallet.index;
-                let associated_types = core::mem::take(&mut system_pallet.associated_types);
+        if !keep_pallet("System")
+            && let Some(system_pallet) = self.pallets.iter_mut().find(|p| p.name == "System")
+        {
+            let index = system_pallet.index;
+            let associated_types = core::mem::take(&mut system_pallet.associated_types);
 
-                *system_pallet = v16::PalletMetadata {
-                    name: "System".to_string(),
-                    index,
-                    associated_types,
-                    // Everything else is empty:
-                    storage: None,
-                    calls: None,
-                    event: None,
-                    constants: vec![],
-                    error: None,
-                    view_functions: vec![],
-                    docs: vec![],
-                    deprecation_info: v16::ItemDeprecationInfo::NotDeprecated,
-                };
-            }
+            *system_pallet = v16::PalletMetadata {
+                name: "System".to_string(),
+                index,
+                associated_types,
+                // Everything else is empty:
+                storage: None,
+                calls: None,
+                event: None,
+                constants: vec![],
+                error: None,
+                view_functions: vec![],
+                docs: vec![],
+                deprecation_info: v16::ItemDeprecationInfo::NotDeprecated,
+            };
         }
 
         // Now, only retain types we care about in the registry:


### PR DESCRIPTION
## Summary

Impl #2247 

Upgrades the light client stack and hardens the light client integration tests.

- Bump `smoldot` 1.1.0 → 2.1.0 and `smoldot-light` 1.1.0 → 1.3.1.
- Raise the workspace `rust-version` 1.85.0 → 1.88.0 (required by the newer smoldot).
- Harden the light client integration tests: wrap client initialization and each step in explicit timeouts so a stalled light client fails fast and names the stuck step, and initialise a `RUST_LOG`-driven tracing subscriber so smoldot/subxt logs are attached to failures.