### PR TITLE
tests: update integration tests for the latest substrate-node runtime

### DIFF
--- a/subxt/src/config/transaction_extensions.rs
+++ b/subxt/src/config/transaction_extensions.rs
@@ -704,7 +704,10 @@ mod test {
         let ext = VerifySignature::<PolkadotConfig>(VerifySignatureDetails::Disabled);
         let mut buf = Vec::new();
         ext.encode_implicit_to(0, &registry, &mut buf).unwrap();
-        assert!(buf.is_empty(), "VerifyMultiSignature implicit should be empty (Disabled)");
+        assert!(
+            buf.is_empty(),
+            "VerifyMultiSignature implicit should be empty (Disabled)"
+        );
 
         // After inject_signature: implicit should still be empty.
         let mut ext = VerifySignature::<PolkadotConfig>(VerifySignatureDetails::Disabled);
@@ -715,7 +718,10 @@ mod test {
         ext.inject_signature(&account, &signature);
         let mut buf = Vec::new();
         ext.encode_implicit_to(0, &registry, &mut buf).unwrap();
-        assert!(buf.is_empty(), "VerifyMultiSignature implicit should be empty (Signed)");
+        assert!(
+            buf.is_empty(),
+            "VerifyMultiSignature implicit should be empty (Signed)"
+        );
     }
 
     #[test]

--- a/testing/integration-tests/src/full_client/blocks.rs
+++ b/testing/integration-tests/src/full_client/blocks.rs
@@ -346,6 +346,7 @@ async fn decode_transaction_extensions_from_blocks() {
     assert_eq!(tip2, tip2_static);
 
     let expected_transaction_extensions = [
+        "AsScarcity",
         "AuthorizeCall",
         "CheckNonZeroSender",
         "CheckSpecVersion",

--- a/testing/integration-tests/src/full_client/client/mod.rs
+++ b/testing/integration-tests/src/full_client/client/mod.rs
@@ -40,7 +40,7 @@ async fn storage_iter() -> Result<(), subxt::Error> {
         .count()
         .await;
 
-    assert_eq!(len, 19);
+    assert_eq!(len, 17);
     Ok(())
 }
 


### PR DESCRIPTION
The CI node binary cache was rebuilt on Aug 14 against latest polkadot-sdk master, which broke two integration tests for every PR (both failures also reproduce on master's daily compatibility run):

- `decode_transaction_extensions_from_blocks`: the kitchensink runtime gained a new `AsScarcity` transaction extension (paritytech/polkadot-sdk#12730), so 13 extensions are now advertised vs the 12 hardcoded in the test.
- `storage_iter`: `System.Account` now has 17 genesis entries rather than 19.

Notably, the first failure is a live example of what #2265 / #2273 addresses: a runtime adding a transaction extension breaks a client with hardcoded knowledge of the extension set.

Also includes a `cargo fmt` fix for two test asserts in `transaction_extensions.rs` which landed unformatted on master and fail the fmt check for every PR.
