### PR TITLE
ci: Promote lightclient test jobs from flaky to mandatory

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -395,8 +395,8 @@ jobs:
           wasm-pack test --headless --chrome
         working-directory: signer/tests/wasm
 
-  flaky_lightclient_wasm_tests:
-    name: Flaky lightclient WASM tests
+  lightclient_wasm_tests:
+    name: Lightclient WASM tests
     runs-on: ubuntu-latest
     needs: [clippy, wasm_clippy, check, wasm_check, docs]
     timeout-minutes: 10
@@ -414,41 +414,22 @@ jobs:
         uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
 
       - name: Run subxt-lightclient WASM tests
-        id: test
         working-directory: testing/wasm-lightclient-tests
         run: |
           # These tests connect to RPC nodes and so don't need a local node running.
-          if wasm-pack test --headless --firefox && wasm-pack test --headless --chrome; then
-            echo "result=success" >> $GITHUB_OUTPUT
-          else
-            echo "result=failure" >> $GITHUB_OUTPUT
-          fi
+          # Failures are filed to a tracking issue by the lightclient_failure_report
+          # job below.
+          wasm-pack test --headless --firefox
+          wasm-pack test --headless --chrome
 
-      - name: Report flaky test result
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const result = '${{ steps.test.outputs.result }}';
-            await github.rest.checks.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              name: 'Flaky: Lightclient WASM tests',
-              head_sha: context.sha,
-              conclusion: result === 'success' ? 'success' : 'neutral',
-              output: {
-                title: result === 'success' ? 'Tests passed' : 'Tests failed (flaky)',
-                summary: result === 'success'
-                  ? 'All lightclient WASM tests passed.'
-                  : 'Lightclient WASM tests failed. These tests are known to be flaky and do not block the PR.'
-              }
-            });
-
-  flaky_lightclient_integration_tests:
-    name: "Flaky lightclient integration tests (${{ matrix.feature }})"
+  lightclient_integration_tests:
+    name: "Lightclient integration tests (${{ matrix.feature }})"
     runs-on: parity-large
     needs: [clippy, wasm_clippy, check, wasm_check, docs]
     timeout-minutes: 15
     strategy:
+      # Let each backend report independently now that failures block the PR.
+      fail-fast: false
       matrix:
         # Test each of the backends with the light client.
         feature:
@@ -470,35 +451,58 @@ jobs:
           override: true
 
       - name: Run crate tests
-        id: test
         env:
-          RUST_LOG: "info,subxt=debug,integration_tests=trace"
+          RUST_LOG: "debug,integration_tests=trace"
         run: |
-          if cargo test -p integration-tests --features light-client-rpc,${{ matrix.feature }} light_client -- --nocapture; then
-            echo "result=success" >> $GITHUB_OUTPUT
-          else
-            echo "result=failure" >> $GITHUB_OUTPUT
-          fi
+          # Failures are filed to a tracking issue by the lightclient_failure_report
+          # job below.
+          cargo test -p integration-tests --features light-client-rpc,${{ matrix.feature }} light_client -- --nocapture
 
-      - name: Report flaky test result
+  lightclient_failure_report:
+    name: Report lightclient test failure
+    runs-on: ubuntu-latest
+    needs: [lightclient_wasm_tests, lightclient_integration_tests]
+    # Run only when a lightclient job failed, so that every failure lands in
+    # the tracking issue even if a later job re-run goes green.
+    if: ${{ always() && (needs.lightclient_wasm_tests.result == 'failure' || needs.lightclient_integration_tests.result == 'failure') }}
+    permissions:
+      issues: write
+    steps:
+      - name: File or update the tracking issue
         uses: actions/github-script@v7
         with:
           script: |
-            const result = '${{ steps.test.outputs.result }}';
-            const feature = '${{ matrix.feature }}';
-            await github.rest.checks.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              name: `Flaky: Lightclient integration tests (${feature})`,
-              head_sha: context.sha,
-              conclusion: result === 'success' ? 'success' : 'neutral',
-              output: {
-                title: result === 'success' ? 'Tests passed' : 'Tests failed (flaky)',
-                summary: result === 'success'
-                  ? `Lightclient integration tests (${feature}) passed.`
-                  : `Lightclient integration tests (${feature}) failed. These tests are known to be flaky and do not block the PR.`
+            const { owner, repo } = context.repo;
+            const label = 'lightclient-ci-failure';
+            const failed = [
+              ['Lightclient WASM tests', '${{ needs.lightclient_wasm_tests.result }}'],
+              ['Lightclient integration tests', '${{ needs.lightclient_integration_tests.result }}'],
+            ].filter(([, result]) => result === 'failure').map(([name]) => name);
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+            const pr = context.payload.pull_request;
+            const body = [
+              `Mandatory lightclient CI jobs failed: ${failed.join(', ')}.`,
+              '',
+              `- Run (smoldot debug logs included): ${runUrl}`,
+              `- Commit: ${context.sha}`,
+              pr ? `- PR: ${pr.html_url}` : `- Branch: ${context.ref}`,
+            ].join('\n');
+            try {
+              const { data: issues } = await github.rest.issues.listForRepo({
+                owner, repo, state: 'open', labels: label, per_page: 1,
+              });
+              if (issues.length > 0) {
+                await github.rest.issues.createComment({ owner, repo, issue_number: issues[0].number, body });
+              } else {
+                await github.rest.issues.create({
+                  owner, repo, labels: [label],
+                  title: 'Lightclient CI tests failing',
+                  body: `${body}\n\nFiled automatically when a mandatory lightclient job fails; subsequent failures are added as comments.`,
+                });
               }
-            });
+            } catch (e) {
+              core.warning(`Could not file the lightclient failure issue: ${e.message}`);
+            }
 
   nostd_tests:
     name: "Test (no_std)"

--- a/testing/wasm-lightclient-tests/tests/wasm.rs
+++ b/testing/wasm-lightclient-tests/tests/wasm.rs
@@ -9,19 +9,20 @@ wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 // Run the tests by calling:
 //
 // ```text
-// RUST_LOG=info WASM_BINDGEN_TEST_TIMEOUT=300 wasm-pack test --headless --chrome
-// ```
-//
-// Use the following to enable logs:
-// ```
-//  console_error_panic_hook::set_once();
-//  tracing_wasm::set_as_global_default();
+// WASM_BINDGEN_TEST_TIMEOUT=300 wasm-pack test --headless --chrome
 // ```
 
 const POLKADOT_SPEC: &str = include_str!("../../../artifacts/demo_chain_specs/polkadot.json");
 
 #[wasm_bindgen_test]
 async fn light_client_works() {
+    console_error_panic_hook::set_once();
+    tracing_wasm::set_as_global_default_with_config(
+        tracing_wasm::WASMLayerConfigBuilder::new()
+            .set_max_level(tracing::Level::DEBUG)
+            .build(),
+    );
+
     // Create a new LightClient based client. This uses the same chainSpec as our
     // native light client tests. If we hit any issues then we probably need to update our
     // chain spec so that the light client is uptodate enough not to need to sync lots


### PR DESCRIPTION
Closes #2247.

The light client CI steps were previously "flaky": test failures were swallowed and reported as a neutral `Flaky: ...` check that never blocked PRs. After the smoldot 2.1.0 upgrade (#2248) the systematic failures behind that marking are gone — a 60-iteration stress run over the suites passed 59/60, with the single failure being a live-network slow-peer stall (details: https://github.com/paritytech/subxt/issues/2247#issuecomment-5050977340).

This promotes the steps to mandatory:

- Test failures now fail the job. The swallow-and-report-neutral machinery is removed, and the jobs drop the "Flaky" prefix: `Lightclient WASM tests`, `Lightclient integration tests (<feature>)`.
- Every failure is filed to a rolling tracking issue (label `lightclient-ci-failure`) by a new `lightclient_failure_report` job, linking the failed run — so live-network stalls are reported to maintainers rather than swallowed, and a manual re-run doesn't lose the report. (On PRs from forks the token is read-only, so the report degrades to a warning.)
- smoldot diagnostics are captured for the linked runs: the integration job runs with `RUST_LOG=debug` (smoldot logs under bare targets like `network` and `sync-service-polkadot`, which can't be prefix-filtered as a group), and the wasm test now writes logs to the browser console, which wasm-bindgen-test prints for failing tests.
- `fail-fast: false` on the integration matrix so each backend reports independently.

Note for admins: the `Flaky: ...` informational check runs are no longer created, and if the old job names appear in branch protection required checks they need updating to the new names.
