### PR TITLE
refactor: use is_authorization_extension for VerifySignature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ darling = "0.20.10"
 derive-where = "1.2.7"
 either = { version = "1.13.0", default-features = false }
 finito = { version = "0.1.0", default-features = false }
-frame-decode = { version = "0.18.0", default-features = false }
+frame-decode = { version = "0.18.1", default-features = false }
 frame-metadata = { version = "23.0.0", default-features = false }
 futures = { version = "0.3.31", default-features = false, features = ["std"] }
 getrandom = { version = "0.2", default-features = false }

--- a/subxt/src/config/transaction_extensions.rs
+++ b/subxt/src/config/transaction_extensions.rs
@@ -53,6 +53,10 @@ impl<T: Config> frame_decode::extrinsics::TransactionExtension<PortableRegistry>
 {
     const NAME: &str = "VerifyMultiSignature";
 
+    fn is_authorization_extension(&self) -> bool {
+        true
+    }
+
     fn encode_value_to(
         &self,
         type_id: u32,
@@ -62,28 +66,13 @@ impl<T: Config> frame_decode::extrinsics::TransactionExtension<PortableRegistry>
         self.0.encode_as_type_to(type_id, type_resolver, v)?;
         Ok(())
     }
-    fn encode_value_for_signer_payload_to(
-        &self,
-        _type_id: u32,
-        _type_resolver: &PortableRegistry,
-        v: &mut Vec<u8>,
-    ) -> Result<(), frame_decode::extrinsics::TransactionExtensionError> {
-        // This extension is never encoded to the signer payload, and extensions
-        // prior to this are ignored when creating said payload, so clear anything
-        // we've seen so far.
-        v.clear();
-        Ok(())
-    }
+
     fn encode_implicit_to(
         &self,
         _type_id: u32,
         _type_resolver: &PortableRegistry,
-        v: &mut Vec<u8>,
+        _v: &mut Vec<u8>,
     ) -> Result<(), frame_decode::extrinsics::TransactionExtensionError> {
-        // We only use the "implicit" data for extensions _after_ this one
-        // in the pipeline to form the signer payload. Thus, clear anything
-        // we've seen so far.
-        v.clear();
         Ok(())
     }
 }


### PR DESCRIPTION
Adopt `is_authorization_extension` from frame-decode, replacing `out.clear()` side effects.

Uses frame-decode 0.18.1.