### PR TITLE
fix: decode v4 extrinsics with transaction extension version 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- V4 extrinsics are now decoded using transaction extension version 0, rather than the newest version present in the metadata. A v4 extrinsic encodes no transaction extension version and is defined to use version 0, so on a runtime exposing more than one version (Polkadot Asset Hub spec 2005000 exposes `[0, 1]`) the extras were read against the wrong extension set and decoding failed with `VariantNotFound`. V5 extrinsics are unaffected: they carry an explicit version and it is used as given. Addresses the v4 half of [#1998](https://github.com/paritytech/subxt/issues/1998).
+
 ## [0.50.3] - 2026-08-06
 
 This release updates `frame-decode` to 0.18.1, which fixes V5 signer payload construction and improves how authorization extensions (like `VerifyMultiSignature`) are handled.

--- a/metadata/src/lib.rs
+++ b/metadata/src/lib.rs
@@ -193,9 +193,9 @@ impl frame_decode::extrinsics::ExtrinsicTypeInfo for Metadata {
         extension_version: Option<u8>,
     ) -> Result<ExtrinsicExtensionInfo<'_, Self::TypeId>, ExtrinsicInfoError<'_>> {
         let extension_version = extension_version.unwrap_or_else(|| {
-            // We have some transaction, probably a V4 one with no extension version,
-            // but our metadata may support multiple versions. Use the metadata to decide
-            // what version to assume we'll decode it as.
+            // No extension version means a V4 transaction, which encodes none and is
+            // defined to use version 0. A V5 General transaction always hands us the
+            // version it declared, and that is used verbatim.
             self.extrinsic()
                 .transaction_extension_version_to_use_for_decoding()
         });
@@ -1007,12 +1007,13 @@ impl ExtrinsicMetadata {
     }
 
     /// When presented with a v4 extrinsic that has no version, treat it as being this version.
+    ///
+    /// This is always version 0. A v4 extrinsic encodes no transaction extension version
+    /// and is defined to use version 0 of the transaction extensions, whatever other
+    /// versions the runtime happens to expose in its metadata. Only v5 "General"
+    /// extrinsics carry an explicit version, and that version is used as given.
     pub fn transaction_extension_version_to_use_for_decoding(&self) -> u8 {
-        *self
-            .transaction_extensions_by_version
-            .keys()
-            .max()
-            .expect("At least one version of transaction extensions is expected")
+        0
     }
 }
 
@@ -1371,4 +1372,84 @@ fn from_runtime_metadata(
         let e: codec::Error = "Metadata::decode failed: Cannot try_into() to Metadata".into();
         e.chain(reason.to_string())
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// An `ExtrinsicMetadata` exposing the given transaction extension versions, each
+    /// version pointing at a single extension named after it.
+    fn extrinsic_metadata_with_versions(versions: &[u8]) -> ExtrinsicMetadata {
+        let transaction_extensions = versions
+            .iter()
+            .map(|v| TransactionExtensionMetadataInner {
+                identifier: format!("Extension{v}"),
+                extra_ty: 0,
+                additional_ty: 0,
+            })
+            .collect();
+
+        let transaction_extensions_by_version = versions
+            .iter()
+            .enumerate()
+            .map(|(idx, v)| (*v, vec![idx as u32]))
+            .collect();
+
+        ExtrinsicMetadata {
+            address_ty: 0,
+            signature_ty: 0,
+            supported_versions: vec![4, 5],
+            transaction_extensions,
+            transaction_extensions_by_version,
+        }
+    }
+
+    /// A v4 extrinsic encodes no transaction extension version and is defined to use
+    /// version 0, so the version we decode it with must not follow whatever the newest
+    /// version in the metadata happens to be.
+    #[test]
+    fn v4_extrinsics_decode_with_transaction_extension_version_0() {
+        for versions in [&[0][..], &[0, 1][..], &[0, 1, 2][..]] {
+            let extrinsic = extrinsic_metadata_with_versions(versions);
+            assert_eq!(
+                extrinsic.transaction_extension_version_to_use_for_decoding(),
+                0,
+                "expected version 0 for a v4 extrinsic, metadata exposed {versions:?}"
+            );
+        }
+    }
+
+    /// Encoding a v5 extrinsic is a separate decision and still prefers the newest
+    /// version, so a regression there should not be hidden by the test above.
+    #[test]
+    fn v5_encoding_still_prefers_the_newest_version() {
+        let extrinsic = extrinsic_metadata_with_versions(&[0, 1, 2]);
+        assert_eq!(
+            extrinsic.transaction_extension_version_to_use_for_encoding(),
+            2
+        );
+    }
+
+    /// The extensions handed back for decoding a v4 extrinsic must be version 0's set,
+    /// not the newest version's, which is what made v4 extrinsics fail to decode on
+    /// runtimes exposing versions 0 and 1.
+    #[test]
+    fn extension_info_for_a_v4_extrinsic_uses_version_0_extensions() {
+        use frame_decode::extrinsics::ExtrinsicTypeInfo;
+
+        let md_bytes = std::fs::read("../artifacts/polkadot_metadata_small.scale").unwrap();
+        let mut metadata = Metadata::decode_from(&md_bytes).unwrap();
+        metadata.extrinsic = extrinsic_metadata_with_versions(&[0, 1]);
+
+        let names: Vec<String> = metadata
+            .extrinsic_extension_info(None)
+            .expect("version 0 extensions should be found")
+            .extension_ids
+            .iter()
+            .map(|e| e.name.to_string())
+            .collect();
+
+        assert_eq!(names, vec!["Extension0".to_string()]);
+    }
 }


### PR DESCRIPTION
Addresses the v4 half of #1998.

### Description

A v4 extrinsic encodes no transaction extension version and is defined to use version 0. `transaction_extension_version_to_use_for_decoding` instead returned the highest version in the metadata, which was harmless while chains only exposed version 0.

Polkadot Asset Hub spec 2005000 exposes `[0, 1]`, and version 1 prepends `UnitTransactionExtension` and `VerifyMultiSignature`. V4 extras were read against that set, so the era bytes were interpreted as enum variant indexes and decoding failed with `VariantNotFound`. Reproduced on Polkadot Asset Hub block 20487777, where `extrinsics().iter()` yielded errors for the two v4 signed extrinsics and decoded 2 of 4. With this change it decodes 4 of 4, and block 20494727, whose signed extrinsic is a v5 General declaring version 1, still decodes 3 of 3.

Downstream report: paritytech/polkadot-rest-api#405.

### Changes

`transaction_extension_version_to_use_for_decoding` now returns 0, matching what its doc comment already described. Metadata below V16 only ever populates version 0, so this is a no op for V14, V15 and legacy metadata, and only changes behaviour on V16 runtimes exposing more than one version.

V5 extrinsics are untouched: they carry an explicit version, which is passed through `extrinsic_extension_info` and used as given. `transaction_extension_version_to_use_for_encoding` still prefers the newest version.

### Not in scope

The other half of #1998, picking the matching rather than the newest extension set when encoding v5, needs to reconcile the configured extensions against the metadata and is left alone here.
