### PR TITLE
chore: Release v0.50.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.50.4] - 2026-09-11
+
+This release fixes the decoding of v4 extrinsics on runtimes that expose more than one transaction extension version, such as Polkadot Asset Hub from spec version 2005000.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.50.4] - 2026-09-11
 
-This release fixes the decoding of v4 extrinsics on runtimes that expose more than one transaction extension version, such as Polkadot Asset Hub from spec version 2005000.
+A v4 extrinsic has no transaction extension version of its own, and is always meant to use version 0. Subxt was instead using whichever version was newest in the metadata. That made no difference while chains only published version 0, but Polkadot Asset Hub started publishing versions 0 and 1 in spec 2005000, and subxt then read and wrote v4 extrinsics against the wrong set of extensions.
+
+This broke two things at once, and both are fixed here.
 
 ### Fixed
 
-- V4 extrinsics are now decoded using transaction extension version 0, rather than the newest version present in the metadata. A v4 extrinsic encodes no transaction extension version and is defined to use version 0, so on a runtime exposing more than one version (Polkadot Asset Hub spec 2005000 exposes `[0, 1]`) the extras were read against the wrong extension set and decoding failed with `VariantNotFound`. V5 extrinsics are unaffected: they carry an explicit version and it is used as given. Addresses the v4 half of [#1998](https://github.com/paritytech/subxt/issues/1998).
+- Reading blocks. V4 extrinsics failed to decode with `VariantNotFound` and were silently skipped, so blocks came back missing extrinsics. ([#2277](https://github.com/paritytech/subxt/pull/2277))
+- Signing. Building a v4 transaction failed with `TransactionExtensions(NotFound("RestrictOrigins"))`, because subxt tried to encode version 1's extensions and cannot supply a value for that one. This is the v4 half of [#2265](https://github.com/paritytech/subxt/issues/2265). Signing a v5 transaction still uses the newest version in the metadata and is not fixed here. ([#2277](https://github.com/paritytech/subxt/pull/2277))
+
+V5 extrinsics are unaffected when decoding, since they carry their own extension version and subxt uses the one they declare. This also covers the v4 half of [#1998](https://github.com/paritytech/subxt/issues/1998).
 
 ## [0.50.3] - 2026-08-06
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,7 +464,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "artifacts"
-version = "0.50.3"
+version = "0.50.4"
 dependencies = [
  "substrate-runner",
 ]
@@ -2156,7 +2156,7 @@ dependencies = [
 
 [[package]]
 name = "generate-custom-metadata"
-version = "0.50.3"
+version = "0.50.4"
 dependencies = [
  "frame-metadata 23.0.0",
  "parity-scale-codec",
@@ -2789,7 +2789,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.50.3"
+version = "0.50.4"
 dependencies = [
  "assert_matches",
  "cfg_aliases",
@@ -5653,7 +5653,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-runner"
-version = "0.50.3"
+version = "0.50.4"
 
 [[package]]
 name = "subtle"
@@ -5663,7 +5663,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "subxt"
-version = "0.50.3"
+version = "0.50.4"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -5712,7 +5712,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-cli"
-version = "0.50.3"
+version = "0.50.4"
 dependencies = [
  "clap",
  "color-eyre",
@@ -5746,7 +5746,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-codegen"
-version = "0.50.3"
+version = "0.50.4"
 dependencies = [
  "frame-metadata 23.0.0",
  "getrandom 0.2.16",
@@ -5763,7 +5763,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-lightclient"
-version = "0.50.3"
+version = "0.50.4"
 dependencies = [
  "futures",
  "futures-timer",
@@ -5788,7 +5788,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.50.3"
+version = "0.50.4"
 dependencies = [
  "darling",
  "parity-scale-codec",
@@ -5808,7 +5808,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-metadata"
-version = "0.50.3"
+version = "0.50.4"
 dependencies = [
  "bitvec",
  "criterion",
@@ -5827,7 +5827,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-rpcs"
-version = "0.50.3"
+version = "0.50.4"
 dependencies = [
  "derive-where",
  "finito",
@@ -5856,7 +5856,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-signer"
-version = "0.50.3"
+version = "0.50.4"
 dependencies = [
  "base64 0.22.1",
  "bip32",
@@ -5890,7 +5890,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-test-macro"
-version = "0.50.3"
+version = "0.50.4"
 dependencies = [
  "quote",
  "syn 2.0.101",
@@ -5898,7 +5898,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-utils-accountid32"
-version = "0.50.3"
+version = "0.50.4"
 dependencies = [
  "base58",
  "blake2",
@@ -5914,7 +5914,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-utils-fetchmetadata"
-version = "0.50.3"
+version = "0.50.4"
 dependencies = [
  "frame-metadata 23.0.0",
  "hex",
@@ -5927,7 +5927,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-utils-stripmetadata"
-version = "0.50.3"
+version = "0.50.4"
 dependencies = [
  "either",
  "frame-metadata 23.0.0",
@@ -6010,7 +6010,7 @@ dependencies = [
 
 [[package]]
 name = "test-runtime"
-version = "0.50.3"
+version = "0.50.4"
 dependencies = [
  "hex",
  "impl-serde",
@@ -6436,7 +6436,7 @@ checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "ui-tests"
-version = "0.50.3"
+version = "0.50.4"
 dependencies = [
  "frame-metadata 23.0.0",
  "generate-custom-metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ resolver = "2"
 [workspace.package]
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2024"
-version = "0.50.3"
+version = "0.50.4"
 rust-version = "1.88.0"
 license = "Apache-2.0 OR GPL-3.0"
 repository = "https://github.com/paritytech/subxt"


### PR DESCRIPTION
### Description

Patch release for the v4 transaction extension version fix in #2277. Polkadot Asset Hub from spec version 2005000 exposes transaction extension versions `[0, 1]`, and v4 extrinsics were being decoded against version 1's extension set, so they failed with `VariantNotFound` and were dropped by anything iterating a block. Downstream report: paritytech/polkadot-rest-api#405.

Everything since `v0.50.3`:

1. #2277, the v4 decoding fix.
2. #2274, integration test updates for the latest substrate-node runtime, test only, so not in the changelog.

No API changes, so this is a patch.

### Changes

`Cargo.toml` bumps the workspace version to 0.50.4, `Cargo.lock` picks that up across the 18 workspace crates with no dependency churn, and `CHANGELOG.md` dates the existing entry as `[0.50.4] - 2026-09-11` with a summary line.
