### PR TITLE
ci: Update Artifacts PRs reuse a single branch

### DIFF
--- a/.github/workflows/update-artifacts.yml
+++ b/.github/workflows/update-artifacts.yml
@@ -54,7 +54,7 @@ jobs:
           base: master
           branch: update-artifacts
           commit-message: Update Artifacts (auto-generated)
-          branch-suffix: timestamp
+          delete-branch: true
           title: Update Artifacts (auto-generated)
           body: |
             This PR updates the artifacts by fetching fresh metadata from a substrate node.


### PR DESCRIPTION
Closes #2252. Drops branch-suffix: timestamp so the weekly job updates one PR from current master instead of piling up stale PRs that rot as the toolchain moves.